### PR TITLE
fix: harden sync-wiki + fix labeler typo, seed missing labels

### DIFF
--- a/.github/scripts/create-labels.ps1
+++ b/.github/scripts/create-labels.ps1
@@ -104,10 +104,15 @@ $labels = @(
     @{ name = "testing"; color = "BFD4F2"; description = "Testing, validation, Pester tests" }
 
     # ========== PRIORITY LEVELS ==========
-    @{ name = "priority:high"; color = "B60205"; description = "High priority issue" }
+    @{ name = "priority-high"; color = "B60205"; description = "High priority issue" }
     @{ name = "good-first-issue"; color = "7057FF"; description = "Good for newcomers" }
 
     # ========== PROCESS LABELS ==========
+    @{ name = "pinned"; color = "FEF2C0"; description = "Pinned issue/PR exempt from stale-closing" }
+    @{ name = "work-in-progress"; color = "FFD93D"; description = "PR or issue still in progress" }
+    @{ name = "help-wanted"; color = "008672"; description = "Help wanted from contributors" }
+    @{ name = "triage"; color = "B60205"; description = "Needs triage" }
+    @{ name = "new-script"; color = "0E8A16"; description = "New script submission" }
     @{ name = "stale"; color = "EDEDED"; description = "Inactive issue/PR (auto-applied)" }
     @{ name = "broken-links"; color = "D93F0B"; description = "Broken links in documentation" }
     @{ name = "automated"; color = "BFDADC"; description = "Created by automation" }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,14 +16,14 @@ This directory contains automated workflows for repository management and qualit
 - Analyzes issue title and body for keywords
 - Applies relevant technology labels (azure, intune, m365, etc.)
 - Applies issue type labels (bug, enhancement, documentation, etc.)
-- Applies priority labels (priority:high, good-first-issue)
+- Applies priority labels (priority-high, good-first-issue)
 - Adds a comment when multiple categories are detected
 - Adds a helpful comment when no labels match
 
 **Labels Applied** (46 total):
 - **Technology** (29): azure, aws, containers, intune, winget, windows-server, active-directory, security, etc.
 - **Issue Type** (6): bug, enhancement, documentation, question, performance, testing
-- **Priority** (2): priority:high, good-first-issue
+- **Priority** (2): priority-high, good-first-issue
 - **Process** (5): stale, broken-links, automated, dependencies, github-actions
 
 **Configuration:**

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -103,7 +103,7 @@ jobs:
 
             // Critical/High Priority
             if (combined.match(/\b(critical|urgent|emergency|security vulnerability|broken)\b/)) {
-              labels.push('priority:high');
+              labels.push('priority-high');
             }
 
             // Good first issue (for contributors)
@@ -129,7 +129,7 @@ jobs:
               // Add comment if multiple categories detected
               if (uniqueLabels.length >= 3) {
                 const categoryLabels = uniqueLabels.filter(l =>
-                  !['bug', 'enhancement', 'documentation', 'question', 'performance', 'testing', 'priority:high', 'good-first-issue'].includes(l)
+                  !['bug', 'enhancement', 'documentation', 'question', 'performance', 'testing', 'priority-high', 'good-first-issue'].includes(l)
                 );
 
                 if (categoryLabels.length > 1) {

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify wiki repository exists
+        env:
+          GH_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}.wiki >/dev/null 2>&1 || { echo "::error::wiki repository does not exist"; exit 1; }
+
       - name: Checkout wiki repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -21,7 +21,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WIKI_TOKEN }}
         run: |
-          gh api repos/${{ github.repository }}.wiki >/dev/null 2>&1 || { echo "::error::wiki repository does not exist"; exit 1; }
+          has_wiki=$(gh api "repos/${{ github.repository }}" --jq .has_wiki)
+          if [ "$has_wiki" != "true" ]; then
+            echo "::error::GitHub wiki is not enabled for ${{ github.repository }}. Enable it under Settings > General > Features, or create the wiki repo, then re-run."
+            exit 1
+          fi
 
       - name: Checkout wiki repository
         uses: actions/checkout@v4
@@ -41,13 +45,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Check if there are changes
-          if git diff --quiet; then
+          # Stage all changes (including newly copied untracked files) before checking for a diff
+          git add .
+
+          # If there is nothing staged, there is nothing to commit
+          if git diff --cached --quiet; then
             echo "No changes to commit"
             exit 0
           fi
 
-          git add .
           git commit -m "docs: Auto-sync wiki from main repository
 
           Synced from commit: ${{ github.sha }}


### PR DESCRIPTION
Fixes #89 #95

- sync-wiki.yml: check has_wiki before checkout; stage untracked pages before diff guard
- issue-labeler.yml: priority:high -> priority-high
- create-labels.ps1: add pinned, work-in-progress, triage, new-script, help-wanted

## Summary by Sourcery

Harden wiki sync automation and align priority and process labels across workflows and label-seeding scripts.

Enhancements:
- Add a pre-check in the wiki sync workflow to ensure the repository wiki is enabled before attempting checkout and committing changes.
- Stage all wiki changes, including new pages, before the diff guard to avoid missing commits during sync.
- Align the high-priority label name from priority:high to priority-high across the issue labeler workflow and label creation script.
- Extend the label creation script with additional process labels such as pinned, work-in-progress, help-wanted, triage, and new-script.

Documentation:
- Update workflow documentation to reference the renamed priority-high label in the issue labeler description.