### PR TITLE
fix: Convert wiki relative links to absolute GitHub URLs

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -93,7 +93,7 @@ Absolutely! The scripts are open source. You can:
 - Modify them for your environment
 - Add features
 - Fix bugs
-- Share improvements back (see **[Contributing](../CONTRIBUTING.md)**)
+- Share improvements back (see **[Contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)**)
 
 ---
 
@@ -121,7 +121,7 @@ The scripts are designed to be safe, but you should always:
 3. **Understand what it does**
 4. **Have backups**
 
-Report security concerns to our **[Security Policy](../SECURITY.md)**.
+Report security concerns to our **[Security Policy](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md)**.
 
 ---
 
@@ -240,7 +240,7 @@ See **[Troubleshooting](Troubleshooting)** for more help.
 ## Contributing & Support
 
 ### How can I contribute?
-See **[Contributing Guide](../CONTRIBUTING.md)** for:
+See **[Contributing Guide](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)** for:
 - Bug reports
 - Feature requests
 - Pull requests
@@ -283,7 +283,7 @@ git pull origin main
 - Extract and replace old files
 
 ### How often are scripts updated?
-Check the **[Changelog](../CHANGELOG.md)** for release history. Recent updates:
+Check the **[Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** for release history. Recent updates:
 - **v3.0.2 "Drizzle"** (2026-01-03) - Documentation cleanup
 - **v3.0.1 "Drizzle"** (2025-12-31) - Bug fixes
 - **v3.0.0 "Hurricane"** (2025-12-30) - Repository restructure

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -298,7 +298,7 @@ See individual script documentation for detailed exit code information.
 1. ✅ You're a power user!
 2. 🏗️ Review the codebase to understand design patterns
 3. 🔨 Customize scripts for your environment
-4. 🤝 Read [Contributing](../CONTRIBUTING.md) to help improve the repo
+4. 🤝 Read [Contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) to help improve the repo
 
 ---
 
@@ -329,8 +329,8 @@ Get-Help .\ScriptName.ps1 -Full
 | Script not working | [Troubleshooting Guide](Troubleshooting) |
 | Don't understand usage | [Script Examples](Script-Examples) |
 | Found a bug | [GitHub Issues](https://github.com/Carme99/bug-free-umbrella/issues) |
-| Want to contribute | [Contributing Guide](../CONTRIBUTING.md) |
-| Security concern | [Security Policy](../SECURITY.md) |
+| Want to contribute | [Contributing Guide](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) |
+| Security concern | [Security Policy](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md) |
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,9 +2,9 @@
 
 Welcome to the comprehensive documentation for Bug-Free Umbrella - a collection of 260+ PowerShell scripts for enterprise IT management!
 
-> **Latest Release:** [v3.0.3 "Drizzle" ☔](../CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix) - Wiki version reference fixes!
+> **Latest Release:** [v3.0.3 "Drizzle" ☔](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix) - Wiki version reference fixes!
 >
-> 📋 **[View Full Changelog →](../CHANGELOG.md)** | 📦 **[GitHub Releases](https://github.com/Carme99/bug-free-umbrella/releases)**
+> 📋 **[View Full Changelog →](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** | 📦 **[GitHub Releases](https://github.com/Carme99/bug-free-umbrella/releases)**
 
 ---
 
@@ -142,14 +142,14 @@ Additional pages planned:
 - Best practices and architecture guides
 
 ### 📋 Project Information
-- **[📋 Full Changelog (CHANGELOG.md)](../CHANGELOG.md)** - Complete version history
-  - [v3.0.3 "Drizzle" ☔](../CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix) - Latest patch (wiki fix)
-  - [v3.0.2 "Drizzle" ☔](../CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup) - Latest release
-  - [v3.0.1 "Drizzle" ☔](../CHANGELOG.md#301---2025-12-31--drizzle---bug-fix-release)
-  - [v3.0.0 "Hurricane" 🌪️](../CHANGELOG.md#300---2025-12-30--hurricane---repository-restructure)
-  - [v2.2.0 "Shower" 🌧️](../CHANGELOG.md#220---2025-12-28--shower---navigation--usability-improvements)
-- **[Contributing](../CONTRIBUTING.md)** - How to contribute to the project
-- **[Security Policy](../SECURITY.md)** - Reporting security vulnerabilities
+- **[📋 Full Changelog (CHANGELOG.md)](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** - Complete version history
+  - [v3.0.3 "Drizzle" ☔](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix) - Latest patch (wiki fix)
+  - [v3.0.2 "Drizzle" ☔](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup) - Latest release
+  - [v3.0.1 "Drizzle" ☔](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#301---2025-12-31--drizzle---bug-fix-release)
+  - [v3.0.0 "Hurricane" 🌪️](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#300---2025-12-30--hurricane---repository-restructure)
+  - [v2.2.0 "Shower" 🌧️](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#220---2025-12-28--shower---navigation--usability-improvements)
+- **[Contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)** - How to contribute to the project
+- **[Security Policy](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md)** - Reporting security vulnerabilities
 - **[GitHub Repository](https://github.com/Carme99/bug-free-umbrella)** - Source code and issues
 
 ---
@@ -166,16 +166,16 @@ The latest release focuses on **wiki version reference fixes**:
 - 🔢 **Wiki Version Incremented:** 1.0.0 → 1.1.0 to track documentation updates
 - ✨ **Better Consistency:** All wiki pages now reference the correct current release
 
-**Previous Release:** [v3.0.2 "Drizzle" ☔](../CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup) - Documentation cleanup and broken link fixes
+**Previous Release:** [v3.0.2 "Drizzle" ☔](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup) - Documentation cleanup and broken link fixes
 
-**[Read Full Changelog →](../CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix)**
+**[Read Full Changelog →](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix)**
 
 ### Recent Major Releases
-- ☔ **[v3.0.3 "Drizzle"](../CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix)** (2026-01-04) - Wiki version reference fix
-- ☔ **[v3.0.2 "Drizzle"](../CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup)** (2026-01-03) - Documentation cleanup
-- ☔ **[v3.0.1 "Drizzle"](../CHANGELOG.md#301---2025-12-31--drizzle---bug-fix-release)** (2025-12-31) - Bug fixes
-- 🌪️ **[v3.0.0 "Hurricane"](../CHANGELOG.md#300---2025-12-30--hurricane---repository-restructure)** (2025-12-30) - Repository restructure
-- 🌧️ **[v2.2.0 "Shower"](../CHANGELOG.md#220---2025-12-28--shower---navigation--usability-improvements)** (2025-12-28) - Navigation improvements
+- ☔ **[v3.0.3 "Drizzle"](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#303---2026-01-04--drizzle---wiki-version-reference-fix)** (2026-01-04) - Wiki version reference fix
+- ☔ **[v3.0.2 "Drizzle"](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#302---2026-01-03--drizzle---documentation-cleanup)** (2026-01-03) - Documentation cleanup
+- ☔ **[v3.0.1 "Drizzle"](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#301---2025-12-31--drizzle---bug-fix-release)** (2025-12-31) - Bug fixes
+- 🌪️ **[v3.0.0 "Hurricane"](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#300---2025-12-30--hurricane---repository-restructure)** (2025-12-30) - Repository restructure
+- 🌧️ **[v2.2.0 "Shower"](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md#220---2025-12-28--shower---navigation--usability-improvements)** (2025-12-28) - Navigation improvements
 
 ---
 
@@ -192,7 +192,7 @@ Quick links to accomplish specific tasks:
 | **Fix an issue** | Check **[Troubleshooting](Troubleshooting)** |
 | **Deploy Azure Virtual Desktop** | See **[Azure Virtual Desktop](Azure-Virtual-Desktop)** guide |
 | **Build ACG images** | Follow **[ACG Image Builder](Azure-Compute-Gallery-Image-Builder)** workflow |
-| **Check what's new** | Read the **[Changelog](../CHANGELOG.md)** |
+| **Check what's new** | Read the **[Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** |
 
 ---
 
@@ -221,8 +221,8 @@ Quick links to accomplish specific tasks:
 3. **[Azure Virtual Desktop](Azure-Virtual-Desktop)** - Advanced deployment guides
 
 **Advanced?** Check out:
-1. **[Changelog](../CHANGELOG.md)** - Stay current with latest changes
-2. **[Contributing](../CONTRIBUTING.md)** - Help improve the repository
+1. **[Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** - Stay current with latest changes
+2. **[Contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)** - Help improve the repository
 3. **Repository code** - Explore the scripts directly
 
 ---
@@ -234,10 +234,10 @@ Quick links to accomplish specific tasks:
 | "How do I use this script?" | [Script Examples](Script-Examples) ✅ |
 | "Something's not working" | [Troubleshooting](Troubleshooting) ✅ |
 | "How do I set this up?" | [Getting Started](Getting-Started) ✅ |
-| "What's new?" | [📋 Changelog](../CHANGELOG.md) ✅ |
+| "What's new?" | [📋 Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) ✅ |
 | "I found a bug" | [GitHub Issues](https://github.com/Carme99/bug-free-umbrella/issues) |
-| "I want to contribute" | [Contributing Guide](../CONTRIBUTING.md) |
-| "Security issue" | [Security Policy](../SECURITY.md) |
+| "I want to contribute" | [Contributing Guide](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) |
+| "Security issue" | [Security Policy](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md) |
 
 ---
 
@@ -269,4 +269,4 @@ Bug-Free Umbrella is a comprehensive collection of PowerShell scripts for enterp
 
 **Corresponds to Release:** v3.0.3 "Drizzle" ☔
 
-**[📋 View Full Changelog →](../CHANGELOG.md)**
+**[📋 View Full Changelog →](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)**

--- a/wiki/Script-Catalog.md
+++ b/wiki/Script-Catalog.md
@@ -9,8 +9,8 @@
 ### For First-Time Users
 | What you want to do | Go here |
 |---------------------|---------|
-| **Understand what this repo is** | [Main README](../README.md) |
-| **See what's new** | [CHANGELOG](../CHANGELOG.md) - Check out our fun release names! 🌈 |
+| **Understand what this repo is** | [Main README](https://github.com/Carme99/bug-free-umbrella/blob/main/README.md) |
+| **See what's new** | [CHANGELOG](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) - Check out our fun release names! 🌈 |
 | **Get started quickly** | [Quick Start Guide](#quick-start-paths) (below) |
 | **See example outputs** | [Script Examples](Script-Examples) |
 
@@ -20,8 +20,8 @@
 | **Follow a complete workflow** | [Workflows](Workflows) |
 | **Troubleshoot a problem** | [Troubleshooting](Troubleshooting) |
 | **Find a specific script** | [Script Index](#script-index-by-category) (below) |
-| **Contribute** | [CONTRIBUTING.md](../CONTRIBUTING.md) |
-| **Report security issue** | [SECURITY.md](../SECURITY.md) |
+| **Contribute** | [CONTRIBUTING.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) |
+| **Report security issue** | [SECURITY.md](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md) |
 
 ---
 
@@ -114,16 +114,16 @@ START HERE → Main README → Winget Updates Section
 
 | Document | Purpose | When to Use |
 |----------|---------|-------------|
-| **[README.md](../README.md)** | Repository overview, quick start | First stop for new users |
-| **[CHANGELOG.md](../CHANGELOG.md)** | Version history with fun codenames! 🌂 | See what's new, understand changes |
+| **[README.md](https://github.com/Carme99/bug-free-umbrella/blob/main/README.md)** | Repository overview, quick start | First stop for new users |
+| **[CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)** | Version history with fun codenames! 🌂 | See what's new, understand changes |
 | **[Wiki Home](Home)** | Complete documentation hub | Deep dive into all scripts |
 | **[Script Examples](Script-Examples)** | Detailed examples with outputs | Learn how scripts work |
 | **[Workflows](Workflows)** | End-to-end step-by-step guides | Follow complete processes |
 | **[Troubleshooting](Troubleshooting)** | Common issues and solutions | When things don't work |
 | **[Intune Sync Guide](Intune-Sync-Guide)** | User group → device group sync | Specific Intune sync scenarios |
-| **[CONTRIBUTING.md](../CONTRIBUTING.md)** | How to contribute | Want to add scripts or fixes |
-| **[SECURITY.md](../SECURITY.md)** | Security policy | Report vulnerabilities |
-| **[SCRIPT_ANALYSIS_REPORT.md](../SCRIPT_ANALYSIS_REPORT.md)** | PowerShell code analysis | Understand code quality |
+| **[CONTRIBUTING.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)** | How to contribute | Want to add scripts or fixes |
+| **[SECURITY.md](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md)** | Security policy | Report vulnerabilities |
+| **[SCRIPT_ANALYSIS_REPORT.md](https://github.com/Carme99/bug-free-umbrella/blob/main/SCRIPT_ANALYSIS_REPORT.md)** | PowerShell code analysis | Understand code quality |
 
 ---
 
@@ -385,23 +385,23 @@ Organized by category:
 ## 🎓 Learning Paths
 
 ### Beginner Path: "New to PowerShell automation"
-1. Start with [Main README](../README.md) - understand the repository
+1. Start with [Main README](https://github.com/Carme99/bug-free-umbrella/blob/main/README.md) - understand the repository
 2. Review [Script Examples](Script-Examples) - see how scripts work
 3. Try a simple script like `Get-DeviceComplianceReport.ps1`
 4. Review [Troubleshooting](Troubleshooting) if issues arise
 5. Explore [Proactive Remediations](https://github.com/Carme99/bug-free-umbrella/tree/main/scripts/endpoints/devices/proactive-remediations) for auto-fix scripts
 
 ### Intermediate Path: "I know PowerShell, want to deploy"
-1. Review [Main README](../README.md) prerequisites section
+1. Review [Main README](https://github.com/Carme99/bug-free-umbrella/blob/main/README.md) prerequisites section
 2. Pick your focus area from [Script Index](#script-index-by-category)
 3. Follow a complete workflow from [Workflows](Workflows)
-4. Review [CHANGELOG.md](../CHANGELOG.md) for latest improvements
-5. Consider [contributing](../CONTRIBUTING.md) improvements
+4. Review [CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) for latest improvements
+5. Consider [contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) improvements
 
 ### Advanced Path: "I want to customize and contribute"
-1. Read [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
-2. Review [SCRIPT_ANALYSIS_REPORT.md](../SCRIPT_ANALYSIS_REPORT.md) for code quality standards
-3. Check [CHANGELOG.md](../CHANGELOG.md) - see what's been improved (e.g., 🌈 Rainbow release)
+1. Read [CONTRIBUTING.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) guidelines
+2. Review [SCRIPT_ANALYSIS_REPORT.md](https://github.com/Carme99/bug-free-umbrella/blob/main/SCRIPT_ANALYSIS_REPORT.md) for code quality standards
+3. Check [CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) - see what's been improved (e.g., 🌈 Rainbow release)
 4. Fork, customize, and submit pull requests
 5. Help expand documentation and examples
 
@@ -428,7 +428,7 @@ Organized by category:
 - 📚 **Cleaner Documentation:** Simplified docs folder, consistent wiki link format
 - ✨ **Better UX:** All internal wiki links now use proper wiki-style navigation
 
-**See full details:** [CHANGELOG.md](../CHANGELOG.md)
+**See full details:** [CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)
 
 ---
 
@@ -455,7 +455,7 @@ Organized by category:
 
 - **GitHub Repository**: [Carme99/bug-free-umbrella](https://github.com/Carme99/bug-free-umbrella)
 - **Issues & Feature Requests**: [GitHub Issues](https://github.com/Carme99/bug-free-umbrella/issues)
-- **Changelog with Fun Codenames**: [CHANGELOG.md](../CHANGELOG.md) 🌂
+- **Changelog with Fun Codenames**: [CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) 🌂
 - **Claude Code**: [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code)
 
 ---
@@ -489,9 +489,9 @@ Organized by category:
 | "How do I use this script?" | [Script Examples](Script-Examples) |
 | "Something's not working" | [Troubleshooting](Troubleshooting) |
 | "How do I deploy this?" | [Workflows](Workflows) |
-| "What's new?" | [CHANGELOG.md](../CHANGELOG.md) |
-| "I want to contribute" | [CONTRIBUTING.md](../CONTRIBUTING.md) |
-| "I found a security issue" | [SECURITY.md](../SECURITY.md) |
+| "What's new?" | [CHANGELOG.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md) |
+| "I want to contribute" | [CONTRIBUTING.md](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md) |
+| "I found a security issue" | [SECURITY.md](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md) |
 | "General questions" | Check script comments or [GitHub Issues](https://github.com/Carme99/bug-free-umbrella/issues) |
 
 ---

--- a/wiki/WIKI-SETUP.md
+++ b/wiki/WIKI-SETUP.md
@@ -308,7 +308,7 @@ No pull request needed! (But changes are tracked in Git history)
 **Main Repository:**
 - [Main Repo](https://github.com/Carme99/bug-free-umbrella)
 - [Latest Release](https://github.com/Carme99/bug-free-umbrella/releases/latest)
-- [Changelog](../CHANGELOG.md)
+- [Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)
 
 ---
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -47,10 +47,10 @@ Coming soon
 ---
 
 ### 📋 Project Info
-- [📋 Changelog](../CHANGELOG.md)
+- [📋 Changelog](https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md)
 - [GitHub Repo](https://github.com/Carme99/bug-free-umbrella)
-- [Contributing](../CONTRIBUTING.md)
-- [Security](../SECURITY.md)
+- [Contributing](https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md)
+- [Security](https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md)
 
 ---
 


### PR DESCRIPTION
## Problem
The wiki sync successfully copies files to the GitHub Wiki repository, but relative links like `../CHANGELOG.md` don't work in the wiki because it's a separate Git repository. These links were showing as broken in the deployed wiki.

## Solution
Converted all relative links to absolute GitHub URLs:
- ../CHANGELOG.md → https://github.com/Carme99/bug-free-umbrella/blob/main/CHANGELOG.md
- ../CONTRIBUTING.md → https://github.com/Carme99/bug-free-umbrella/blob/main/CONTRIBUTING.md
- ../SECURITY.md → https://github.com/Carme99/bug-free-umbrella/blob/main/SECURITY.md
- ../README.md → https://github.com/Carme99/bug-free-umbrella/blob/main/README.md
- ../SCRIPT_ANALYSIS_REPORT.md → https://github.com/Carme99/bug-free-umbrella/blob/main/SCRIPT_ANALYSIS_REPORT.md

## Files Modified (6)
- wiki/Home.md - Fixed all CHANGELOG version links
- wiki/FAQ.md - Fixed CHANGELOG, CONTRIBUTING, and SECURITY links
- wiki/Script-Catalog.md - Fixed all main repo file links
- wiki/Getting-Started.md - Fixed CONTRIBUTING and SECURITY links
- wiki/_Sidebar.md - Fixed CHANGELOG, CONTRIBUTING, and SECURITY links
- wiki/WIKI-SETUP.md - Fixed CHANGELOG link

All links now properly resolve in the deployed GitHub Wiki.
