### PR TITLE
fix: dedupe winget retry function + implement SCCM remediation

### DIFF
--- a/Tests/ProactiveRemediations/WingetDuplicateFunction.Tests.ps1
+++ b/Tests/ProactiveRemediations/WingetDuplicateFunction.Tests.ps1
@@ -1,0 +1,45 @@
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Guardrail test asserting every winget detect/remediate script defines the
+    `Invoke-WingetWithRetry` helper at most once.
+
+.DESCRIPTION
+    A nested second `function Invoke-WingetWithRetry` definition shadows the
+    first and, depending on placement, can swallow the actual winget invocation,
+    leaving the outer function's `$result` unassigned. Each Intune proactive
+    remediation script must be self-contained, so we keep exactly one canonical
+    definition per file and forbid duplicates across the whole winget tree.
+#>
+
+BeforeAll {
+    $script:wingetRoot = Join-Path $PSScriptRoot "..\..\scripts\endpoints\devices\winget"
+    $script:wingetScripts = @(Get-ChildItem -Path $wingetRoot -Recurse -Filter *.ps1 -File)
+}
+
+Describe "Winget Invoke-WingetWithRetry single definition" {
+    It "finds winget scripts to validate" {
+        $script:wingetScripts.Count | Should -BeGreaterThan 0
+    }
+
+    It "defines Invoke-WingetWithRetry at most once per file" {
+        $violations = foreach ($file in $script:wingetScripts) {
+            $count = @(Get-Content -Path $file.FullName | Where-Object { $_ -match '^\s*function\s+Invoke-WingetWithRetry' }).Count
+            if ($count -gt 1) {
+                $file.FullName
+            }
+        }
+        $violations | Should -BeNullOrEmpty
+    }
+
+    It "keeps a winget helper file's ProcessStartInfo execution assigning the result" {
+        # Spot-check the canonical pattern is intact in representative scripts:
+        # the retry function must actually launch winget and assign $result,
+        # rather than being shadowed by a nested empty definition.
+        $probe = Join-Path $wingetRoot "security\1Password\detect.ps1"
+        $content = Get-Content -Path $probe -Raw
+        $content | Should -Match 'ProcessStartInfo'
+        $content | Should -Match '\$result\s*=\s*\$stdout'
+    }
+}

--- a/scripts/endpoints/devices/sccm/remediate.ps1
+++ b/scripts/endpoints/devices/sccm/remediate.ps1
@@ -1,14 +1,107 @@
 # Remediation script for SCCM
 
-# Define the path to ccmsetup.exe
+<#
+.SYNOPSIS
+    Remediation script for the SCCM client Proactive Remediation.
+
+.DESCRIPTION
+    Installs the Configuration Manager (SCCM) client from a local or UNC source
+    path when the client is not already installed. Uses the secure
+    ProcessStartInfo pattern (no shell, no window) to run ccmsetup.exe against
+    the supplied source tree and reports the actual install outcome.
+
+.PARAMETER SourcePath
+    Local or UNC path containing ccmsetup.exe and the client source
+    (e.g. \\SCCM-SERVER\SCCMContentLib\Client or C:\SCCM).
+    Required when the client is not already installed.
+
+.PARAMETER ManagementPoint
+    (Optional) FQDN of the management point to pass to ccmsetup via /MP:.
+#>
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$SourcePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ManagementPoint
+)
+
+# Define the path to an already-installed ccmsetup.exe
 $ccmSetupPath = "$env:windir\ccmsetup\ccmsetup.exe"
 
-# Check if ccmsetup.exe exists
+# Already installed - nothing to remediate.
 if (Test-Path $ccmSetupPath) {
     Write-Output " SCCM client is installed."
     Exit 0
 }
-else {
-    Write-Output " SCCM client is NOT installed. Remediation requires an installer/source path."
+
+# Client not installed. A source path is required to install it.
+if (-not $SourcePath -or -not (Test-Path $SourcePath)) {
+    Write-Error " SCCM client is NOT installed and no valid -SourcePath was provided. Supply a local/UNC path containing ccmsetup.exe (e.g. \\SCCM-SERVER\SCCMContentLib\Client or C:\SCCM)."
     Exit 1
 }
+
+# Locate ccmsetup.exe in the source tree (source root or ccmsetup subfolder).
+$sourceCcmSetup = Join-Path $SourcePath "ccmsetup.exe"
+if (-not (Test-Path $sourceCcmSetup)) {
+    $subPath = Join-Path $SourcePath "ccmsetup\ccmsetup.exe"
+    if (Test-Path $subPath) {
+        $sourceCcmSetup = $subPath
+    }
+}
+
+if (-not (Test-Path $sourceCcmSetup)) {
+    Write-Error " ccmsetup.exe was not found under -SourcePath '$SourcePath'. Verify the source tree."
+    Exit 1
+}
+
+# Build argument list for ccmsetup.exe.
+$arguments = "/Source:$SourcePath"
+if ($ManagementPoint) {
+    $arguments = "$arguments /MP:$ManagementPoint"
+}
+
+Write-Output " SCCM client not installed. Installing from '$SourcePath' using ccmsetup.exe."
+
+# Launch ccmsetup.exe with the secure ProcessStartInfo pattern.
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $sourceCcmSetup
+$psi.Arguments = $arguments
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+
+$process = New-Object System.Diagnostics.Process
+$process.StartInfo = $psi
+$process.Start() | Out-Null
+
+# Drain output/error streams before waiting, then read the exit code only
+# after the process has exited (ExitCode throws if read too early).
+$stdout = $process.StandardOutput.ReadToEnd()
+$stderr = $process.StandardError.ReadToEnd()
+$process.WaitForExit()
+$exitCode = $process.ExitCode
+
+Write-Output " ccmsetup.exe exit code: $exitCode"
+if ($stdout) {
+    $stdout -split "`r?`n" | ForEach-Object { if ($_) { Write-Output " $_" } }
+}
+if ($stderr) {
+    $stderr -split "`r?`n" | ForEach-Object { if ($_) { Write-Output " $_" } }
+}
+
+# ccmsetup returns 0 on success and 7 when a reboot is required (still success).
+$installSucceeded = ($exitCode -eq 0 -or $exitCode -eq 7)
+if ($installSucceeded -and (Test-Path $ccmSetupPath)) {
+    if ($exitCode -eq 7) {
+        Write-Output " SCCM client installed successfully; a reboot is required."
+    }
+    else {
+        Write-Output " SCCM client installed successfully."
+    }
+    Exit 0
+}
+
+Write-Error " SCCM client installation did not succeed (ccmsetup exit code: $exitCode)."
+Exit 1

--- a/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
@@ -99,18 +99,13 @@ function Invoke-WingetWithRetry {
     $attempt = 1
     $delay = $RetryDelaySeconds
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
 
             # Execute winget command
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -123,15 +118,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             # Check if result is valid (not empty and not an error)
             if ($result -and -not ($result -match "error|failed|exception")) {

--- a/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
@@ -115,6 +115,8 @@ function Stop-ApplicationProcess {
     )
 
     $attempt = 1
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
 
@@ -152,13 +154,6 @@ function Invoke-WingetWithRetry {
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -171,15 +166,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             if ($result -and -not ($result -match "error|failed|exception")) {
                 return $result

--- a/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
@@ -99,18 +99,13 @@ function Invoke-WingetWithRetry {
     $attempt = 1
     $delay = $RetryDelaySeconds
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
 
             # Execute winget command
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -123,15 +118,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             # Check if result is valid (not empty and not an error)
             if ($result -and -not ($result -match "error|failed|exception")) {

--- a/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
@@ -115,6 +115,8 @@ function Stop-ApplicationProcess {
     )
 
     $attempt = 1
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
 
@@ -152,13 +154,6 @@ function Invoke-WingetWithRetry {
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -171,15 +166,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             if ($result -and -not ($result -match "error|failed|exception")) {
                 return $result

--- a/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
@@ -115,8 +115,6 @@ function Stop-ApplicationProcess {
     )
 
     $attempt = 1
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
 
@@ -150,6 +148,9 @@ function Invoke-WingetWithRetry {
 
     $attempt = 1
     $delay = $RetryDelaySeconds
+
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
 
     while ($attempt -le $MaxAttempts) {
         try {
@@ -193,17 +194,6 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
-
-    # Locate winget executable
-
-    if ($wingetexe.Count -gt 1) {
-        $SystemContext = $wingetexe[-1].Path
-    } else {
-        $SystemContext = $wingetexe.Path
-    }
-
-    
-    Write-Log "Found winget: $SystemContext" -Level Info
 
     # Get package information
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
@@ -69,16 +69,11 @@ function Invoke-WingetWithRetry {
     $attempt = 1
     $delay = $RetryDelaySeconds
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -91,15 +86,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             if ($result -and -not ($result -match "error|failed|exception")) {
                 Write-Log "Winget command succeeded on attempt $attempt" -Level Info

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
@@ -32,16 +32,11 @@ function Test-NetworkConnectivity { try { return (Test-Connection -ComputerName 
 function Invoke-WingetWithRetry {
     param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
     $attempt = 1; $delay = $RetryDelaySeconds
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing: sysget $Arguments (Attempt $attempt/$MaxAttempts)" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -54,15 +49,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
             if ($result -and -not ($result -match "error|failed|exception")) { Write-Log "Command succeeded" -Level Info; return $result }
             Write-Log "Invalid result on attempt $attempt" -Level Warning
         } catch { Write-Log "Failed: $($_.Exception.Message)" -Level Warning }

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
@@ -56,6 +56,8 @@ function Show-UserNotification {
 function Stop-ApplicationProcess {
     param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
     $attempt = 1
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
         if (-not $process) { return $true }
@@ -72,13 +74,6 @@ function Invoke-WingetWithRetry {
     $attempt = 1; $delay = $RetryDelaySeconds
     while ($attempt -le $MaxAttempts) {
         try {
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -91,15 +86,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
             if ($result -and -not ($result -match "error|failed|exception")) { return $result }
         } catch { Write-Log "Failed: $($_.Exception.Message)" -Level Warning }
         if ($attempt -lt $MaxAttempts) { Start-Sleep -Seconds $delay; $delay = $delay * 2 }

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
@@ -56,8 +56,6 @@ function Show-UserNotification {
 function Stop-ApplicationProcess {
     param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
     $attempt = 1
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
         if (-not $process) { return $true }
@@ -72,6 +70,10 @@ function Stop-ApplicationProcess {
 function Invoke-WingetWithRetry {
     param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
     $attempt = 1; $delay = $RetryDelaySeconds
+
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     while ($attempt -le $MaxAttempts) {
         try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
@@ -100,10 +102,6 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     Write-Log "=== Starting Microsoft Teams update ===" -Level Info
-
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $SystemContext = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
 
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
     $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"

--- a/scripts/endpoints/devices/winget/security/1Password/detect.ps1
+++ b/scripts/endpoints/devices/winget/security/1Password/detect.ps1
@@ -44,16 +44,11 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
     $attempt = 1
     $delay = $RetryDelaySeconds
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -66,15 +61,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
             if ($result -and -not ($result -match "error|failed|exception")) {
                 Write-Log "Winget command succeeded on attempt $attempt" -Level Info
                 return $result

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
@@ -68,16 +68,11 @@ function Invoke-WingetWithRetry {
     $attempt = 1
     $delay = $RetryDelaySeconds
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -90,15 +85,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
 
             if ($result -and -not ($result -match "error|failed|exception")) {
                 Write-Log "Winget command succeeded on attempt $attempt" -Level Info

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
@@ -51,6 +51,8 @@ function Write-Log {
 function Stop-ApplicationProcess {
     param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
     $attempt = 1
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
         if (-not $process) {
@@ -77,13 +79,6 @@ function Invoke-WingetWithRetry {
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing: sysget $Arguments (Attempt $attempt/$MaxAttempts)" -Level Info
-function Invoke-WingetWithRetry {
-    param([string]$Arguments)
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
-        try {
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -96,15 +91,8 @@ function Invoke-WingetWithRetry {
             $p.Start() | Out-Null
             $stdout = $p.StandardOutput.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
-        Start-Sleep -Seconds 2
-        $a++
-    }
-    throw "Failed after 3 attempts"
-}
+            $result = $stdout
+
             if ($result -and -not ($result -match "error|failed|exception")) { return $result }
             Write-Log "Invalid result on attempt $attempt" -Level Warning
         } catch {

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
@@ -51,8 +51,6 @@ function Write-Log {
 function Stop-ApplicationProcess {
     param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
     $attempt = 1
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
         if (-not $process) {
@@ -76,6 +74,10 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
     $attempt = 1
     $delay = $RetryDelaySeconds
+
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing: sysget $Arguments (Attempt $attempt/$MaxAttempts)" -Level Info
@@ -108,11 +110,6 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     Write-Log "=== Starting 7-Zip update ===" -Level Info
-
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    if ($wingetexe.Count -gt 1) { $SystemContext = $wingetexe[-1].Path } else { $SystemContext = $wingetexe.Path }
-    
-    Write-Log "Found winget: $SystemContext" -Level Info
 
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
 


### PR DESCRIPTION
Fixes #91 #92

- Collapse 10 duplicate Invoke-WingetWithRetry definitions
- Add guardrail test Tests/ProactiveRemediations/WingetDuplicateFunction.Tests.ps1
- sccm/remediate.ps1 now installs ccmsetup.exe via secure ProcessStartInfo when client missing

## Summary by Sourcery

Consolidate winget retry helper definitions and enhance SCCM client remediation to support secure installation when the client is missing.

Bug Fixes:
- Ensure each winget proactive remediation script uses a single Invoke-WingetWithRetry helper to avoid nested function shadowing and unassigned results.

Enhancements:
- Add secure ProcessStartInfo-based SCCM remediation that can install the Configuration Manager client from a supplied source path and reports accurate install outcomes.

Tests:
- Add a Pester guardrail test to assert each winget detect/remediate script defines Invoke-WingetWithRetry at most once and preserves the canonical ProcessStartInfo pattern.