### PR TITLE
Create weekly reboot scheduled task script

### DIFF
--- a/scripts/server/README.md
+++ b/scripts/server/README.md
@@ -15,6 +15,7 @@ A comprehensive collection of PowerShell scripts for managing Windows Server 201
   - [Get Disk Report](#3-get-disk-report)
   - [Set English UK Regional Settings](#4-set-english-uk-regional-settings)
   - [Remove US Language Pack](#5-remove-us-language-pack)
+  - [New Weekly Reboot Schedule](#17-new-weekly-reboot-schedule)
 - [Usage Guidelines](#usage-guidelines)
 - [Best Practices](#best-practices)
 - [Troubleshooting](#troubleshooting)
@@ -984,6 +985,233 @@ Get-ChildItem *.ps1
 
 ---
 
+### 17. New Weekly Reboot Schedule
+
+**File**: `New-WeeklyRebootSchedule.ps1`
+
+Creates a scheduled task to automatically reboot Windows Server on a weekly basis.
+
+#### Features
+- Interactive day of week selection (Monday-Sunday)
+- 24-hour time format input with validation
+- Runs under NT AUTHORITY\SYSTEM account
+- Configurable reboot delay for graceful shutdown
+- Automatic detection and handling of existing tasks
+- Comprehensive input validation
+- Detailed logging and status reporting
+- Task verification after creation
+
+#### Usage
+
+**Interactive Mode** (Recommended):
+```powershell
+.\New-WeeklyRebootSchedule.ps1
+```
+The script will prompt you to:
+1. Select the day of week (1-7 for Monday-Sunday)
+2. Enter the time in 24-hour format (HH:mm)
+
+**Non-Interactive Mode**:
+```powershell
+# Schedule reboot for Sunday at 3:00 AM
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Sunday -Time "03:00"
+
+# Schedule with custom reboot delay (2 minutes)
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Saturday -Time "23:30" -RebootDelay 120
+
+# Force overwrite existing task
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Monday -Time "02:00" -Force
+```
+
+**Custom Task Name**:
+```powershell
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Wednesday -Time "04:00" -TaskName "Maintenance Reboot"
+```
+
+#### Parameters
+
+| Parameter | Description | Default | Example |
+|-----------|-------------|---------|---------|
+| `-DayOfWeek` | Day for weekly reboot (Monday-Sunday) | Interactive prompt | `Sunday` |
+| `-Time` | Time in 24-hour format (HH:mm) | Interactive prompt | `"03:00"` |
+| `-TaskName` | Custom name for scheduled task | Weekly Server Reboot | `"Maintenance Reboot"` |
+| `-RebootDelay` | Delay in seconds before reboot | 60 | `120` |
+| `-Force` | Overwrite existing task without prompting | False | `-Force` |
+
+#### Scheduled Task Configuration
+
+The script creates a scheduled task with the following settings:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| **User Account** | NT AUTHORITY\SYSTEM | Ensures task runs with highest privileges |
+| **Run Level** | Highest | Required for shutdown command |
+| **Trigger** | Weekly on selected day | Consistent reboot schedule |
+| **Action** | `shutdown.exe /r /f /t [delay]` | Forced reboot with delay |
+| **Settings** | Start if on batteries, Start when available | Ensures task runs reliably |
+| **Network** | Not required | Task runs regardless of network status |
+
+#### Reboot Delay Explanation
+
+The `-RebootDelay` parameter (default: 60 seconds) provides time for:
+- Users to save work (if logged in)
+- Services to shut down gracefully
+- Disk writes to complete
+- Network connections to close properly
+
+**Recommended Values**:
+- **30 seconds**: Minimal delay for automated environments
+- **60 seconds**: Standard delay (default)
+- **120-300 seconds**: Extended delay for servers with many services
+
+#### When to Use
+
+**Recommended Scenarios**:
+- Patch Tuesday maintenance (Tuesday or Wednesday early morning)
+- Weekly maintenance windows
+- Clearing memory leaks or resource buildup
+- Forcing Windows Update installation
+- Regular server hygiene
+
+**Best Practice Schedule Examples**:
+```powershell
+# Patch deployment schedule
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Wednesday -Time "03:00"
+
+# End-of-week maintenance
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Sunday -Time "02:00"
+
+# Mid-week maintenance (avoid Monday/Friday)
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Wednesday -Time "23:30"
+```
+
+#### Output Example
+
+```
+========================================
+  Weekly Reboot Scheduler for Windows
+========================================
+Server: SERVER01
+OS: Microsoft Windows Server 2022 Datacenter
+Version: 10.0.20348
+========================================
+
+[2025-12-29 10:15:30] [INFO] Starting Weekly Reboot Scheduler configuration...
+
+Please select the day of week for the weekly reboot:
+  1. Monday
+  2. Tuesday
+  3. Wednesday
+  4. Thursday
+  5. Friday
+  6. Saturday
+  7. Sunday
+
+Enter selection (1-7): 7
+
+[2025-12-29 10:15:35] [INFO] Selected day: Sunday
+
+Please enter the time for the weekly reboot (24-hour format):
+  Examples: 02:00, 23:30, 18:45
+
+Enter time (HH:mm): 03:00
+
+[2025-12-29 10:15:40] [INFO] Selected time: 03:00
+
+========================================
+  Configuration Summary
+========================================
+Task Name:     Weekly Server Reboot
+Day:           Sunday
+Time:          03:00 (24-hour format)
+Reboot Delay:  60 seconds
+Run As:        NT AUTHORITY\SYSTEM
+========================================
+
+[2025-12-29 10:15:45] [SUCCESS] Scheduled task created successfully!
+
+========================================
+  Scheduled Task Created Successfully
+========================================
+Task Name:       Weekly Server Reboot
+Schedule:        Every Sunday at 03:00
+Reboot Delay:    60 seconds
+Run As:          NT AUTHORITY\SYSTEM
+State:           Ready
+Next Run:        Sunday, December 31, 2025 3:00:00 AM
+========================================
+```
+
+#### Managing the Scheduled Task
+
+**View Task Details**:
+```powershell
+Get-ScheduledTask -TaskName "Weekly Server Reboot"
+Get-ScheduledTaskInfo -TaskName "Weekly Server Reboot"
+```
+
+**Disable Task Temporarily**:
+```powershell
+Disable-ScheduledTask -TaskName "Weekly Server Reboot"
+```
+
+**Enable Task**:
+```powershell
+Enable-ScheduledTask -TaskName "Weekly Server Reboot"
+```
+
+**Test Reboot Immediately** (⚠️ Warning: Will reboot the server!):
+```powershell
+Start-ScheduledTask -TaskName "Weekly Server Reboot"
+```
+
+**Remove Task**:
+```powershell
+Unregister-ScheduledTask -TaskName "Weekly Server Reboot" -Confirm:$false
+```
+
+**Modify Schedule**:
+```powershell
+# Just run the script again with different parameters
+# Use -Force to overwrite without confirmation
+.\New-WeeklyRebootSchedule.ps1 -DayOfWeek Monday -Time "04:00" -Force
+```
+
+#### Important Notes
+
+1. **Administrator Rights Required**: Script must run with elevated privileges
+2. **System Account**: Task runs as NT AUTHORITY\SYSTEM for reliability
+3. **Forced Reboot**: The shutdown command uses `/f` flag to force applications to close
+4. **No User Intervention**: Task will execute automatically - ensure maintenance window is appropriate
+5. **Reboot Message**: Users will see: "Scheduled weekly server reboot - initiated by scheduled task"
+6. **Task Persistence**: Task survives reboots and will continue running on schedule
+7. **Overwrite Protection**: Script warns if task exists unless `-Force` is used
+
+#### Troubleshooting
+
+**Task Not Running**:
+- Check task status: `Get-ScheduledTask -TaskName "Weekly Server Reboot"`
+- Verify next run time: `Get-ScheduledTaskInfo -TaskName "Weekly Server Reboot"`
+- Check Task Scheduler event log: `Get-WinEvent -LogName "Microsoft-Windows-TaskScheduler/Operational" -MaxEvents 20`
+
+**Task Disabled After Reboot**:
+- Some group policies may disable scheduled tasks
+- Check GPO settings: `gpresult /h gpresult.html`
+- Ensure "Task Scheduler" service is running and set to Automatic
+
+**Permission Issues**:
+- Verify running as Administrator
+- Check if Task Scheduler service is running: `Get-Service -Name Schedule`
+- Ensure user has rights to create scheduled tasks
+
+**Reboot Not Occurring**:
+- Verify server was powered on at scheduled time
+- Check if task has "Start when available" enabled
+- Review Task Scheduler history for execution logs
+- Ensure system wasn't in use (some policies prevent reboot if users logged in)
+
+---
+
 ## Support and Contributions
 
 ### Getting Help
@@ -1055,9 +1283,10 @@ These scripts are provided as-is for system administration purposes. Use at your
 | System Integrity | Check-SystemIntegrity.ps1 | `.\Check-SystemIntegrity.ps1 -GenerateReport` |
 | Configure UK Settings | Set-EnglishUKRegion.ps1 | `.\Set-EnglishUKRegion.ps1 -ApplyToExistingUsers` |
 | Remove US Language | Remove-USLanguagePack.ps1 | `.\Remove-USLanguagePack.ps1 -BackupFirst` |
+| Weekly Reboot Schedule | New-WeeklyRebootSchedule.ps1 | `.\New-WeeklyRebootSchedule.ps1` |
 
 ---
 
 **Compatible**: Windows Server 2016, 2019, 2022
 **PowerShell**: 5.1+
-**Total Scripts**: 16
+**Total Scripts**: 17

--- a/scripts/server/system/New-WeeklyRebootSchedule.ps1
+++ b/scripts/server/system/New-WeeklyRebootSchedule.ps1
@@ -1,0 +1,452 @@
+<#
+.SYNOPSIS
+    Creates a scheduled task to reboot Windows Server on a weekly basis.
+
+.DESCRIPTION
+    This script creates a comprehensive weekly reboot schedule for Windows Server by:
+    - Interactively prompting for day of week selection
+    - Accepting time input in 24-hour format
+    - Creating a scheduled task under the SYSTEM account
+    - Configuring the task with appropriate security settings
+    - Validating all inputs before task creation
+    - Providing detailed logging and error handling
+
+    The scheduled task will execute a system reboot at the specified day and time.
+    The task runs under the NT AUTHORITY\SYSTEM account with highest privileges.
+
+.PARAMETER DayOfWeek
+    Optional. The day of the week for the reboot (Monday-Sunday).
+    If not provided, the script will prompt interactively.
+
+.PARAMETER Time
+    Optional. The time for the reboot in 24-hour format (HH:mm).
+    If not provided, the script will prompt interactively.
+
+.PARAMETER TaskName
+    Optional. Custom name for the scheduled task.
+    Default: "Weekly Server Reboot"
+
+.PARAMETER RebootDelay
+    Optional. Delay in seconds before the reboot executes (for graceful shutdown).
+    Default: 60 seconds
+
+.PARAMETER Force
+    Optional. Overwrites existing task with the same name without prompting.
+
+.EXAMPLE
+    .\New-WeeklyRebootSchedule.ps1
+    Runs interactively, prompting for day and time.
+
+.EXAMPLE
+    .\New-WeeklyRebootSchedule.ps1 -DayOfWeek Sunday -Time "03:00"
+    Creates a weekly reboot scheduled for Sunday at 3:00 AM.
+
+.EXAMPLE
+    .\New-WeeklyRebootSchedule.ps1 -DayOfWeek Saturday -Time "23:30" -RebootDelay 120
+    Creates a weekly reboot for Saturday at 11:30 PM with 2-minute delay.
+
+.EXAMPLE
+    .\New-WeeklyRebootSchedule.ps1 -DayOfWeek Monday -Time "02:00" -Force
+    Creates/replaces the task for Monday at 2:00 AM without confirmation.
+
+.NOTES
+    Author: System Administrator
+    Requires: Administrator privileges
+    Compatible: Windows Server 2016, 2019, 2022
+    Version: 1.0
+    Last Updated: 2025-12-29
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$false)]
+    [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
+    [string]$DayOfWeek,
+
+    [Parameter(Mandatory=$false)]
+    [ValidatePattern('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$')]
+    [string]$Time,
+
+    [Parameter(Mandatory=$false)]
+    [string]$TaskName = "Weekly Server Reboot",
+
+    [Parameter(Mandatory=$false)]
+    [ValidateRange(0, 600)]
+    [int]$RebootDelay = 60,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Force
+)
+
+#Requires -RunAsAdministrator
+
+# ============================================================================
+# FUNCTIONS
+# ============================================================================
+
+function Write-Log {
+    <#
+    .SYNOPSIS
+        Writes formatted log messages to console with color coding.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Message,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("INFO", "SUCCESS", "WARNING", "ERROR")]
+        [string]$Type = "INFO"
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $color = switch($Type) {
+        "ERROR"   { "Red" }
+        "SUCCESS" { "Green" }
+        "WARNING" { "Yellow" }
+        default   { "White" }
+    }
+    Write-Host "[$timestamp] [$Type] $Message" -ForegroundColor $color
+}
+
+function Show-Banner {
+    <#
+    .SYNOPSIS
+        Displays script banner and system information.
+    #>
+    Write-Host "`n========================================" -ForegroundColor Cyan
+    Write-Host "  Weekly Reboot Scheduler for Windows  " -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "Server: $env:COMPUTERNAME" -ForegroundColor Gray
+    $os = Get-CimInstance Win32_OperatingSystem
+    Write-Host "OS: $($os.Caption)" -ForegroundColor Gray
+    Write-Host "Version: $($os.Version)" -ForegroundColor Gray
+    Write-Host "========================================`n" -ForegroundColor Cyan
+}
+
+function Get-DayOfWeekSelection {
+    <#
+    .SYNOPSIS
+        Prompts user to select day of week.
+    #>
+    Write-Host "`nPlease select the day of week for the weekly reboot:" -ForegroundColor Yellow
+    Write-Host "  1. Monday" -ForegroundColor White
+    Write-Host "  2. Tuesday" -ForegroundColor White
+    Write-Host "  3. Wednesday" -ForegroundColor White
+    Write-Host "  4. Thursday" -ForegroundColor White
+    Write-Host "  5. Friday" -ForegroundColor White
+    Write-Host "  6. Saturday" -ForegroundColor White
+    Write-Host "  7. Sunday" -ForegroundColor White
+
+    do {
+        Write-Host "`nEnter selection (1-7): " -NoNewline -ForegroundColor Cyan
+        $selection = Read-Host
+
+        switch ($selection) {
+            "1" { return "Monday" }
+            "2" { return "Tuesday" }
+            "3" { return "Wednesday" }
+            "4" { return "Thursday" }
+            "5" { return "Friday" }
+            "6" { return "Saturday" }
+            "7" { return "Sunday" }
+            default {
+                Write-Host "Invalid selection. Please enter a number between 1 and 7." -ForegroundColor Red
+            }
+        }
+    } while ($true)
+}
+
+function Get-TimeInput {
+    <#
+    .SYNOPSIS
+        Prompts user to enter time in 24-hour format.
+    #>
+    Write-Host "`nPlease enter the time for the weekly reboot (24-hour format):" -ForegroundColor Yellow
+    Write-Host "  Examples: 02:00, 23:30, 18:45" -ForegroundColor Gray
+
+    do {
+        Write-Host "`nEnter time (HH:mm): " -NoNewline -ForegroundColor Cyan
+        $timeInput = Read-Host
+
+        # Validate time format
+        if ($timeInput -match '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$') {
+            # Normalize to HH:mm format
+            $timeParts = $timeInput -split ':'
+            $hour = $timeParts[0].PadLeft(2, '0')
+            $minute = $timeParts[1]
+            return "$hour:$minute"
+        } else {
+            Write-Host "Invalid time format. Please use 24-hour format (HH:mm), e.g., 02:00 or 23:30" -ForegroundColor Red
+        }
+    } while ($true)
+}
+
+function Test-ScheduledTaskExists {
+    <#
+    .SYNOPSIS
+        Checks if a scheduled task exists.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Name
+    )
+
+    try {
+        $task = Get-ScheduledTask -TaskName $Name -ErrorAction SilentlyContinue
+        return ($null -ne $task)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Remove-ExistingTask {
+    <#
+    .SYNOPSIS
+        Removes an existing scheduled task.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Name
+    )
+
+    try {
+        Unregister-ScheduledTask -TaskName $Name -Confirm:$false -ErrorAction Stop
+        Write-Log "Removed existing scheduled task: $Name" "SUCCESS"
+        return $true
+    }
+    catch {
+        Write-Log "Failed to remove existing task: $($_.Exception.Message)" "ERROR"
+        return $false
+    }
+}
+
+function New-RebootScheduledTask {
+    <#
+    .SYNOPSIS
+        Creates the scheduled task for weekly reboots.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$TaskName,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Day,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ScheduledTime,
+
+        [Parameter(Mandatory=$true)]
+        [int]$Delay
+    )
+
+    try {
+        Write-Log "Creating scheduled task configuration..." "INFO"
+
+        # Create task action (shutdown command with delay)
+        $actionCmd = "shutdown.exe"
+        $actionArgs = "/r /f /t $Delay /c `"Scheduled weekly server reboot - initiated by scheduled task`""
+        $action = New-ScheduledTaskAction -Execute $actionCmd -Argument $actionArgs
+
+        # Create trigger (weekly on specified day)
+        $trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek $Day -At $ScheduledTime
+
+        # Create task settings
+        $settings = New-ScheduledTaskSettingsSet `
+            -AllowStartIfOnBatteries `
+            -DontStopIfGoingOnBatteries `
+            -StartWhenAvailable `
+            -RunOnlyIfNetworkAvailable:$false `
+            -DontStopOnIdleEnd `
+            -RestartCount 3 `
+            -RestartInterval (New-TimeSpan -Minutes 1)
+
+        # Create task principal (run as SYSTEM with highest privileges)
+        $principal = New-ScheduledTaskPrincipal `
+            -UserId "NT AUTHORITY\SYSTEM" `
+            -LogonType ServiceAccount `
+            -RunLevel Highest
+
+        # Register the scheduled task
+        Write-Log "Registering scheduled task..." "INFO"
+        $task = Register-ScheduledTask `
+            -TaskName $TaskName `
+            -Action $action `
+            -Trigger $trigger `
+            -Settings $settings `
+            -Principal $principal `
+            -Description "Automatically reboots the server weekly on $Day at $ScheduledTime. Created by New-WeeklyRebootSchedule.ps1" `
+            -ErrorAction Stop
+
+        return $task
+    }
+    catch {
+        Write-Log "Failed to create scheduled task: $($_.Exception.Message)" "ERROR"
+        return $null
+    }
+}
+
+function Show-TaskSummary {
+    <#
+    .SYNOPSIS
+        Displays a summary of the created scheduled task.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [Microsoft.Management.Infrastructure.CimInstance]$Task,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Day,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ScheduledTime,
+
+        [Parameter(Mandatory=$true)]
+        [int]$Delay
+    )
+
+    Write-Host "`n========================================" -ForegroundColor Green
+    Write-Host "  Scheduled Task Created Successfully  " -ForegroundColor Green
+    Write-Host "========================================" -ForegroundColor Green
+    Write-Host "Task Name:       $($Task.TaskName)" -ForegroundColor White
+    Write-Host "Schedule:        Every $Day at $ScheduledTime" -ForegroundColor White
+    Write-Host "Reboot Delay:    $Delay seconds" -ForegroundColor White
+    Write-Host "Run As:          NT AUTHORITY\SYSTEM" -ForegroundColor White
+    Write-Host "State:           $($Task.State)" -ForegroundColor White
+
+    # Calculate next run time
+    $taskInfo = Get-ScheduledTaskInfo -TaskName $Task.TaskName
+    if ($taskInfo.NextRunTime) {
+        Write-Host "Next Run:        $($taskInfo.NextRunTime)" -ForegroundColor Cyan
+    }
+
+    Write-Host "========================================`n" -ForegroundColor Green
+}
+
+function Get-UserConfirmation {
+    <#
+    .SYNOPSIS
+        Prompts user for confirmation.
+    #>
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Message
+    )
+
+    Write-Host "`n$Message" -ForegroundColor Yellow
+    Write-Host "Continue? (Y/N): " -NoNewline -ForegroundColor Cyan
+    $response = Read-Host
+    return ($response -eq 'Y' -or $response -eq 'y')
+}
+
+# ============================================================================
+# MAIN SCRIPT
+# ============================================================================
+
+# Display banner
+Show-Banner
+
+Write-Log "Starting Weekly Reboot Scheduler configuration..." "INFO"
+
+# Get day of week (interactive or parameter)
+if ([string]::IsNullOrEmpty($DayOfWeek)) {
+    $DayOfWeek = Get-DayOfWeekSelection
+    Write-Log "Selected day: $DayOfWeek" "INFO"
+} else {
+    Write-Log "Using day from parameter: $DayOfWeek" "INFO"
+}
+
+# Get time (interactive or parameter)
+if ([string]::IsNullOrEmpty($Time)) {
+    $Time = Get-TimeInput
+    Write-Log "Selected time: $Time" "INFO"
+} else {
+    Write-Log "Using time from parameter: $Time" "INFO"
+}
+
+# Display configuration summary
+Write-Host "`n========================================" -ForegroundColor Cyan
+Write-Host "  Configuration Summary" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Task Name:     $TaskName" -ForegroundColor White
+Write-Host "Day:           $DayOfWeek" -ForegroundColor White
+Write-Host "Time:          $Time (24-hour format)" -ForegroundColor White
+Write-Host "Reboot Delay:  $RebootDelay seconds" -ForegroundColor White
+Write-Host "Run As:        NT AUTHORITY\SYSTEM" -ForegroundColor White
+Write-Host "========================================`n" -ForegroundColor Cyan
+
+# Check if task already exists
+$taskExists = Test-ScheduledTaskExists -Name $TaskName
+
+if ($taskExists) {
+    Write-Log "A scheduled task with the name '$TaskName' already exists." "WARNING"
+
+    if (-not $Force) {
+        $confirmOverwrite = Get-UserConfirmation -Message "Do you want to replace the existing task?"
+        if (-not $confirmOverwrite) {
+            Write-Log "Operation cancelled by user." "INFO"
+            exit 0
+        }
+    } else {
+        Write-Log "Force parameter specified - will overwrite existing task." "INFO"
+    }
+
+    # Remove existing task
+    $removed = Remove-ExistingTask -Name $TaskName
+    if (-not $removed) {
+        Write-Log "Cannot proceed - failed to remove existing task." "ERROR"
+        exit 1
+    }
+}
+
+# Final confirmation (unless Force is specified)
+if (-not $Force) {
+    $confirmCreate = Get-UserConfirmation -Message "Create the scheduled task with the above configuration?"
+    if (-not $confirmCreate) {
+        Write-Log "Operation cancelled by user." "INFO"
+        exit 0
+    }
+}
+
+# Create the scheduled task
+Write-Log "Creating scheduled task for weekly reboot..." "INFO"
+$createdTask = New-RebootScheduledTask `
+    -TaskName $TaskName `
+    -Day $DayOfWeek `
+    -ScheduledTime $Time `
+    -Delay $RebootDelay
+
+if ($null -eq $createdTask) {
+    Write-Log "Failed to create scheduled task. Please check the error messages above." "ERROR"
+    exit 1
+}
+
+# Verify task was created successfully
+Start-Sleep -Seconds 2
+$verifyTask = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+
+if ($null -eq $verifyTask) {
+    Write-Log "Task creation reported success, but task cannot be found in Task Scheduler." "ERROR"
+    exit 1
+}
+
+# Display success summary
+Write-Log "Scheduled task created successfully!" "SUCCESS"
+Show-TaskSummary -Task $verifyTask -Day $DayOfWeek -ScheduledTime $Time -Delay $RebootDelay
+
+# Display additional information
+Write-Host "Additional Information:" -ForegroundColor Cyan
+Write-Host "  - To view the task: " -NoNewline -ForegroundColor Gray
+Write-Host "Get-ScheduledTask -TaskName '$TaskName'" -ForegroundColor White
+Write-Host "  - To disable the task: " -NoNewline -ForegroundColor Gray
+Write-Host "Disable-ScheduledTask -TaskName '$TaskName'" -ForegroundColor White
+Write-Host "  - To enable the task: " -NoNewline -ForegroundColor Gray
+Write-Host "Enable-ScheduledTask -TaskName '$TaskName'" -ForegroundColor White
+Write-Host "  - To remove the task: " -NoNewline -ForegroundColor Gray
+Write-Host "Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:`$false" -ForegroundColor White
+Write-Host "  - To test the reboot: " -NoNewline -ForegroundColor Gray
+Write-Host "Start-ScheduledTask -TaskName '$TaskName'" -ForegroundColor White
+Write-Host ""
+
+Write-Log "Script completed successfully." "SUCCESS"
+exit 0


### PR DESCRIPTION
- Created New-WeeklyRebootSchedule.ps1 comprehensive script
  * Interactive day of week selection (Monday-Sunday)
  * 24-hour time format input with validation
  * Runs under NT AUTHORITY\SYSTEM account
  * Configurable reboot delay for graceful shutdown
  * Automatic handling of existing tasks
  * Comprehensive input validation and error handling
  * Detailed logging and status reporting

- Updated scripts/server/README.md with full documentation
  * Added script features and usage examples
  * Included parameter descriptions and defaults
  * Added troubleshooting section
  * Updated quick reference table
  * Incremented total script count to 17

The script creates a scheduled task that automatically reboots Windows Server on a weekly basis at a user-specified day and time, providing a reliable maintenance window solution.