### PR TITLE
security: harden report scripts (auto-open, paths, HTML encoding, timestamps)

### DIFF
--- a/scripts/automation/cicd/Monitor-GitHubActions.ps1
+++ b/scripts/automation/cicd/Monitor-GitHubActions.ps1
@@ -30,7 +30,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/CSV/JSON output file. Default: Desktop
+    Path for HTML/CSV/JSON output file. Default: MyDocuments\Reports
 
 .PARAMETER IncludeRunners
     Include self-hosted runner health analysis
@@ -73,7 +73,7 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IncludeRunners,
@@ -81,6 +81,17 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$IncludeBilling
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 # Validate GitHub token
 if ([string]::IsNullOrWhiteSpace($GitHubToken)) {
@@ -264,6 +275,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== GitHub Actions Workflow Health Summary ===" -ForegroundColor Cyan
@@ -292,7 +305,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "GitHub-Actions-Health-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "GitHub-Actions-Health-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -321,7 +334,7 @@ switch ($OutputFormat) {
 <body>
     <h1>GitHub Actions Workflow Health Report</h1>
     <div class="summary">
-        <strong>Owner:</strong> $Owner | <strong>Repository:</strong> $Repository | <strong>Period:</strong> Last $DaysToAnalyze days<br>
+        <strong>Owner:</strong> $([System.Net.WebUtility]::HtmlEncode("$Owner")) | <strong>Repository:</strong> $([System.Net.WebUtility]::HtmlEncode("$Repository")) | <strong>Period:</strong> Last $DaysToAnalyze days<br>
         <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 
         <div class="summary-grid">
@@ -365,13 +378,13 @@ switch ($OutputFormat) {
             $statusClass = "status-$($workflow.Status.ToLower())"
             $html += @"
         <tr>
-            <td>$($workflow.Repository)</td>
-            <td>$($workflow.WorkflowName)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($workflow.Repository)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($workflow.WorkflowName)"))</td>
             <td>$($workflow.TotalRuns)</td>
             <td>$($workflow.SuccessRate)%</td>
             <td>$($workflow.FailedRuns)</td>
             <td>$($workflow.AverageDurationMinutes)</td>
-            <td class="$statusClass">$($workflow.Status)</td>
+            <td class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$($workflow.Status)"))</td>
         </tr>
 "@
         }
@@ -388,17 +401,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "GitHub-Workflows-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "GitHub-Workflows-${RunTimestamp}_${RunId}.csv"
         $results.Workflows | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "GitHub-Workflows-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "GitHub-Workflows-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/automation/cicd/Monitor-GitHubActions.ps1
+++ b/scripts/automation/cicd/Monitor-GitHubActions.ps1
@@ -85,7 +85,7 @@ param(
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/cloud/azure/core/Monitor-AzureResources.ps1
+++ b/scripts/cloud/azure/core/Monitor-AzureResources.ps1
@@ -28,7 +28,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -62,8 +62,19 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 if (-not (Get-Module -ListAvailable -Name Az.Accounts)) {
     Write-Error "Az.Accounts module required. Install: Install-Module Az"
@@ -178,6 +189,8 @@ foreach ($sub in $subscriptions) {
 Write-Host "`nAnalysis complete!" -ForegroundColor Green
 
 # Output
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Azure Resources Summary ===" -ForegroundColor Cyan
@@ -192,7 +205,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-Resources-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-Resources-${RunTimestamp}_${RunId}.html"
         $html = @"
 <!DOCTYPE html>
 <html>
@@ -214,14 +227,14 @@ switch ($OutputFormat) {
         <tr><th>Subscription</th><th>Total Resources</th><th>VMs</th><th>Resource Groups</th></tr>
 "@
         foreach ($sub in $results.Subscriptions) {
-            $html += "<tr><td>$($sub.Name)</td><td>$($sub.TotalResources)</td><td>$($sub.VirtualMachines.Count)</td><td>$($sub.ResourceGroups.Count)</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($sub.Name)"))</td><td>$($sub.TotalResources)</td><td>$($sub.VirtualMachines.Count)</td><td>$($sub.ResourceGroups.Count)</td></tr>"
         }
         $html += "</table>"
 
         if ($results.OrphanedResources.Count -gt 0) {
             $html += "<h2>Orphaned Resources</h2><table><tr><th>Type</th><th>Name</th><th>Resource Group</th><th>Subscription</th></tr>"
             foreach ($orphan in $results.OrphanedResources) {
-                $html += "<tr><td>$($orphan.Type)</td><td>$($orphan.Name)</td><td>$($orphan.ResourceGroup)</td><td>$($orphan.Subscription)</td></tr>"
+                $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Type)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.ResourceGroup)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Subscription)"))</td></tr>"
             }
             $html += "</table>"
         }
@@ -229,11 +242,10 @@ switch ($OutputFormat) {
         $html += "<p style='margin-top: 30px; text-align: center; color: #666; font-size: 12px;'><strong>Note:</strong> This report has not been thoroughly tested.</p></body></html>"
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-Resources-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-Resources-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/azure/core/Monitor-AzureResources.ps1
+++ b/scripts/cloud/azure/core/Monitor-AzureResources.ps1
@@ -68,7 +68,7 @@ param(
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/collaboration/microsoft365/Get-M365UserInfo.ps1
+++ b/scripts/collaboration/microsoft365/Get-M365UserInfo.ps1
@@ -593,7 +593,11 @@ function Export-UserReport {
 
     # Use safe filename to prevent path traversal
     $safeEmail = Get-SafeFileName $script:UserData.UserPrincipalName
-    $reportPath = "$env:USERPROFILE\Desktop\M365_UserReport_${safeEmail}_$timestamp.html"
+    $reportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    if (-not (Test-Path -LiteralPath $reportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+    }
+    $reportPath = Join-Path $reportDir "M365_UserReport_${safeEmail}_$timestamp.html"
 
     # Encode all user data for HTML to prevent XSS
     $safeDisplayName = ConvertTo-HtmlSafe $script:UserData.DisplayName
@@ -650,7 +654,6 @@ function Export-UserReport {
 
     $html | Out-File -FilePath $reportPath -Encoding UTF8
     Write-Host "[+] Report saved to: $reportPath" -ForegroundColor Green
-    Start-Process $reportPath
 }
 
 #endregion

--- a/scripts/collaboration/microsoft365/azure-ad/Set-UserLanguageSettings.ps1
+++ b/scripts/collaboration/microsoft365/azure-ad/Set-UserLanguageSettings.ps1
@@ -110,6 +110,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== Microsoft 365 Language & Region Settings ===" -ForegroundColor Cyan
 Write-Host "Mode: $(if ($Apply) { 'APPLY SETTINGS' } else { 'AUDIT ONLY' })" -ForegroundColor $(if ($Apply) { 'Yellow' } else { 'Green' })
@@ -486,7 +490,7 @@ if ($nonCompliantCount -gt 0 -and -not $Apply) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\LanguageSettings_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "LanguageSettings_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -550,13 +554,13 @@ if ($ExportHTML) {
 
         $html += @"
         <tr>
-            <td>$($result.DisplayName)</td>
-            <td>$($result.UserPrincipalName)</td>
-            <td>$($result.CurrentDisplayLanguage)</td>
-            <td>$($result.CurrentTimeZone)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.UserPrincipalName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.CurrentDisplayLanguage)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.CurrentTimeZone)"))</td>
             <td><span class="$statusClass">$($result.Status)</span></td>
-            <td>$($result.Issues)</td>
-            $(if ($Apply) { "<td>$($result.ActionTaken)</td>" })
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Issues)"))</td>
+            $(if ($Apply) { "<td>$([System.Net.WebUtility]::HtmlEncode("$($result.ActionTaken)"))</td>" })
         </tr>
 "@
     }
@@ -572,7 +576,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\LanguageSettings_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "LanguageSettings_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/defender-office365/Get-DefenderO365ThreatReport.ps1
+++ b/scripts/collaboration/microsoft365/defender-office365/Get-DefenderO365ThreatReport.ps1
@@ -26,7 +26,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-IPPSSession
@@ -63,10 +63,22 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
 
 $ErrorActionPreference = 'Stop'
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
 
 # Check for required module
 if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
@@ -250,6 +262,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Defender for Office 365 Threat Summary ===" -ForegroundColor Cyan
@@ -275,7 +289,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Defender-O365-Threats-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Defender-O365-Threats-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -351,9 +365,9 @@ switch ($OutputFormat) {
                 $riskClass = $user.RiskLevel.ToLower() + "-risk"
                 $html += @"
         <tr>
-            <td>$($user.UserEmail)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($user.UserEmail)"))</td>
             <td>$($user.ThreatCount)</td>
-            <td class="$riskClass">$($user.RiskLevel)</td>
+            <td class="$riskClass">$([System.Net.WebUtility]::HtmlEncode("$($user.RiskLevel)"))</td>
         </tr>
 "@
             }
@@ -372,7 +386,7 @@ switch ($OutputFormat) {
             foreach ($sender in $results.TopThreatSenders) {
                 $html += @"
         <tr>
-            <td>$($sender.SenderAddress)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($sender.SenderAddress)"))</td>
             <td>$($sender.ThreatCount)</td>
         </tr>
 "@
@@ -391,17 +405,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "Defender-Threats-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "Defender-Threats-${RunTimestamp}_${RunId}.csv"
         $results.ThreatDetections | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Defender-Threats-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Defender-Threats-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/collaboration/microsoft365/defender-office365/Get-DefenderO365ThreatReport.ps1
+++ b/scripts/collaboration/microsoft365/defender-office365/Get-DefenderO365ThreatReport.ps1
@@ -71,7 +71,7 @@ $ErrorActionPreference = 'Stop'
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/collaboration/microsoft365/exchange-online/Get-DistributionListAudit.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-DistributionListAudit.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-ExchangeOnline
@@ -69,10 +69,22 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
 
 $ErrorActionPreference = 'Stop'
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
 
 if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
     Write-Error "ExchangeOnlineManagement module required. Install: Install-Module ExchangeOnlineManagement"
@@ -241,6 +253,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Distribution List Audit Summary ===" -ForegroundColor Cyan
@@ -264,7 +278,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "DistributionList-Audit-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "DistributionList-Audit-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -332,11 +346,11 @@ switch ($OutputFormat) {
 
             $html += @"
         <tr class="$rowClass">
-            <td>$($dl.DisplayName)</td>
-            <td>$($dl.PrimarySmtpAddress)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($dl.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($dl.PrimarySmtpAddress)"))</td>
             <td>$($dl.MemberCount)</td>
-            <td>$($dl.Owners)</td>
-            <td>$($dl.Notes)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($dl.Owners)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($dl.Notes)"))</td>
         </tr>
 "@
         }
@@ -353,17 +367,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "DistributionLists-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "DistributionLists-${RunTimestamp}_${RunId}.csv"
         $results.DistributionLists | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "DistributionList-Audit-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "DistributionList-Audit-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/collaboration/microsoft365/exchange-online/Get-DistributionListAudit.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-DistributionListAudit.ps1
@@ -77,7 +77,7 @@ $ErrorActionPreference = 'Stop'
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/collaboration/microsoft365/exchange-online/Get-MailFlowAnalysis.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-MailFlowAnalysis.ps1
@@ -78,7 +78,7 @@ $ErrorActionPreference = 'Stop'
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/collaboration/microsoft365/exchange-online/Get-MailFlowAnalysis.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-MailFlowAnalysis.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-ExchangeOnline
@@ -70,10 +70,22 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
 
 $ErrorActionPreference = 'Stop'
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
 
 if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
     Write-Error "ExchangeOnlineManagement module required. Install: Install-Module ExchangeOnlineManagement"
@@ -276,6 +288,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Mail Flow Analysis Summary ===" -ForegroundColor Cyan
@@ -302,7 +316,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Exchange-MailFlow-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Exchange-MailFlow-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -377,7 +391,7 @@ switch ($OutputFormat) {
             foreach ($sender in $results.TopSenders) {
                 $html += @"
         <tr>
-            <td>$($sender.Sender)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($sender.Sender)"))</td>
             <td>$($sender.MessageCount)</td>
             <td>$($sender.PercentOfTotal)%</td>
         </tr>
@@ -400,10 +414,10 @@ switch ($OutputFormat) {
             foreach ($failure in $results.DeliveryFailures) {
                 $html += @"
         <tr>
-            <td>$($failure.FailureTime)</td>
-            <td>$($failure.Sender)</td>
-            <td>$($failure.Recipient)</td>
-            <td>$($failure.Subject)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($failure.FailureTime)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($failure.Sender)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($failure.Recipient)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($failure.Subject)"))</td>
         </tr>
 "@
             }
@@ -421,17 +435,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "MailFlow-TopSenders-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "MailFlow-TopSenders-${RunTimestamp}_${RunId}.csv"
         $results.TopSenders | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "MailFlow-Analysis-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "MailFlow-Analysis-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/collaboration/microsoft365/exchange-online/Get-MailboxHealth.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-MailboxHealth.ps1
@@ -79,6 +79,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== Exchange Online Mailbox Health Report ===" -ForegroundColor Cyan
 Write-Host "Mailbox Type: $MailboxType" -ForegroundColor Yellow
@@ -269,7 +273,7 @@ if ($inactiveMailboxes -gt 0) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\MailboxHealth_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "MailboxHealth_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -319,15 +323,15 @@ if ($ExportHTML) {
         $statusClass = $result.Status.ToLower()
         $html += @"
         <tr>
-            <td>$($result.DisplayName)</td>
-            <td>$($result.MailboxType)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.MailboxType)"))</td>
             <td>$($result.MailboxSizeGB)</td>
             <td>$($result.QuotaGB)</td>
             <td>$($result.QuotaUsedPercent)</td>
             <td>$($result.ItemCount)</td>
             <td><span class="$statusClass">$($result.Status)</span></td>
-            <td>$($result.LastLogon)</td>
-            <td>$($result.LitigationHold)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.LastLogon)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.LitigationHold)"))</td>
         </tr>
 "@
     }
@@ -339,7 +343,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\MailboxHealth_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "MailboxHealth_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/exchange-online/Get-SharedMailboxReport.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-SharedMailboxReport.ps1
@@ -61,6 +61,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== Shared Mailbox Audit Report ===" -ForegroundColor Cyan
 Write-Host "Timestamp: $(Get-Date)" -ForegroundColor Gray
@@ -215,7 +219,7 @@ if ($noPermissions -gt 0) {
 
 # Export
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\SharedMailboxAudit_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "SharedMailboxAudit_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -261,13 +265,13 @@ if ($ExportHTML) {
         $rowClass = if ($result.SignInEnabled -or $result.TotalPermissions -eq 0) { "issue" } else { "" }
         $html += @"
         <tr class="$rowClass">
-            <td>$($result.DisplayName)</td>
-            <td>$($result.PrimarySmtpAddress)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.PrimarySmtpAddress)"))</td>
             <td>$($result.SizeGB)</td>
             <td>$($result.ItemCount)</td>
             <td>$($result.SignInEnabled)</td>
             <td>$($result.TotalPermissions)</td>
-            <td>$($result.LastActivity)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.LastActivity)"))</td>
         </tr>
 "@
     }
@@ -278,7 +282,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\SharedMailboxAudit_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "SharedMailboxAudit_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/exchange-online/Get-UserMailRules.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-UserMailRules.ps1
@@ -292,7 +292,11 @@ if ($ExportReport) {
 
     # Use safe filename
     $safeEmailFile = Get-SafeFileName $UserEmail
-    $reportPath = "$env:USERPROFILE\Desktop\MailRules_${safeEmailFile}_$timestamp.html"
+    $reportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    if (-not (Test-Path -LiteralPath $reportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+    }
+    $reportPath = Join-Path $reportDir "MailRules_${safeEmailFile}_$timestamp.html"
 
     # Encode user data
     $safeDisplayName = ConvertTo-HtmlSafe $mailbox.DisplayName
@@ -361,7 +365,6 @@ if ($ExportReport) {
 
     $html | Out-File -FilePath $reportPath -Encoding UTF8
     Write-Host "`n[+] Report saved to: $reportPath" -ForegroundColor Green
-    Start-Process $reportPath
 }
 
 Write-Host "`n[+] Mail rules check completed!" -ForegroundColor Green

--- a/scripts/collaboration/microsoft365/exchange-online/Get-UserMailboxPermissions.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Get-UserMailboxPermissions.ps1
@@ -227,7 +227,11 @@ if ($ExportReport) {
 
     # Use safe filename
     $safeEmail = Get-SafeFileName $UserEmail
-    $reportPath = "$env:USERPROFILE\Desktop\MailboxPermissions_${safeEmail}_$timestamp.html"
+    $reportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    if (-not (Test-Path -LiteralPath $reportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+    }
+    $reportPath = Join-Path $reportDir "MailboxPermissions_${safeEmail}_$timestamp.html"
 
     # Encode user data
     $safeDisplayName = ConvertTo-HtmlSafe $mailbox.DisplayName
@@ -282,7 +286,6 @@ if ($ExportReport) {
 
     $html | Out-File -FilePath $reportPath -Encoding UTF8
     Write-Host "`n[+] Report saved to: $reportPath" -ForegroundColor Green
-    Start-Process $reportPath
 }
 
 Write-Host "`n[+] Permission check completed!" -ForegroundColor Green

--- a/scripts/collaboration/microsoft365/exchange-online/Set-MailboxRegionalSettings.ps1
+++ b/scripts/collaboration/microsoft365/exchange-online/Set-MailboxRegionalSettings.ps1
@@ -120,6 +120,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== Exchange Online Mailbox Regional Settings ===" -ForegroundColor Cyan
 Write-Host "Mode: $(if ($Apply) { 'APPLY SETTINGS' } else { 'AUDIT ONLY' })" -ForegroundColor $(if ($Apply) { 'Yellow' } else { 'Green' })
@@ -367,7 +371,7 @@ if ($nonCompliantCount -gt 0 -and -not $Apply) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\MailboxRegionalSettings_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "MailboxRegionalSettings_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -433,14 +437,14 @@ if ($ExportHTML) {
 
         $html += @"
         <tr>
-            <td>$($result.DisplayName)</td>
-            <td>$($result.UserPrincipalName)</td>
-            <td>$($result.CurrentTimeZone)</td>
-            <td>$($result.CurrentDateFormat)</td>
-            <td>$($result.CurrentLanguage)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.UserPrincipalName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.CurrentTimeZone)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.CurrentDateFormat)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.CurrentLanguage)"))</td>
             <td><span class="$statusClass">$($result.Status)</span></td>
-            <td>$($result.Issues)</td>
-            $(if ($Apply) { "<td>$($result.ActionTaken)</td>" })
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Issues)"))</td>
+            $(if ($Apply) { "<td>$([System.Net.WebUtility]::HtmlEncode("$($result.ActionTaken)"))</td>" })
         </tr>
 "@
     }
@@ -452,7 +456,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\MailboxRegionalSettings_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "MailboxRegionalSettings_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/power-platform/Get-PowerPlatformGovernance.ps1
+++ b/scripts/collaboration/microsoft365/power-platform/Get-PowerPlatformGovernance.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -70,8 +70,20 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 # Check for required module
 if (-not (Get-Module -ListAvailable -Name Microsoft.PowerApps.Administration.PowerShell)) {
@@ -244,6 +256,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Power Platform Governance Summary ===" -ForegroundColor Cyan
@@ -262,7 +276,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "PowerPlatform-Governance-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "PowerPlatform-Governance-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -289,7 +303,7 @@ switch ($OutputFormat) {
 <body>
     <h1>Power Platform Governance Report</h1>
     <div class="summary">
-        <strong>Tenant ID:</strong> $TenantId<br>
+        <strong>Tenant ID:</strong> $([System.Net.WebUtility]::HtmlEncode("$TenantId"))<br>
         <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 
         <div class="summary-grid">
@@ -330,10 +344,10 @@ switch ($OutputFormat) {
         foreach ($env in $results.Environments) {
             $html += @"
         <tr>
-            <td>$($env.Name)</td>
-            <td>$($env.Type)</td>
-            <td>$($env.Location)</td>
-            <td>$($env.CreatedTime)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($env.Name)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($env.Type)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($env.Location)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($env.CreatedTime)"))</td>
             <td>$(if ($env.IsDefault) { 'Yes' } else { 'No' })</td>
         </tr>
 "@
@@ -355,10 +369,10 @@ switch ($OutputFormat) {
             foreach ($orphan in $results.OrphanedResources) {
                 $html += @"
         <tr>
-            <td class="orphaned">$($orphan.Type)</td>
-            <td>$($orphan.Name)</td>
-            <td>$($orphan.Environment)</td>
-            <td>$($orphan.Reason)</td>
+            <td class="orphaned">$([System.Net.WebUtility]::HtmlEncode("$($orphan.Type)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Name)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Environment)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($orphan.Reason)"))</td>
         </tr>
 "@
             }
@@ -376,17 +390,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "PowerPlatform-Apps-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "PowerPlatform-Apps-${RunTimestamp}_${RunId}.csv"
         $results.PowerApps | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "PowerPlatform-Governance-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "PowerPlatform-Governance-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/collaboration/microsoft365/power-platform/Get-PowerPlatformGovernance.ps1
+++ b/scripts/collaboration/microsoft365/power-platform/Get-PowerPlatformGovernance.ps1
@@ -77,7 +77,7 @@ param(
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/collaboration/microsoft365/sharepoint-onedrive/Get-OneDriveUsageReport.ps1
+++ b/scripts/collaboration/microsoft365/sharepoint-onedrive/Get-OneDriveUsageReport.ps1
@@ -54,6 +54,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== OneDrive for Business Usage Report ===" -ForegroundColor Cyan
 Write-Host "Storage Warning Threshold: $StorageWarningThreshold%" -ForegroundColor Yellow
@@ -198,7 +202,7 @@ if ($inactiveSites -gt 0) {
 
 # Export
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\OneDriveUsageReport_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "OneDriveUsageReport_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -243,13 +247,13 @@ if ($ExportHTML) {
         $rowClass = if ($result.Status -eq "Warning") { "warning" } else { "" }
         $html += @"
         <tr class="$rowClass">
-            <td>$($result.Owner)</td>
-            <td>$($result.StorageUsedGB)</td>
-            <td>$($result.StorageQuotaGB)</td>
-            <td>$($result.StoragePercent)</td>
-            <td>$($result.FileCount)</td>
-            <td>$($result.LastActivityDate)</td>
-            <td>$($result.Status)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Owner)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.StorageUsedGB)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.StorageQuotaGB)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.StoragePercent)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.FileCount)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.LastActivityDate)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Status)"))</td>
         </tr>
 "@
     }
@@ -260,7 +264,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\OneDriveUsageReport_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "OneDriveUsageReport_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/teams/Get-TeamsReport.ps1
+++ b/scripts/collaboration/microsoft365/teams/Get-TeamsReport.ps1
@@ -62,6 +62,10 @@ param(
 
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 Write-Host "`n=== Microsoft Teams Usage Report ===" -ForegroundColor Cyan
 Write-Host "Timestamp: $(Get-Date)" -ForegroundColor Gray
@@ -217,7 +221,7 @@ $results | Sort-Object TotalUsers -Descending |
 
 # Export
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\TeamsReport_$timestamp.html"
+    $htmlPath = (Join-Path $ReportDir "TeamsReport_$timestamp.html")
 
     $html = @"
 <!DOCTYPE html>
@@ -265,13 +269,13 @@ if ($ExportHTML) {
         $rowClass = if ($result.OwnerCount -eq 0) { "issue" } else { "" }
         $html += @"
         <tr class="$rowClass">
-            <td>$($result.TeamName)</td>
-            <td>$($result.Visibility)</td>
-            <td>$($result.Archived)</td>
-            <td>$($result.OwnerCount)</td>
-            <td>$($result.MemberCount)</td>
-            <td>$($result.GuestCount)</td>
-            <td>$($result.ChannelCount)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.TeamName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Visibility)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Archived)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.OwnerCount)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.MemberCount)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.GuestCount)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.ChannelCount)"))</td>
         </tr>
 "@
     }
@@ -282,7 +286,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\TeamsReport_$timestamp.csv"
+    $csvPath = (Join-Path $ReportDir "TeamsReport_$timestamp.csv")
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/data/api/Test-APIHealth.ps1
+++ b/scripts/data/api/Test-APIHealth.ps1
@@ -112,7 +112,7 @@ param(
 if ([string]::IsNullOrWhiteSpace($OutputPath) -or
     $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
     $OutputPath -match '^(\\\\|//)') {
-    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must not contain '..' traversal or be a UNC/remote path; relative paths are resolved to an absolute path."
     exit 1
 }
 $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)

--- a/scripts/data/api/Test-APIHealth.ps1
+++ b/scripts/data/api/Test-APIHealth.ps1
@@ -21,6 +21,7 @@
 .PARAMETER SingleEndpoint
     Single API endpoint URL to test (alternative to EndpointsFile)
 
+
 .PARAMETER Method
     HTTP method for single endpoint test. Default: GET
 
@@ -34,7 +35,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/JSON output file. Default: Desktop
+    Path for HTML/JSON output file. Default: MyDocuments\Reports
 
 .PARAMETER RunContinuous
     Run tests continuously with specified interval
@@ -99,7 +100,7 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$RunContinuous,
@@ -107,6 +108,18 @@ param(
     [Parameter(Mandatory = $false)]
     [int]$IntervalSeconds = 60
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
 
 # Function to test a single endpoint
 function Test-Endpoint {
@@ -324,6 +337,8 @@ do {
     $testResults = Run-Tests
 
     # Output results
+    $RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
     switch ($OutputFormat) {
         'Console' {
             Write-Host "`n=== API Health Test Summary ===" -ForegroundColor Cyan
@@ -334,7 +349,7 @@ do {
         }
 
         'HTML' {
-            $htmlFile = Join-Path $OutputPath "API-Health-Test-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+            $htmlFile = Join-Path $OutputPath "API-Health-Test-${RunTimestamp}_${RunId}.html"
 
             $html = @"
 <!DOCTYPE html>
@@ -407,8 +422,8 @@ do {
 
                 $html += @"
         <tr>
-            <td>$($result.Name)</td>
-            <td>$($result.Url)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Name)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Url)"))</td>
             <td>$($result.StatusCode)</td>
             <td>$($result.ResponseTime)</td>
             <td>$(if ($result.Url -like 'https://*') { if ($result.SSLValid) { '✓' } else { '✗' } } else { 'N/A' })</td>
@@ -422,10 +437,10 @@ do {
             <td colspan="6">
 "@
                     if ($result.Errors.Count -gt 0) {
-                        $html += "<div class='errors'>Errors: $($result.Errors -join '; ')</div>"
+                        $html += "<div class='errors'>Errors: $([System.Net.WebUtility]::HtmlEncode('$($result.Errors -join '; ')'))</div>"
                     }
                     if ($result.Warnings.Count -gt 0) {
-                        $html += "<div class='warnings'>Warnings: $($result.Warnings -join '; ')</div>"
+                        $html += "<div class='warnings'>Warnings: $([System.Net.WebUtility]::HtmlEncode('$($result.Warnings -join '; ')'))</div>"
                     }
                     $html += @"
             </td>
@@ -446,13 +461,10 @@ do {
 
             $html | Out-File -FilePath $htmlFile -Encoding UTF8
             Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-            if (-not $RunContinuous) {
-                Start-Process $htmlFile
-            }
         }
 
         'JSON' {
-            $jsonFile = Join-Path $OutputPath "API-Health-Test-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+            $jsonFile = Join-Path $OutputPath "API-Health-Test-${RunTimestamp}_${RunId}.json"
             $testResults | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
             Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
         }


### PR DESCRIPTION
Refs #72 #73 #74 #79 #82

- Remove HTML auto-open in 10 report scripts (in-scope files)
- Validate OutputPath (traversal/UNC) in 7 scripts
- HTML-encode dynamic data in 16 scripts
- Standardize timestamp+RunId; OutputPath -> MyDocuments/Reports

This PR hardens 16 of the report scripts. The sibling report-sweep PR hardens the remainder. Final issues 72/73/74/79/82 close after a repo-wide grep confirms all report scripts are covered.