### PR TITLE
fix: Update wiki sync to use WIKI_TOKEN for authentication

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki-repo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WIKI_TOKEN }}
 
       - name: Sync wiki files
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN doesn't have permission to push to wiki repos. Updated workflow to use WIKI_TOKEN secret instead.

Setup instructions:
1. Create a Personal Access Token with 'repo' scope
2. Add it as WIKI_TOKEN secret in repository settings
3. Workflow will then have permission to push to wiki