### PR TITLE
Add simplified winget update templates with force close support

### DIFF
--- a/scripts/device-management/winget-updates/Template/README.md
+++ b/scripts/device-management/winget-updates/Template/README.md
@@ -1,0 +1,304 @@
+# Winget Update Templates for Intune
+
+This folder contains simplified templates for deploying winget-based application updates through Intune Proactive Remediations. Technicians only need to provide the **winget package ID** - everything else is auto-detected!
+
+## 🚀 Quick Start
+
+### Step 1: Find the Winget Package ID
+
+Search for your application on winget:
+
+```powershell
+winget search "Google Chrome"
+```
+
+Example output:
+```
+Name          Id              Version
+------------------------------------------
+Google Chrome Google.Chrome   120.0.6099.130
+```
+
+The **Id** column is what you need: `Google.Chrome`
+
+### Step 2: Choose Your Template
+
+| Template | Use Case | Behavior |
+|----------|----------|----------|
+| **detect_v2.ps1** | Detection script | Checks if update is available |
+| **remediate_v2_standard.ps1** | Standard update | Waits for app to close before updating |
+| **remediate_v2_force_close.ps1** | Force close update | Automatically closes app before updating ⚠️ |
+
+### Step 3: Configure (One Line!)
+
+Open your chosen template and set the winget ID:
+
+```powershell
+$ID = 'Google.Chrome'  # That's it!
+```
+
+**Everything else is auto-detected:**
+- ✅ Application name (from winget)
+- ✅ Process name (from package ID)
+- ✅ Version checking
+- ✅ Update logic
+
+## 📋 Template Details
+
+### detect_v2.ps1
+
+**Purpose:** Checks if an application update is available
+
+**Configuration Required:**
+```powershell
+$ID = 'WINGETID'  # Replace with your package ID
+```
+
+**Exit Codes:**
+- `0` = No update available or app not installed (no action)
+- `1` = Update available (triggers remediation)
+
+**Example:**
+```powershell
+$ID = 'Mozilla.Firefox'
+```
+
+---
+
+### remediate_v2_standard.ps1
+
+**Purpose:** Updates applications, waiting for them to close naturally
+
+**Configuration Required:**
+```powershell
+$ID = 'WINGETID'  # Replace with your package ID
+```
+
+**Optional Configuration:**
+```powershell
+$name = 'Custom Display Name'  # Override auto-detected name
+$AppProcess = 'customprocess'  # Override auto-detected process name
+```
+
+**Behavior:**
+- Checks if app is running
+- If running: Skips update and retries later
+- If not running: Installs update
+- Best for: User-facing applications where force closing would lose work
+
+**Example:**
+```powershell
+# Minimal configuration
+$ID = 'Google.Chrome'
+
+# With optional customization
+$ID = 'Google.Chrome'
+$name = 'Google Chrome Browser'
+$AppProcess = 'chrome'  # Usually auto-detected correctly
+```
+
+---
+
+### remediate_v2_force_close.ps1
+
+**Purpose:** Updates applications, forcefully closing them if needed
+
+⚠️ **WARNING:** This will close the application without saving user work!
+
+**Configuration Required:**
+```powershell
+$ID = 'WINGETID'  # Replace with your package ID
+```
+
+**Optional Configuration:**
+```powershell
+$name = 'Custom Display Name'          # Override auto-detected name
+$AppProcess = 'customprocess'          # Override auto-detected process name
+$GracePeriodSeconds = 5                # Wait time after closing app
+$VerifyWaitSeconds = 10                # Wait time after update to verify
+```
+
+**Behavior:**
+- Checks if app is running
+- If running: Force closes the application
+- Waits for grace period
+- Installs update
+- Verifies installation
+- Best for: Background services, developer tools, or maintenance windows
+
+**Example:**
+```powershell
+# Minimal configuration
+$ID = 'TeamViewer.TeamViewer'
+
+# With optional customization
+$ID = 'TeamViewer.TeamViewer'
+$name = 'TeamViewer Full'
+$AppProcess = 'TeamViewer'
+$GracePeriodSeconds = 10  # Wait 10 seconds after force close
+```
+
+## 🎯 Common Use Cases
+
+### Scenario 1: Update Google Chrome (Wait for User)
+
+**Use:** `remediate_v2_standard.ps1`
+
+```powershell
+$ID = 'Google.Chrome'
+```
+
+Users must close Chrome before update installs. Good for business hours.
+
+### Scenario 2: Update TeamViewer (Force Close)
+
+**Use:** `remediate_v2_force_close.ps1`
+
+```powershell
+$ID = 'TeamViewer.TeamViewer'
+```
+
+TeamViewer will be forcefully closed and updated. Good for maintenance windows.
+
+### Scenario 3: Update Adobe Reader (Wait for User)
+
+**Use:** `remediate_v2_standard.ps1`
+
+```powershell
+$ID = 'Adobe.Acrobat.Reader.64-bit'
+```
+
+Won't close Adobe Reader if user has documents open.
+
+### Scenario 4: Update Visual Studio Code (Force Close)
+
+**Use:** `remediate_v2_force_close.ps1`
+
+```powershell
+$ID = 'Microsoft.VisualStudioCode'
+```
+
+VS Code will be forcefully closed. Ensure users are notified beforehand!
+
+## 🔧 Advanced: When Auto-Detection Fails
+
+In rare cases, you may need to manually specify the process name:
+
+```powershell
+# If the app has a different process name than the package ID suggests
+$ID = 'Adobe.Acrobat.Reader.64-bit'
+$AppProcess = 'AcroRd32'  # Adobe Reader's actual process name
+```
+
+**How to find the process name:**
+1. Open Task Manager (Ctrl+Shift+Esc)
+2. Find your application
+3. Right-click → Go to details
+4. Note the process name (without .exe)
+
+## 📊 Deployment to Intune
+
+### Create Proactive Remediation Package
+
+1. **Sign in to Intune**: https://intune.microsoft.com
+2. **Navigate to**: Devices → Scripts and remediations → Proactive remediations
+3. **Click**: Create script package
+4. **Configure**:
+   - **Name**: `Winget Update - Google Chrome`
+   - **Detection script**: Upload your configured `detect_v2.ps1`
+   - **Remediation script**: Upload your configured `remediate_v2_standard.ps1` or `remediate_v2_force_close.ps1`
+   - **Run script in 64-bit PowerShell**: Yes
+   - **Run this script using logged on credentials**: No (run as system)
+5. **Assign** to device groups
+6. **Schedule** (e.g., daily at 2 AM for force close, or every 4 hours for standard)
+
+## 🆚 Template Comparison
+
+| Feature | Standard | Force Close |
+|---------|----------|-------------|
+| Closes app automatically | ❌ No | ✅ Yes |
+| User data loss risk | ❌ None | ⚠️ Possible |
+| Best for business hours | ✅ Yes | ❌ No |
+| Best for maintenance windows | ❌ No | ✅ Yes |
+| Guarantees update install | ❌ No | ✅ Yes |
+| Requires user action | ✅ Yes | ❌ No |
+
+## 📚 Popular Winget Package IDs
+
+Quick reference for common applications:
+
+| Application | Winget ID |
+|------------|-----------|
+| Google Chrome | `Google.Chrome` |
+| Mozilla Firefox | `Mozilla.Firefox` |
+| Adobe Acrobat Reader (64-bit) | `Adobe.Acrobat.Reader.64-bit` |
+| Adobe Acrobat Reader (32-bit) | `Adobe.Acrobat.Reader.32-bit` |
+| Microsoft Edge | `Microsoft.Edge` |
+| Visual Studio Code | `Microsoft.VisualStudioCode` |
+| 7-Zip | `7zip.7zip` |
+| Notepad++ | `Notepad++.Notepad++` |
+| VLC Media Player | `VideoLAN.VLC` |
+| TeamViewer | `TeamViewer.TeamViewer` |
+| Zoom | `Zoom.Zoom` |
+| Git | `Git.Git` |
+| Python 3 | `Python.Python.3.12` |
+| Node.js | `OpenJS.NodeJS` |
+
+Search for more: `winget search "<app name>"`
+
+## 🔍 Troubleshooting
+
+### Issue: Script fails with "winget not found"
+
+**Solution:** Ensure App Installer is installed and updated on target devices.
+
+```powershell
+# Check winget availability
+winget --version
+```
+
+### Issue: Process name auto-detection doesn't work
+
+**Solution:** Manually specify the process name:
+
+```powershell
+$ID = 'YourApp.ID'
+$AppProcess = 'actualprocessname'  # Find in Task Manager
+```
+
+### Issue: Update detected but remediation doesn't run
+
+**Solution:**
+- Check Intune assignment and schedule
+- Verify script is set to run as **system**, not user
+- Check device sync status in Intune
+
+### Issue: Force close doesn't close the app
+
+**Solution:** Increase grace period and try multiple close attempts:
+
+```powershell
+$GracePeriodSeconds = 10
+# Script already retries force close if first attempt fails
+```
+
+## 📖 Learn More
+
+- **Winget Documentation**: https://learn.microsoft.com/en-us/windows/package-manager/winget/
+- **Intune Proactive Remediations**: https://learn.microsoft.com/en-us/mem/intune/fundamentals/remediations
+- **Find Package IDs**: https://winget.run/
+
+## 🏷️ Version History
+
+- **v2 Templates** (Current): Simplified configuration with auto-detection
+  - `detect_v2.ps1`
+  - `remediate_v2_standard.ps1`
+  - `remediate_v2_force_close.ps1`
+
+- **v1 Templates** (Legacy): Required manual configuration of all variables
+  - `detect.ps1`
+  - `remediate.ps1`
+
+---
+
+**Pro Tip:** Start with the standard template for user-facing apps during business hours. Use force close templates during scheduled maintenance windows or for background services.

--- a/scripts/device-management/winget-updates/Template/detect_v2.ps1
+++ b/scripts/device-management/winget-updates/Template/detect_v2.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+    Winget update detection script for Intune Proactive Remediations.
+
+.DESCRIPTION
+    This template checks if an app update is available via winget.
+    Returns exit code 1 if update is available (triggers remediation).
+    Returns exit code 0 if app is up to date or not installed (no action needed).
+
+.NOTES
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name.
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize $name if you want a specific display name
+
+.EXAMPLE
+    # For Google Chrome, you only need to set:
+    $ID = 'Google.Chrome'
+
+    # The script will automatically detect the name from winget
+#>
+
+#region Configuration
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'WINGETID'  # Example: 'Google.Chrome', 'Mozilla.Firefox', 'Adobe.Acrobat.Reader.64-bit'
+
+# ===== OPTIONAL: Customize these if needed =====
+$name = $null     # Leave as $null to auto-detect from winget, or set manually: 'Google Chrome'
+#endregion
+
+#region Script - DO NOT MODIFY BELOW THIS LINE
+try {
+    # Locate winget executable
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $SystemContext = $wingetexe[-1].Path
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+
+    # Get package information
+    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Host "$name is not installed on this device."
+        exit 0
+    }
+
+    # Check if update is available
+    if ($packageInfo -match '\bVersion\s+Available\b') {
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+        [pscustomobject] @{
+            Name = $name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+        }
+        exit 1  # Trigger remediation
+    } else {
+        # No update available
+        if ($packageInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Host "$name is already up to date (version $versionInstalled)"
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+            }
+            exit 0  # No action needed
+        }
+    }
+} catch {
+    $errMsg = $_.Exception.Message
+    Write-Error "Failed to check $name for updates: $errMsg"
+    exit 0  # Don't trigger remediation on error
+}
+#endregion

--- a/scripts/device-management/winget-updates/Template/remediate_v2_force_close.ps1
+++ b/scripts/device-management/winget-updates/Template/remediate_v2_force_close.ps1
@@ -1,0 +1,138 @@
+<#
+.SYNOPSIS
+    Force close winget update script that automatically closes the app before updating.
+
+.DESCRIPTION
+    This template checks if an app update is available and installs it.
+    If the app is running, it will forcefully close the app before updating.
+
+.NOTES
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
+    WARNING: This will force close the application without saving user work!
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize $name if you want a specific display name
+    3. (Optional) Set $AppProcess if auto-detection doesn't work
+    4. (Optional) Adjust $GracePeriodSeconds for app shutdown time
+
+.EXAMPLE
+    # For TeamViewer, you only need to set:
+    $ID = 'TeamViewer.TeamViewer'
+
+    # The script will automatically:
+    # - Detect name: "TeamViewer"
+    # - Detect process: "TeamViewer"
+    # - Close the app if running
+    # - Install the update
+#>
+
+#region Configuration
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'WINGETID'  # Example: 'TeamViewer.TeamViewer', 'Mozilla.Firefox', 'OBSProject.OBSStudio'
+
+# ===== OPTIONAL: Customize these if needed =====
+$name = $null                   # Leave as $null to auto-detect from winget, or set manually: 'TeamViewer'
+$AppProcess = $null             # Leave as $null to auto-detect, or set manually: 'TeamViewer'
+$GracePeriodSeconds = 5         # Time to wait after closing app before updating
+$VerifyWaitSeconds = 10         # Time to wait after update to verify installation
+#endregion
+
+#region Script - DO NOT MODIFY BELOW THIS LINE
+try {
+    # Locate winget executable
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $SystemContext = $wingetexe[-1].Path
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+
+    # Get package information
+    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Host "$name is not installed on this device."
+        exit 0
+    }
+
+    # Auto-detect process name if not provided
+    if (-not $AppProcess) {
+        # Extract process name from package ID (e.g., 'TeamViewer.TeamViewer' -> 'TeamViewer')
+        $AppProcess = ($ID -split '\.')[-1]
+    }
+
+    # Check if app is running and force close if needed
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    if ($process) {
+        Write-Host "$name is running. Force closing application..."
+        Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds $GracePeriodSeconds
+
+        # Verify process was closed
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+        if ($process) {
+            Write-Warning "$name process still running after force close attempt. Retrying..."
+            Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds 2
+        }
+        Write-Host "$name closed successfully."
+    } else {
+        Write-Host "$name is not currently running."
+    }
+
+    # Check if update is available
+    if ($packageInfo -match '\bVersion\s+Available\b') {
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        Write-Host "Update available for $name : $verInstalled -> $verAvailable"
+
+        # Perform upgrade
+        Write-Host "Installing $name update..."
+        sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
+
+        # Wait for installation to complete
+        Start-Sleep -Seconds $VerifyWaitSeconds
+
+        # Verify installation
+        $verifyInfo = sysget list --accept-source-agreements --Id $ID
+        if ($verifyInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $verifyInfo[-1])[-2]
+            Write-Host "$name updated successfully to version $versionInstalled"
+            [pscustomobject] @{
+                Name = $name
+                PreviousVersion = $verInstalled
+                InstalledVersion = $versionInstalled
+                Status = "Force Updated Successfully"
+            }
+            exit 0
+        } else {
+            Write-Error "Failed to verify $name installation after update."
+            exit 1
+        }
+    } else {
+        # No update available
+        if ($packageInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Host "$name is already up to date (version $versionInstalled)"
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Up to Date"
+            }
+            exit 0
+        }
+    }
+} catch {
+    $errMsg = $_.Exception.Message
+    Write-Error "Failed to update $name : $errMsg"
+    exit 1
+}
+#endregion

--- a/scripts/device-management/winget-updates/Template/remediate_v2_standard.ps1
+++ b/scripts/device-management/winget-updates/Template/remediate_v2_standard.ps1
@@ -1,0 +1,120 @@
+<#
+.SYNOPSIS
+    Standard winget update script that waits for app to close before updating.
+
+.DESCRIPTION
+    This template checks if an app update is available and installs it.
+    If the app is running, it will skip the update and retry later.
+
+.NOTES
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize $name if you want a specific display name
+    3. (Optional) Set $AppProcess if auto-detection doesn't work
+
+.EXAMPLE
+    # For Google Chrome, you only need to set:
+    $ID = 'Google.Chrome'
+
+    # The script will automatically use:
+    # - Name: "Google Chrome" (from winget)
+    # - Process: "chrome" (auto-detected)
+#>
+
+#region Configuration
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'WINGETID'  # Example: 'Google.Chrome', 'Mozilla.Firefox', 'Adobe.Acrobat.Reader.64-bit'
+
+# ===== OPTIONAL: Customize these if needed =====
+$name = $null           # Leave as $null to auto-detect from winget, or set manually: 'Google Chrome'
+$AppProcess = $null     # Leave as $null to auto-detect, or set manually: 'chrome'
+#endregion
+
+#region Script - DO NOT MODIFY BELOW THIS LINE
+try {
+    # Locate winget executable
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $SystemContext = $wingetexe[-1].Path
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+
+    # Get package information
+    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Host "$name is not installed on this device."
+        exit 0
+    }
+
+    # Check if update is available
+    if ($packageInfo -match '\bVersion\s+Available\b') {
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        Write-Verbose -Verbose "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+        # Auto-detect process name if not provided
+        if (-not $AppProcess) {
+            # Extract process name from package ID (e.g., 'Google.Chrome' -> 'chrome')
+            $AppProcess = ($ID -split '\.')[-1]
+        }
+
+        # Check if app is running
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+        if ($process) {
+            Write-Host "$name is currently running. Will try again later."
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $verInstalled
+                AvailableVersion = $verAvailable
+                Status = "Skipped - App Running"
+            }
+            exit 1
+        }
+
+        # Perform upgrade
+        Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+        sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
+
+        # Verify installation
+        Start-Sleep -Seconds 5
+        $verifyInfo = sysget list --accept-source-agreements --Id $ID
+        if ($verifyInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $verifyInfo[-1])[-2]
+            Write-Host "$name updated successfully to version $versionInstalled"
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Updated Successfully"
+            }
+            exit 0
+        }
+    } else {
+        # No update available
+        if ($packageInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Host "$name is already up to date (version $versionInstalled)"
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Up to Date"
+            }
+            exit 0
+        }
+    }
+} catch {
+    $errMsg = $_.Exception.Message
+    Write-Error "Failed to update $name : $errMsg"
+    exit 1
+}
+#endregion


### PR DESCRIPTION
Introduces v2 templates that only require technicians to provide the winget
package ID, with automatic detection of app names and process names.

New Templates:
- detect_v2.ps1: Auto-detecting update detection script
- remediate_v2_standard.ps1: Standard update (waits for app to close)
- remediate_v2_force_close.ps1: Force close update (closes app automatically)
- README.md: Comprehensive documentation and usage guide

Key Features:
- One-line configuration (just set winget ID)
- Auto-detects application name from winget
- Auto-detects process name from package ID
- Optional manual overrides for edge cases
- Force close template for maintenance windows
- Standard template for business hours

This addresses the need for simplified deployment where technicians only
need to specify the winget package ID, making it much easier to create
new update scripts for any application.