### PR TITLE
feat: Add automatic LTS replacement for EOL .NET runtimes

### DIFF
--- a/scripts/utilities/README.md
+++ b/scripts/utilities/README.md
@@ -15,6 +15,7 @@ This advanced script manages ASP.NET Core and Windows Desktop runtimes across yo
 - ✅ **Architecture Aware** - Handles both x64 and x86 runtimes independently
 - ✅ **Automatic Updates** - Downloads and installs latest patches per channel
 - ✅ **EOL Detection** - Identifies and removes end-of-life runtime versions
+- ✅ **Smart EOL Replacement** - Automatically suggests and installs LTS replacements for EOL versions
 - ✅ **Patch Cleanup** - Removes lower patch versions automatically
 - ✅ **Disk Usage Reporting** - Before/after reports with reclaimed space
 - ✅ **LTS Filtering** - Option to only update Long Term Support channels
@@ -103,7 +104,9 @@ This advanced script manages ASP.NET Core and Windows Desktop runtimes across yo
 
 2. **EOL Handling**
    - Detects channels that have reached End of Life
+   - Suggests active LTS replacement versions
    - Optionally removes EOL runtimes (with approval)
+   - Can automatically install recommended LTS replacement
    - Cleans up associated base runtimes
 
 3. **Update Phase**
@@ -126,11 +129,22 @@ This advanced script manages ASP.NET Core and Windows Desktop runtimes across yo
 #### Output Example
 
 ```
-=== ASP.NET Core Channel 8.0 x64 ===
-Update available: 8.0.8 → 8.0.11 (x64)
+=== ASP.NET Core Channel 6.0 x64 ===
+EOL channel detected: 6.0 | End of support: 2024-11-12 | Installed: 6.0.14
+  → Recommended replacement: .NET 8.0 LTS (supported until 2026-11-10)
+  → Will install .NET 8.0 LTS after removal
+Using uninstall tool to remove ASP.NET Core 6.0
+Removal complete for EOL channel 6.0 x64
+Installing replacement: .NET 8.0 LTS x64...
 Downloading ASP.NET Core Runtime x64...
-Installing ASP.NET Core Runtime 8.0.11 x64...
-Update complete for 8.0 x64 to 8.0.11
+Installing ASP.NET Core Runtime 8.0.22 x64...
+Successfully installed .NET 8.0 LTS (8.0.22) x64
+
+=== ASP.NET Core Channel 9.0 x64 ===
+Update available: 9.0.8 → 9.0.11 (x64)
+Downloading ASP.NET Core Runtime x64...
+Installing ASP.NET Core Runtime 9.0.11 x64...
+Update complete for 9.0 x64 to 9.0.11
 
 === Post install patch cleanup ===
 Removing lower patches (tool or filesystem fallback)
@@ -139,8 +153,9 @@ Cleanup complete for ASP.NET Core Runtime x64
 
 ╔═══════════════════════════════════════════════════╗
 ║ Runtime Maintenance Summary                      ║
-║ Updated        : 3                                ║
+║ Updated        : 1                                ║
 ║ EOL removed    : 1                                ║
+║ EOL upgraded   : 1                                ║
 ║ Already current: 2                                ║
 ║ Skipped        : 0                                ║
 ║ Cleanup runs   : 2                                ║

--- a/scripts/utilities/Update-DotNetRuntimes.ps1
+++ b/scripts/utilities/Update-DotNetRuntimes.ps1
@@ -325,11 +325,12 @@ function Write-Box {
 function Get-ActionStats {
     param([object[]]$Actions)
     $stats = @{
-        Updated       = 0
-        'EOL-Removed' = 0
-        Current       = 0
-        Skipped       = 0
-        Cleanup       = 0
+        Updated        = 0
+        'EOL-Removed'  = 0
+        'EOL-Upgraded' = 0
+        Current        = 0
+        Skipped        = 0
+        Cleanup        = 0
     }
     foreach ($a in $Actions) {
         if ($stats.ContainsKey($a.Type)) { $stats[$a.Type]++ }
@@ -346,6 +347,7 @@ function Write-ActionSummary {
     $lines = @(
         ("Updated        : {0}" -f $stats.Updated),
         ("EOL removed    : {0}" -f $stats.'EOL-Removed'),
+        ("EOL upgraded   : {0}" -f $stats.'EOL-Upgraded'),
         ("Already current: {0}" -f $stats.Current),
         ("Skipped        : {0}" -f $stats.Skipped),
         ("Cleanup runs   : {0}" -f $stats.Cleanup),
@@ -551,6 +553,21 @@ function Get-LatestWindowsDesktopVersion {
     } else {
         $null
     }
+}
+
+function Get-ReplacementLtsChannel {
+    param([object]$IndexData)
+
+    # Get all active LTS channels (not EOL)
+    $ltsChannels = $IndexData.'releases-index' | Where-Object {
+        $_.'release-type' -eq 'lts' -and $_.'support-phase' -ne 'eol'
+    } | Sort-Object { [version]$_.'channel-version' }
+
+    if ($ltsChannels -and $ltsChannels.Count -gt 0) {
+        # Return the oldest active LTS (most stable)
+        return $ltsChannels[0]
+    }
+    return $null
 }
 
 #------------------------- Helpers Download Install -----------------#
@@ -1198,10 +1215,36 @@ try {
             $eolDate = $channel.'eol-date'
             Write-Host "EOL channel detected: $majorMinor | End of support: $eolDate | Installed: $($versions -join ', ')" -ForegroundColor Red
 
+            # Suggest LTS replacement
+            $replacementChannel = Get-ReplacementLtsChannel -IndexData $index
+            if ($replacementChannel) {
+                $replacementVersion = $replacementChannel.'channel-version'
+                $replacementEol = $replacementChannel.'eol-date'
+                Write-Host "  → Recommended replacement: .NET $replacementVersion LTS (supported until $replacementEol)" -ForegroundColor Cyan
+            }
+
             $doRemove = $Approve -and $RemoveEol
+            $doInstallReplacement = $false
+
             if (-not $Approve) {
                 $resp = Read-Host "Remove ASP.NET Core $majorMinor $archLabel now? (Y/N)"
-                if ($resp -in @('Y','y')) { $doRemove = $true }
+                if ($resp -in @('Y','y')) {
+                    $doRemove = $true
+
+                    # Ask if user wants to install replacement
+                    if ($replacementChannel) {
+                        $replResp = Read-Host "Install .NET $replacementVersion LTS as replacement? (Y/N)"
+                        if ($replResp -in @('Y','y')) {
+                            $doInstallReplacement = $true
+                        }
+                    }
+                }
+            } else {
+                # In auto-approve mode, offer to install replacement
+                if ($replacementChannel -and $RemoveEol) {
+                    $doInstallReplacement = $true
+                    Write-Host "  → Will install .NET $replacementVersion LTS after removal" -ForegroundColor Green
+                }
             }
 
             if ($doRemove) {
@@ -1211,6 +1254,63 @@ try {
                         Remove-BaseRuntimeChannel -MajorMinor $majorMinor
                         Write-Host "Removal complete for EOL channel $majorMinor $archLabel" -ForegroundColor Green
                         Add-Action -Type 'EOL-Removed' -Channel $majorMinor -Arch $archLabel -Detail "Removed ASP.NET Core + base runtime"
+
+                        # Install replacement if requested
+                        if ($doInstallReplacement -and $replacementChannel) {
+                            $replacementVersion = $replacementChannel.'channel-version'
+                            Write-Host "Installing replacement: .NET $replacementVersion LTS $archLabel..." -ForegroundColor Cyan
+
+                            try {
+                                $replacementReleasesUrl = $replacementChannel.'releases.json'
+                                $replacementReleaseData = Get-OrAddReleaseData -ReleasesJsonUrl $replacementReleasesUrl
+
+                                $latestRepl = Get-LatestAspNetCoreVersion -ReleaseData $replacementReleaseData
+                                if ($latestRepl) {
+                                    $latestReplVersion = $latestRepl.Version
+                                    $aspFile = Get-AspNetCoreDownload -Release $latestRepl.Release -Arch $archLabel
+                                    $rtFile = Get-DotNetRuntimeDownload -Release $latestRepl.Release -Arch $archLabel
+
+                                    if ($aspFile) {
+                                        $temp = Join-Path $env:TEMP ("dotnet-updater-" + [Guid]::NewGuid().ToString('N'))
+                                        New-Item -ItemType Directory -Path $temp -Force | Out-Null
+
+                                        try {
+                                            $aspPath = Join-Path $temp ("aspnetcore-$($latestReplVersion.ToString())-$archLabel.exe")
+                                            Write-Host "Downloading ASP.NET Core Runtime $archLabel..." -ForegroundColor Cyan
+                                            Save-FileWithRetry -Url $aspFile.url -Destination $aspPath
+                                            Test-FileHashIfAvailable -FilePath $aspPath -Sha512 $aspFile.sha512 | Out-Null
+
+                                            $rtPath = $null
+                                            if ($rtFile) {
+                                                $rtPath = Join-Path $temp ("dotnet-runtime-$($latestReplVersion.ToString())-$archLabel.exe")
+                                                Write-Host "Downloading .NET Runtime $archLabel..." -ForegroundColor Cyan
+                                                Save-FileWithRetry -Url $rtFile.url -Destination $rtPath
+                                                Test-FileHashIfAvailable -FilePath $rtPath -Sha512 $rtFile.sha512 | Out-Null
+                                            }
+
+                                            if ($rtPath) {
+                                                Write-Host "Installing .NET Runtime $($latestReplVersion.ToString()) $archLabel..." -ForegroundColor Cyan
+                                                Install-Exe -Path $rtPath
+                                            }
+
+                                            Write-Host "Installing ASP.NET Core Runtime $($latestReplVersion.ToString()) $archLabel..." -ForegroundColor Cyan
+                                            Install-Exe -Path $aspPath
+
+                                            Write-Host "Successfully installed .NET $replacementVersion LTS ($latestReplVersion) $archLabel" -ForegroundColor Green
+                                            Add-Action -Type 'EOL-Upgraded' -Channel $replacementVersion -Arch $archLabel -Detail "Installed $latestReplVersion as replacement for EOL $majorMinor"
+                                        } finally {
+                                            try { Remove-Item -Path $temp -Recurse -Force -ErrorAction SilentlyContinue } catch {}
+                                        }
+                                    } else {
+                                        Write-Warning "Could not find ASP.NET Core installer for .NET $replacementVersion $archLabel"
+                                    }
+                                } else {
+                                    Write-Warning "Could not determine latest version for .NET $replacementVersion"
+                                }
+                            } catch {
+                                Write-Warning "Failed to install replacement .NET $replacementVersion : $($_.Exception.Message)"
+                            }
+                        }
                     }
                 } catch {
                     $overallFailed = $true


### PR DESCRIPTION
When EOL runtimes are detected, the script now:
- Suggests the oldest active LTS version as a replacement
- Shows the recommended version and its support end date
- In auto-approve mode, automatically installs the LTS replacement
- In interactive mode, prompts user to install replacement
- Tracks EOL upgrades separately in action log

Key Features:
- New Get-ReplacementLtsChannel function finds oldest active LTS
- Enhanced EOL handling with install-after-removal logic
- Downloads and installs both base runtime and ASP.NET Core
- Proper error handling for replacement installation
- New "EOL-Upgraded" action type in reporting
- Updated summary box to show EOL upgraded count

Example Output:
```
=== ASP.NET Core Channel 6.0 x64 ===
EOL channel detected: 6.0 | End of support: 2024-11-12
  → Recommended replacement: .NET 8.0 LTS (supported until 2026-11-10)
  → Will install .NET 8.0 LTS after removal
Removal complete for EOL channel 6.0 x64
Installing replacement: .NET 8.0 LTS x64...
Successfully installed .NET 8.0 LTS (8.0.22) x64
```

This addresses the issue where EOL versions were removed but users were left without a supported runtime. Now the script guides users to maintain supported LTS versions automatically.

Updated documentation to reflect the new smart EOL replacement feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)