### PR TITLE
security: harden remaining HTML report scripts + Desktop output defaults (#82)

### DIFF
--- a/scripts/automation/cicd/Analyze-BuildPerformance.ps1
+++ b/scripts/automation/cicd/Analyze-BuildPerformance.ps1
@@ -26,7 +26,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/JSON output file. Default: Desktop
+    Path for HTML/JSON output file. Default: MyDocuments\Reports
 
 .PARAMETER IdentifyRegressions
     Detect builds that are significantly slower than historical average
@@ -66,7 +66,7 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IdentifyRegressions,
@@ -74,6 +74,17 @@ param(
     [Parameter(Mandatory = $false)]
     [int]$RegressionThreshold = 25
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 Write-Host "Analyzing build performance for $Platform (Last $DaysToAnalyze days)..." -ForegroundColor Cyan
 
@@ -238,6 +249,8 @@ $analysis.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Build Performance Summary ===" -ForegroundColor Cyan
@@ -262,10 +275,10 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Build-Performance-Analysis-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Build-Performance-Analysis-${RunTimestamp}_${RunId}.html"
 
         # Create trend chart data
-        $chartLabels = ($analysis.DurationTrends | ForEach-Object { "'$($_.Period)'" }) -join ','
+        $chartLabels = ($analysis.DurationTrends | ForEach-Object { "'$([System.Net.WebUtility]::HtmlEncode("$($_.Period)"))'" }) -join ','
         $chartData = ($analysis.DurationTrends | ForEach-Object { $_.AvgDuration }) -join ','
 
         $html = @"
@@ -295,7 +308,7 @@ switch ($OutputFormat) {
 <body>
     <h1>Build Performance Analysis Report</h1>
     <div class="summary">
-        <strong>Platform:</strong> $Platform | <strong>Analysis Period:</strong> Last $DaysToAnalyze days<br>
+        <strong>Platform:</strong> $([System.Net.WebUtility]::HtmlEncode("$Platform")) | <strong>Analysis Period:</strong> Last $DaysToAnalyze days<br>
         <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 
         <div class="summary-grid">
@@ -345,11 +358,11 @@ switch ($OutputFormat) {
         foreach ($build in $analysis.SlowestBuilds) {
             $html += @"
         <tr>
-            <td>$($build.BuildId)</td>
-            <td>$($build.StartTime)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($build.BuildId)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($build.StartTime)"))</td>
             <td>$($build.DurationMinutes)</td>
-            <td>$($build.Branch)</td>
-            <td>$($build.Result)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($build.Branch)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($build.Result)"))</td>
         </tr>
 "@
         }
@@ -371,8 +384,8 @@ switch ($OutputFormat) {
             foreach ($regression in $analysis.Regressions) {
                 $html += @"
         <tr>
-            <td>$($regression.BuildId)</td>
-            <td>$($regression.StartTime)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($regression.BuildId)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($regression.StartTime)"))</td>
             <td class="regression">$($regression.DurationMinutes)</td>
             <td>$($regression.BaselineAvg)</td>
             <td class="regression">+$($regression.IncreasePercent)%</td>
@@ -418,11 +431,10 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Build-Performance-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Build-Performance-${RunTimestamp}_${RunId}.json"
         $analysis | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/automation/cicd/Monitor-GitLabCI.ps1
+++ b/scripts/automation/cicd/Monitor-GitLabCI.ps1
@@ -28,7 +28,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/CSV/JSON output file. Default: Desktop
+    Path for HTML/CSV/JSON output file. Default: MyDocuments\Reports
 
 .PARAMETER IncludeRunners
     Include GitLab Runner health and utilization analysis
@@ -71,7 +71,7 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IncludeRunners,
@@ -79,6 +79,17 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$IncludeDeployments
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 # Validate token
 if ([string]::IsNullOrWhiteSpace($PrivateToken)) {
@@ -263,6 +274,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== GitLab CI Pipeline Health Summary ===" -ForegroundColor Cyan
@@ -290,7 +303,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "GitLab-CI-Health-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "GitLab-CI-Health-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -386,17 +399,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "GitLab-Pipelines-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "GitLab-Pipelines-${RunTimestamp}_${RunId}.csv"
         $results.Pipelines | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "GitLab-Pipelines-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "GitLab-Pipelines-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/automation/iac/Test-BicepTemplates.ps1
+++ b/scripts/automation/iac/Test-BicepTemplates.ps1
@@ -31,7 +31,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/JSON output file. Default: Desktop
+    Path for HTML/JSON output file. Default: MyDocuments\Reports
 
 .EXAMPLE
     .\Test-BicepTemplates.ps1 -TemplatePath ".\main.bicep"
@@ -73,8 +73,23 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
 $results = @{
     Timestamp = Get-Date
@@ -208,7 +223,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Bicep-Validation-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Bicep-Validation-${RunTimestamp}_${RunId}.html"
         $html = @"
 <!DOCTYPE html>
 <html>
@@ -227,7 +242,7 @@ switch ($OutputFormat) {
 </head>
 <body>
     <h1>Bicep Template Validation Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId</p>
     <h2>Summary</h2>
     <p>Total Templates: $($templates.Count) | Passed: $passedValidation | Failed: $failedValidation</p>
     <p>Security Issues: $totalSecurityIssues | Best Practice Issues: $totalBestPracticeIssues</p>
@@ -238,7 +253,7 @@ switch ($OutputFormat) {
         foreach ($result in $results.ValidationResults) {
             $statusClass = if ($result.SyntaxValid) { 'pass' } else { 'fail' }
             $issues = ($result.SecurityIssues + $result.BestPracticeIssues + $result.Warnings) -join '<br>'
-            $html += "<tr><td>$($result.FileName)</td><td class='$statusClass'>$($result.SyntaxValid)</td><td>$issues</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($result.FileName)"))</td><td class='$statusClass'>$($result.SyntaxValid)</td><td>$([System.Net.WebUtility]::HtmlEncode("$issues"))</td></tr>"
         }
         $html += @"
     </table>
@@ -250,11 +265,10 @@ switch ($OutputFormat) {
 "@
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Bicep-Validation-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Bicep-Validation-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/automation/iac/Test-TerraformConfiguration.ps1
+++ b/scripts/automation/iac/Test-TerraformConfiguration.ps1
@@ -25,7 +25,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     .\Test-TerraformConfiguration.ps1 -ConfigPath ".\terraform"
@@ -60,8 +60,23 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
 $results = @{
     Timestamp = Get-Date
@@ -203,7 +218,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Terraform-Validation-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Terraform-Validation-${RunTimestamp}_${RunId}.html"
         $html = @"
 <!DOCTYPE html>
 <html>
@@ -221,8 +236,8 @@ switch ($OutputFormat) {
 </head>
 <body>
     <h1>Terraform Validation Report</h1>
-    <p><strong>Configuration:</strong> $ConfigPath</p>
-    <p><strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')</p>
+    <p><strong>Configuration:</strong> $([System.Net.WebUtility]::HtmlEncode("$ConfigPath"))</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId</p>
     <h2>Validation Results</h2>
     <table>
         <tr><th>Check</th><th>Status</th></tr>
@@ -234,7 +249,7 @@ switch ($OutputFormat) {
         if ($results.SecurityIssues.Count -gt 0) {
             $html += "<h2>Security Issues</h2><table><tr><th>Rule</th><th>Severity</th><th>Description</th><th>File</th></tr>"
             foreach ($issue in $results.SecurityIssues) {
-                $html += "<tr><td>$($issue.RuleID)</td><td>$($issue.Severity)</td><td>$($issue.Description)</td><td>$($issue.Resource):$($issue.Line)</td></tr>"
+                $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($issue.RuleID)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($issue.Severity)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($issue.Description)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($issue.Resource)")):$([System.Net.WebUtility]::HtmlEncode("$($issue.Line)"))</td></tr>"
             }
             $html += "</table>"
         }
@@ -242,11 +257,10 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Terraform-Validation-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Terraform-Validation-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/azure/avd/Remove-SysprepBlockers.ps1
+++ b/scripts/cloud/azure/avd/Remove-SysprepBlockers.ps1
@@ -19,7 +19,7 @@
     Skip confirmation prompts and automatically remove detected blockers.
 
 .PARAMETER LogPath
-    Path where the log file will be created. Defaults to Desktop.
+    Path where the log file will be created. Defaults to MyDocuments\Reports.
 
 .PARAMETER ExportBlockersList
     Export the list of detected blockers to a CSV file before removal.
@@ -48,7 +48,7 @@ param(
     [switch]$Force,
 
     [Parameter(HelpMessage="Path for log file")]
-    [string]$LogPath = "$env:USERPROFILE\Desktop\SysprepBlockerRemoval_$(Get-Date -Format 'yyyyMMdd_HHmmss').log",
+    [string]$LogPath = (Join-Path (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports') "SysprepBlockerRemoval_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"),
 
     [Parameter(HelpMessage="Export list of blockers to CSV before removal")]
     [switch]$ExportBlockersList
@@ -60,6 +60,18 @@ $script:LogPath = $LogPath
 $script:BlockersRemoved = @()
 $script:BlockersFailed = @()
 $script:StartTime = Get-Date
+
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 
 # Services that may lock AppX packages
 $servicesToStop = @('AppXSVC', 'ClipSVC')
@@ -281,7 +293,7 @@ function Export-BlockersList {
         [array]$Blockers
     )
 
-    $exportPath = "$env:USERPROFILE\Desktop\SysprepBlockers_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $exportPath = Join-Path $ReportDir "SysprepBlockers_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     try {
         $Blockers | Select-Object Name, PackageFullName, Version, Publisher, InstallLocation, SignatureKind |

--- a/scripts/cloud/azure/compute/Azure-VirtualMachines/Get-VMBackupCompliance.ps1
+++ b/scripts/cloud/azure/compute/Azure-VirtualMachines/Get-VMBackupCompliance.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -69,8 +69,19 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 if (-not (Get-Module -ListAvailable -Name Az.RecoveryServices)) {
     Write-Error "Az.RecoveryServices module required. Install: Install-Module Az"
@@ -278,6 +289,10 @@ $results.Summary = @{
     BackupJobsAnalyzed = $results.BackupJobs.Count
 }
 
+# Run-scoped stamp to avoid filename collisions on rapid re-runs
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 # Output
 switch ($OutputFormat) {
     'Console' {
@@ -303,7 +318,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-VM-Backup-Compliance-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-VM-Backup-Compliance-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -367,12 +382,12 @@ switch ($OutputFormat) {
 
             $html += @"
         <tr class="$rowClass">
-            <td>$($vm.VMName)</td>
-            <td>$($vm.ResourceGroup)</td>
-            <td>$($vm.VaultName)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($vm.VMName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($vm.ResourceGroup)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($vm.VaultName)"))</td>
             <td>$($vm.LastBackupTime)</td>
             <td>$($vm.BackupAge)</td>
-            <td>$($vm.ComplianceStatus)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($vm.ComplianceStatus)"))</td>
         </tr>
 "@
         }
@@ -380,11 +395,10 @@ switch ($OutputFormat) {
         $html += "</table><p style='margin-top: 30px; text-align: center; color: #666; font-size: 12px;'><strong>Note:</strong> This report has not been thoroughly tested.</p></body></html>"
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-VM-Backup-Compliance-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-VM-Backup-Compliance-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/azure/compute/Azure-VirtualMachines/Get-VMSecurityConfig.ps1
+++ b/scripts/cloud/azure/compute/Azure-VirtualMachines/Get-VMSecurityConfig.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -63,8 +63,19 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 if (-not (Get-Module -ListAvailable -Name Az.Compute)) {
     Write-Error "Az.Compute module required. Install: Install-Module Az"
@@ -252,6 +263,10 @@ $results.Summary = @{
     TotalFindings = $results.SecurityFindings.Count
 }
 
+# Run-scoped stamp to avoid filename collisions on rapid re-runs
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 # Output
 switch ($OutputFormat) {
     'Console' {
@@ -271,7 +286,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-VM-Security-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-VM-Security-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -306,17 +321,16 @@ switch ($OutputFormat) {
 
         foreach ($vm in ($results.VMSecurityStatus | Sort-Object SecurityScore)) {
             $rowClass = $vm.SecurityRating.ToLower()
-            $html += "<tr class='$rowClass'><td>$($vm.VMName)</td><td>$($vm.SecurityScore)</td><td>$($vm.SecurityRating)</td><td>$($vm.SecurityIssues)</td></tr>"
+            $html += "<tr class='$rowClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.VMName)"))</td><td>$($vm.SecurityScore)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.SecurityRating)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.SecurityIssues)"))</td></tr>"
         }
 
         $html += "</table><p style='margin-top: 30px; text-align: center; color: #666; font-size: 12px;'><strong>Note:</strong> This report has not been thoroughly tested.</p></body></html>"
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-VM-Security-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-VM-Security-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/azure/compute/Azure-VirtualMachines/Optimize-AzureVMs.ps1
+++ b/scripts/cloud/azure/compute/Azure-VirtualMachines/Optimize-AzureVMs.ps1
@@ -32,7 +32,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -76,8 +76,19 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 if (-not (Get-Module -ListAvailable -Name Az.Compute)) {
     Write-Error "Az.Compute module required. Install: Install-Module Az"
@@ -249,6 +260,10 @@ $results.Summary = @{
     EstimatedMonthlySavings = "Calculate based on VM pricing"
 }
 
+# Run-scoped stamp to avoid filename collisions on rapid re-runs
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 # Output
 switch ($OutputFormat) {
     'Console' {
@@ -275,7 +290,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-VM-Optimization-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-VM-Optimization-${RunTimestamp}_${RunId}.html"
         $html = @"
 <!DOCTYPE html>
 <html>
@@ -309,25 +324,24 @@ switch ($OutputFormat) {
             if ($vm.PowerState -eq 'VM stopped') { $rowClass = "stopped" }
             elseif ($vm.AvgCPU -lt $UtilizationThreshold) { $rowClass = "underutilized" }
 
-            $html += "<tr class='$rowClass'><td>$($vm.Name)</td><td>$($vm.Size)</td><td>$($vm.PowerState)</td><td>$($vm.AvgCPU)</td><td>$($vm.HighAvailability)</td></tr>"
+            $html += "<tr class='$rowClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.Size)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.PowerState)"))</td><td>$($vm.AvgCPU)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($vm.HighAvailability)"))</td></tr>"
         }
         $html += "</table>"
 
         if ($results.Recommendations.Count -gt 0) {
             $html += "<h2>Recommendations</h2>"
             foreach ($rec in $results.Recommendations) {
-                $html += "<div class='recommendation'><strong>[$($rec.Type)]</strong> $($rec.Resource)<br>$($rec.Recommendation)<br><em>$($rec.PotentialSavings)</em></div>"
+                $html += "<div class='recommendation'><strong>[$([System.Net.WebUtility]::HtmlEncode("$($rec.Type)"))]</strong> $([System.Net.WebUtility]::HtmlEncode("$($rec.Resource)"))<br>$([System.Net.WebUtility]::HtmlEncode("$($rec.Recommendation)"))<br><em>$([System.Net.WebUtility]::HtmlEncode("$($rec.PotentialSavings)"))</em></div>"
             }
         }
 
         $html += "<p style='margin-top: 30px; text-align: center; color: #666; font-size: 12px;'><strong>Note:</strong> This report has not been thoroughly tested.</p></body></html>"
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-VM-Optimization-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-VM-Optimization-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/azure/keyvault/Azure-KeyVault/Monitor-AzureKeyVaults.ps1
+++ b/scripts/cloud/azure/keyvault/Azure-KeyVault/Monitor-AzureKeyVaults.ps1
@@ -25,7 +25,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -56,8 +56,19 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 if (-not (Get-Module -ListAvailable -Name Az.KeyVault)) {
     Write-Error "Az.KeyVault module required. Install: Install-Module Az.KeyVault"
@@ -195,6 +206,10 @@ $results.Summary = @{
     ComplianceIssues = $results.ComplianceIssues.Count
 }
 
+# Run-scoped stamp to avoid filename collisions on rapid re-runs
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 # Output
 switch ($OutputFormat) {
     'Console' {
@@ -218,7 +233,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-KeyVault-Monitor-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-KeyVault-Monitor-${RunTimestamp}_${RunId}.html"
         $html = @"
 <!DOCTYPE html>
 <html>
@@ -245,16 +260,15 @@ switch ($OutputFormat) {
 "@
         foreach ($exp in ($results.ExpiringSecrets | Sort-Object DaysUntilExpiration)) {
             $severityClass = $exp.Severity.ToLower()
-            $html += "<tr class='$severityClass'><td>$($exp.Vault)</td><td>$($exp.SecretName)</td><td>$($exp.ExpirationDate)</td><td>$($exp.DaysUntilExpiration)</td><td>$($exp.Severity)</td></tr>"
+            $html += "<tr class='$severityClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($exp.Vault)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($exp.SecretName)"))</td><td>$($exp.ExpirationDate)</td><td>$($exp.DaysUntilExpiration)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($exp.Severity)"))</td></tr>"
         }
         $html += "</table><p style='margin-top: 30px; text-align: center; color: #666; font-size: 12px;'><strong>Note:</strong> This report has not been thoroughly tested.</p></body></html>"
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-KeyVault-Monitor-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-KeyVault-Monitor-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/cloud/containers/Get-DockerHealthCheck.ps1
+++ b/scripts/cloud/containers/Get-DockerHealthCheck.ps1
@@ -238,7 +238,19 @@ if ($results.Containers.Count -gt 0) {
 
 # Export HTML
 if ($ExportHTML) {
-    $reportPath = "$env:USERPROFILE\Desktop\Docker_HealthCheck_${timestamp}.html"
+    $ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+        $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportDir -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+    if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+    }
+    $reportPath = Join-Path $ReportDir "Docker_HealthCheck_${timestamp}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -262,8 +274,8 @@ if ($ExportHTML) {
     <h1>Docker Health Check Report</h1>
     <div class="summary">
         <strong>Generated:</strong> $(Get-Date)<br>
-        <strong>Computer:</strong> $($results.ComputerName)<br>
-        <strong>Docker Version:</strong> $($results.DockerVersion)<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.ComputerName)"))<br>
+        <strong>Docker Version:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.DockerVersion)"))<br>
         <strong>Containers Running:</strong> $($results.SystemInfo.ContainersRunning)<br>
         <strong>Containers Stopped:</strong> $($results.SystemInfo.ContainersStopped)<br>
         <strong>Total Images:</strong> $($results.Images.Count)<br>
@@ -274,14 +286,14 @@ if ($ExportHTML) {
     if ($results.Issues.Count -gt 0) {
         $html += "<h2>Issues</h2>"
         foreach ($issue in $results.Issues) {
-            $html += "<div class='issue'>$issue</div>"
+            $html += "<div class='issue'>$([System.Net.WebUtility]::HtmlEncode("$issue"))</div>"
         }
     }
 
     $html += "<h2>Containers</h2><table><tr><th>Name</th><th>Image</th><th>State</th><th>CPU</th><th>Memory</th></tr>"
     foreach ($container in $results.Containers) {
         $stateClass = if ($container.State -eq "running") {"state-running"} else {"state-exited"}
-        $html += "<tr><td>$($container.Name)</td><td>$($container.Image)</td><td class='$stateClass'>$($container.State)</td><td>$($container.CPUPercent)</td><td>$($container.MemoryPercent)</td></tr>"
+        $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($container.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($container.Image)"))</td><td class='$stateClass'>$([System.Net.WebUtility]::HtmlEncode("$($container.State)"))</td><td>$($container.CPUPercent)</td><td>$($container.MemoryPercent)</td></tr>"
     }
 
     $html += "</table></body></html>"

--- a/scripts/cloud/containers/Get-KubernetesHealthCheck.ps1
+++ b/scripts/cloud/containers/Get-KubernetesHealthCheck.ps1
@@ -212,7 +212,19 @@ if ($results.Nodes.Count -gt 0) {
 
 # Export HTML
 if ($ExportHTML) {
-    $reportPath = "$env:USERPROFILE\Desktop\K8s_HealthCheck_${timestamp}.html"
+    $ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+        $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportDir -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+    if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+    }
+    $reportPath = Join-Path $ReportDir "K8s_HealthCheck_${timestamp}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -236,7 +248,7 @@ if ($ExportHTML) {
     <h1>Kubernetes Health Check Report</h1>
     <div class="summary">
         <strong>Generated:</strong> $(Get-Date)<br>
-        <strong>Cluster:</strong> $($results.Cluster)<br>
+        <strong>Cluster:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.Cluster)"))<br>
         <strong>Nodes:</strong> $($results.Nodes.Count)<br>
         <strong>Pods:</strong> $($results.Pods.Count)<br>
         <strong>Deployments:</strong> $($results.Deployments.Count)
@@ -246,19 +258,19 @@ if ($ExportHTML) {
     if ($results.Issues.Count -gt 0) {
         $html += "<h2>Issues ($($results.Issues.Count))</h2>"
         foreach ($issue in $results.Issues) {
-            $html += "<div class='issue'>$issue</div>"
+            $html += "<div class='issue'>$([System.Net.WebUtility]::HtmlEncode("$issue"))</div>"
         }
     }
 
     $html += "<h2>Nodes</h2><table><tr><th>Name</th><th>Status</th><th>Version</th><th>CPU</th><th>Memory</th></tr>"
     foreach ($node in $results.Nodes) {
         $statusClass = if ($node.Status -eq "True") {"status-ready"} else {"status-notready"}
-        $html += "<tr><td>$($node.Name)</td><td class='$statusClass'>$(if ($node.Status -eq 'True') {'Ready'} else {'NotReady'})</td><td>$($node.Version)</td><td>$($node.CPUCapacity)</td><td>$($node.MemoryCapacity)</td></tr>"
+        $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($node.Name)"))</td><td class='$statusClass'>$(if ($node.Status -eq 'True') {'Ready'} else {'NotReady'})</td><td>$([System.Net.WebUtility]::HtmlEncode("$($node.Version)"))</td><td>$($node.CPUCapacity)</td><td>$($node.MemoryCapacity)</td></tr>"
     }
 
     $html += "</table><h2>Pods (showing first 50)</h2><table><tr><th>Namespace</th><th>Name</th><th>Status</th><th>Restarts</th></tr>"
     foreach ($pod in $results.Pods | Select-Object -First 50) {
-        $html += "<tr><td>$($pod.Namespace)</td><td>$($pod.Name)</td><td>$($pod.Status)</td><td>$($pod.Restarts)</td></tr>"
+        $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($pod.Namespace)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($pod.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($pod.Status)"))</td><td>$($pod.Restarts)</td></tr>"
     }
 
     $html += "</table></body></html>"

--- a/scripts/collaboration/microsoft365/azure-ad/Get-AzureADGuestAudit.ps1
+++ b/scripts/collaboration/microsoft365/azure-ad/Get-AzureADGuestAudit.ps1
@@ -59,6 +59,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
@@ -229,7 +241,7 @@ if ($inactiveGuests -gt 0) {
 
 # Export
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\GuestUserAudit_$timestamp.html"
+    $htmlPath = "$ReportDir\GuestUserAudit_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -293,7 +305,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\GuestUserAudit_$timestamp.csv"
+    $csvPath = "$ReportDir\GuestUserAudit_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/azure-ad/Get-AzureADLicenseReport.ps1
+++ b/scripts/collaboration/microsoft365/azure-ad/Get-AzureADLicenseReport.ps1
@@ -53,6 +53,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
@@ -180,7 +192,7 @@ if ($IdentifyUnassigned) {
 
 # Export
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\LicenseReport_$timestamp.html"
+    $htmlPath = "$ReportDir\LicenseReport_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -231,7 +243,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\LicenseReport_$timestamp.csv"
+    $csvPath = "$ReportDir\LicenseReport_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/power-platform/Set-PowerPlatformRegionalSettings.ps1
+++ b/scripts/collaboration/microsoft365/power-platform/Set-PowerPlatformRegionalSettings.ps1
@@ -74,6 +74,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
@@ -190,7 +202,7 @@ Write-Host "Non-Compliant: $nonCompliantCount" -ForegroundColor Yellow
 Write-Host ""
 
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\PowerPlatformRegionalSettings_$timestamp.html"
+    $htmlPath = "$ReportDir\PowerPlatformRegionalSettings_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -238,7 +250,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\PowerPlatformRegionalSettings_$timestamp.csv"
+    $csvPath = "$ReportDir\PowerPlatformRegionalSettings_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/sharepoint-onedrive/Set-OneDriveRegionalSettings.ps1
+++ b/scripts/collaboration/microsoft365/sharepoint-onedrive/Set-OneDriveRegionalSettings.ps1
@@ -74,6 +74,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
@@ -209,7 +221,7 @@ Write-Host "Compliant: $compliantCount" -ForegroundColor Green
 Write-Host "Non-Compliant: $nonCompliantCount" -ForegroundColor Yellow
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\OneDriveRegionalSettings_$timestamp.csv"
+    $csvPath = "$ReportDir\OneDriveRegionalSettings_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/collaboration/microsoft365/sharepoint-onedrive/Set-SiteRegionalSettings.ps1
+++ b/scripts/collaboration/microsoft365/sharepoint-onedrive/Set-SiteRegionalSettings.ps1
@@ -125,6 +125,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
@@ -373,7 +385,7 @@ if ($nonCompliantCount -gt 0 -and -not $Apply) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\SiteRegionalSettings_$timestamp.html"
+    $htmlPath = "$ReportDir\SiteRegionalSettings_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -447,7 +459,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\SiteRegionalSettings_$timestamp.csv"
+    $csvPath = "$ReportDir\SiteRegionalSettings_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/data/api/Monitor-AzureAPIManagement.ps1
+++ b/scripts/data/api/Monitor-AzureAPIManagement.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for HTML/CSV/JSON output file. Default: Desktop
+    Path for HTML/CSV/JSON output file. Default: MyDocuments\Reports
 
 .PARAMETER IncludeAPIDetails
     Include per-API performance metrics
@@ -79,7 +79,7 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IncludeAPIDetails,
@@ -87,6 +87,17 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$IncludeBackendHealth
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 # Check Az module
 if (-not (Get-Module -ListAvailable -Name Az.ApiManagement)) {
@@ -302,6 +313,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Azure API Management Health Summary ===" -ForegroundColor Cyan
@@ -326,7 +339,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Azure-APIM-Health-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Azure-APIM-Health-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -356,8 +369,8 @@ switch ($OutputFormat) {
 <body>
     <h1>Azure API Management Health Report</h1>
     <div class="summary">
-        <strong>Service:</strong> $ServiceName | <strong>Location:</strong> $($results.ServiceHealth.Location) | <strong>SKU:</strong> $($results.ServiceHealth.Sku)<br>
-        <strong>Gateway URL:</strong> $($results.ServiceHealth.GatewayUrl)<br>
+        <strong>Service:</strong> $([System.Net.WebUtility]::HtmlEncode("$ServiceName")) | <strong>Location:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.ServiceHealth.Location)")) | <strong>SKU:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.ServiceHealth.Sku)"))<br>
+        <strong>Gateway URL:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.ServiceHealth.GatewayUrl)"))<br>
         <strong>Analysis Period:</strong> Last $DaysToAnalyze days | <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 
         <div class="summary-grid">
@@ -404,11 +417,11 @@ switch ($OutputFormat) {
             foreach ($api in $results.APIs) {
                 $html += @"
         <tr>
-            <td>$($api.Name)</td>
-            <td>$($api.Path)</td>
-            <td>$($api.Protocols)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($api.Name)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($api.Path)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($api.Protocols)"))</td>
             <td>$($api.OperationCount)</td>
-            <td>$($api.ServiceUrl)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($api.ServiceUrl)"))</td>
         </tr>
 "@
             }
@@ -429,10 +442,10 @@ switch ($OutputFormat) {
             foreach ($backend in $results.Backends) {
                 $html += @"
         <tr>
-            <td>$($backend.Title)</td>
-            <td>$($backend.Url)</td>
-            <td>$($backend.Protocol)</td>
-            <td>$($backend.Description)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($backend.Title)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($backend.Url)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($backend.Protocol)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($backend.Description)"))</td>
         </tr>
 "@
             }
@@ -450,17 +463,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "Azure-APIM-APIs-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "Azure-APIM-APIs-${RunTimestamp}_${RunId}.csv"
         $results.APIs | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Azure-APIM-Health-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Azure-APIM-Health-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON report saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/data/databases/Get-SQLServerHealth.ps1
+++ b/scripts/data/databases/Get-SQLServerHealth.ps1
@@ -317,8 +317,21 @@ Write-Host "Health Score: $healthScore%" -ForegroundColor $(if ($healthScore -ge
 Write-Host ""
 
 # Export results
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\SQLHealthCheck_$timestamp.html"
+    $htmlPath = Join-Path $ReportDir "SQLHealthCheck_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -373,7 +386,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\SQLHealthCheck_$timestamp.csv"
+    $csvPath = Join-Path $ReportDir "SQLHealthCheck_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/data/databases/Monitor-MongoDBHealth.ps1
+++ b/scripts/data/databases/Monitor-MongoDBHealth.ps1
@@ -37,7 +37,7 @@
     Output format: 'Console', 'HTML', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     .\Monitor-MongoDBHealth.ps1 -MongoDBServer "localhost" -Database "*"
@@ -86,8 +86,23 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
 $results = @{
     Timestamp = Get-Date
@@ -130,5 +145,5 @@ if ($Credential) {
 Write-Host "MongoDB monitoring framework ready" -ForegroundColor Green
 Write-Host "Note: Full implementation requires MongoDB .NET driver or mongosh CLI" -ForegroundColor Yellow
 
-$results | ConvertTo-Json -Depth 10 | Out-File -Path (Join-Path $OutputPath "MongoDB-Health-$(Get-Date -Format 'yyyyMMdd-HHmmss').json")
+$results | ConvertTo-Json -Depth 10 | Out-File -Path (Join-Path $OutputPath "MongoDB-Health-${RunTimestamp}_${RunId}.json")
 Write-Host "Template JSON saved for MongoDB monitoring implementation" -ForegroundColor Green

--- a/scripts/endpoints/intune/deployment/New-IntuneWinPackage.ps1
+++ b/scripts/endpoints/intune/deployment/New-IntuneWinPackage.ps1
@@ -17,7 +17,7 @@
     Folder containing installer files to convert.
 
 .PARAMETER OutputFolder
-    Where to save .intunewin packages (default: Desktop\IntuneWinPackages).
+    Where to save .intunewin packages (default: MyDocuments\Reports\IntuneWinPackages).
 
 .PARAMETER SetupFile
     Specific installer file to convert (for single file mode).
@@ -60,7 +60,7 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 
 # Set output folder
 if (-not $OutputFolder) {
-    $OutputFolder = Join-Path $env:USERPROFILE "Desktop\IntuneWinPackages"
+    $OutputFolder = Join-Path (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports') 'IntuneWinPackages'
 }
 
 # Create output folder

--- a/scripts/endpoints/intune/maintenance/Export-IntuneConfiguration.ps1
+++ b/scripts/endpoints/intune/maintenance/Export-IntuneConfiguration.ps1
@@ -14,7 +14,7 @@
     - Autopilot profiles
 
 .PARAMETER OutputPath
-    Where to save exported configuration (default: Desktop).
+    Where to save exported configuration (default: MyDocuments\Reports).
 
 .PARAMETER ConfigTypes
     Comma-separated list: DeviceConfig,Compliance,Apps,Scripts,Autopilot,All (default: All).
@@ -27,7 +27,7 @@
 
 .EXAMPLE
     .\Export-IntuneConfiguration.ps1
-    Exports all configuration to desktop.
+    Exports all configuration to MyDocuments\Reports.
 
 .EXAMPLE
     .\Export-IntuneConfiguration.ps1 -ConfigTypes "DeviceConfig,Compliance" -IncludeAssignments
@@ -41,7 +41,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$false)]
-    [string]$OutputPath = "$env:USERPROFILE\Desktop\IntuneBackup_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath,
 
     [Parameter(Mandatory=$false)]
     [string[]]$ConfigTypes = @('All'),
@@ -76,6 +76,23 @@ try {
 catch {
     Write-ColorOutput "  Failed: $($_.Exception.Message)" -Level Error
     exit 1
+}
+
+
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $ReportDir "IntuneBackup_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
 }
 
 if(-not (Test-Path $OutputPath)) {

--- a/scripts/endpoints/intune/maintenance/Find-PolicyConflicts.ps1
+++ b/scripts/endpoints/intune/maintenance/Find-PolicyConflicts.ps1
@@ -58,6 +58,18 @@ param(
     [switch]$CheckCompliancePolicies
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -299,7 +311,7 @@ try {
 
     # Export reports
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
 
     if ($ExportFormat -eq 'HTML' -or $ExportFormat -eq 'Both') {
         $htmlPath = Join-Path $outputPath "PolicyConflicts_$timestamp.html"

--- a/scripts/endpoints/intune/maintenance/Find-StaleDevices.ps1
+++ b/scripts/endpoints/intune/maintenance/Find-StaleDevices.ps1
@@ -65,6 +65,18 @@ param(
     [switch]$AutoConfirm
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -191,7 +203,7 @@ try {
 
     # Export report
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
 
     if ($ExportFormat -eq 'HTML' -or $ExportFormat -eq 'Both') {
         $htmlPath = Join-Path $outputPath "StaleDevices_${DaysInactive}Days_$timestamp.html"

--- a/scripts/endpoints/intune/reporting/Get-AppInstallErrorReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AppInstallErrorReport.ps1
@@ -53,6 +53,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -Modules Microsoft.Graph.Authentication
 
 $script:report = @{
@@ -138,13 +150,13 @@ th{background:#007bff;color:white;padding:12px}td{padding:10px;border-bottom:1px
 $(foreach($f in $script:report.Failures){"<tr><td>$($f.AppName)</td><td>$($f.DeviceName)</td><td>$($f.UserName)</td><td>$($f.ErrorCode)</td><td>$($f.LastSync)</td></tr>"})
 </table></body></html>
 "@
-    $reportPath = "$env:USERPROFILE\Desktop\AppInstallErrors_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\AppInstallErrors_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
     $html | Out-File -FilePath $reportPath -Encoding UTF8
     Write-ColorOutput "`nHTML report: $reportPath" -Level Success
 }
 
 if($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\AppInstallErrors_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $csvPath = "$ReportDir\AppInstallErrors_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
     $script:report.Failures | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report: $csvPath" -Level Success
 }

--- a/scripts/endpoints/intune/reporting/Get-AppInstallationStatus.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AppInstallationStatus.ps1
@@ -67,6 +67,18 @@ param(
     [switch]$ShowFailuresOnly
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -261,7 +273,7 @@ try {
 
     # Export reports
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
     $appNameClean = $selectedApp.displayName -replace '[\\/:*?"<>|]', '_'
 
     if ($ExportFormat -eq 'HTML' -or $ExportFormat -eq 'Both') {

--- a/scripts/endpoints/intune/reporting/Get-AutopilotDeploymentReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AutopilotDeploymentReport.ps1
@@ -58,6 +58,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.DeviceManagement
 
 $script:report = @{
@@ -148,7 +160,7 @@ if($script:report.Deployments.Count -gt 0) {
 }
 
 if($ExportHTML) {
-    $reportPath = "$env:USERPROFILE\Desktop\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
     $html = @"
 <!DOCTYPE html>
 <html><head><title>Autopilot Deployment Report</title>
@@ -167,7 +179,7 @@ $(foreach($d in $script:report.Deployments){$c=$d.Status.ToLower();"<tr><td>$($d
 }
 
 if($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $csvPath = "$ReportDir\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
     $script:report.Deployments | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report: $csvPath" -Level Success
 }

--- a/scripts/endpoints/intune/reporting/Get-BitLockerStatus.ps1
+++ b/scripts/endpoints/intune/reporting/Get-BitLockerStatus.ps1
@@ -63,6 +63,18 @@ param(
     [switch]$IncludeNonWindows
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -251,7 +263,7 @@ try {
 
     # Export reports
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
 
     if ($ExportFormat -eq 'HTML' -or $ExportFormat -eq 'Both') {
         $htmlPath = Join-Path $outputPath "BitLockerStatus_$timestamp.html"

--- a/scripts/endpoints/intune/reporting/Get-DeviceComplianceReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-DeviceComplianceReport.ps1
@@ -48,6 +48,18 @@ param(
     [string]$OutputPath
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -183,7 +195,7 @@ try {
 
     # Export reports
     if (-not $OutputPath) {
-        $OutputPath = "$env:USERPROFILE\Desktop"
+        $OutputPath = $ReportDir
     }
 
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'

--- a/scripts/endpoints/intune/reporting/Get-DeviceGroupMembership.ps1
+++ b/scripts/endpoints/intune/reporting/Get-DeviceGroupMembership.ps1
@@ -67,6 +67,18 @@ param(
     [switch]$ShowAllMappings
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -289,7 +301,7 @@ try {
 
     # Export reports
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
 
     $reportTitle = if ($DeviceName) {
         "Device_Group_Membership_$($DeviceName)_$timestamp"

--- a/scripts/endpoints/intune/reporting/Get-WindowsUpdateCompliance.ps1
+++ b/scripts/endpoints/intune/reporting/Get-WindowsUpdateCompliance.ps1
@@ -61,6 +61,18 @@ param(
     [int]$DaysOutdated = 30
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Import helper module
 $modulePath = Join-Path $PSScriptRoot "IntuneGraphHelper.psm1"
 Import-Module $modulePath -Force
@@ -269,7 +281,7 @@ try {
 
     # Export reports
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-    $outputPath = "$env:USERPROFILE\Desktop"
+    $outputPath = $ReportDir
 
     if ($ExportFormat -eq 'HTML' -or $ExportFormat -eq 'Both') {
         $htmlPath = Join-Path $outputPath "WindowsUpdateCompliance_$timestamp.html"

--- a/scripts/endpoints/intune/reporting/Get-WingetUpdateCompliance.ps1
+++ b/scripts/endpoints/intune/reporting/Get-WingetUpdateCompliance.ps1
@@ -68,6 +68,18 @@ param(
     [int]$Top
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -Modules Microsoft.Graph.Authentication, Microsoft.Graph.DeviceManagement
 
 $script:report = @{
@@ -214,7 +226,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\WingetCompliance_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\WingetCompliance_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -302,7 +314,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\WingetCompliance_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\WingetCompliance_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.Applications | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/network/Test-NetworkDiagnostics.ps1
+++ b/scripts/infrastructure/network/Test-NetworkDiagnostics.ps1
@@ -45,7 +45,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\NetworkDiag_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$TestInternetConnectivity,
@@ -60,12 +60,24 @@ param(
     [switch]$ScanPorts
 )
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Network Diagnostics Tool ===" -ForegroundColor Cyan
 Write-Host "Computer: $env:COMPUTERNAME" -ForegroundColor Gray
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -341,18 +353,18 @@ try {
     # Export results
     Write-Host "`nExporting results..." -ForegroundColor Yellow
 
-    $jsonPath = Join-Path -Path $OutputPath -ChildPath "NetworkDiagnostics.json"
+    $jsonPath = Join-Path -Path $OutputPath -ChildPath "NetworkDiagnostics_${RunTimestamp}_${RunId}.json"
     $diagnosticResults | ConvertTo-Json -Depth 5 | Out-File -FilePath $jsonPath -Encoding UTF8
     Write-Host "Results saved to: $jsonPath" -ForegroundColor Green
 
     # Generate HTML report
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "NetworkDiagnosticReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "NetworkDiagnosticReport_${RunTimestamp}_${RunId}.html"
 
     $issuesHtml = ""
     if ($diagnosticResults.Issues.Count -gt 0) {
         $issuesHtml = "<h2>Issues Detected</h2><ul>"
         foreach ($issue in $diagnosticResults.Issues) {
-            $issuesHtml += "<li>$issue</li>"
+            $issuesHtml += "<li>$([System.Net.WebUtility]::HtmlEncode("$issue"))</li>"
         }
         $issuesHtml += "</ul>"
     } else {
@@ -381,8 +393,8 @@ try {
 <body>
     <h1>Network Diagnostic Report</h1>
     <div class="info">
-        <strong>Computer:</strong> $env:COMPUTERNAME<br>
-        <strong>Report Time:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
+        <strong>Report Time:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
         <strong>Active Adapters:</strong> $($adapters.Count)<br>
         <strong>Issues Found:</strong> $($diagnosticResults.Issues.Count)
     </div>
@@ -403,12 +415,12 @@ try {
         $statusClass = if ($adapter.Status -eq 'Up') { 'success' } else { 'failed' }
         $html += @"
         <tr>
-            <td>$($adapter.Name)</td>
-            <td class="$statusClass">$($adapter.Status)</td>
-            <td>$($adapter.IPAddress)</td>
-            <td>$($adapter.Gateway)</td>
-            <td>$($adapter.DNSServers)</td>
-            <td>$($adapter.Speed)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($adapter.Name)"))</td>
+            <td class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$($adapter.Status)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($adapter.IPAddress)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($adapter.Gateway)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($adapter.DNSServers)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($adapter.Speed)"))</td>
         </tr>
 "@
     }
@@ -420,7 +432,7 @@ try {
         $html += "<h2>Connectivity Tests</h2><table><tr><th>Target</th><th>Status</th><th>Avg Latency</th><th>Packet Loss</th></tr>"
         foreach ($test in $diagnosticResults.ConnectivityTests) {
             $statusClass = if ($test.Status -eq 'Reachable') { 'success' } else { 'failed' }
-            $html += "<tr><td>$($test.Target)</td><td class='$statusClass'>$($test.Status)</td><td>$($test.AverageLatency) ms</td><td>$($test.PacketLoss)%</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($test.Target)"))</td><td class='$statusClass'>$([System.Net.WebUtility]::HtmlEncode("$($test.Status)"))</td><td>$($test.AverageLatency) ms</td><td>$($test.PacketLoss)%</td></tr>"
         }
         $html += "</table>"
     }
@@ -434,9 +446,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "HTML report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/print/Get-PrintServerHealth.ps1
+++ b/scripts/infrastructure/print/Get-PrintServerHealth.ps1
@@ -69,6 +69,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== Print Server Health Check ===" -ForegroundColor Cyan
 Write-Host "Server: $env:COMPUTERNAME" -ForegroundColor Yellow
 Write-Host "Timestamp: $(Get-Date)" -ForegroundColor Gray

--- a/scripts/infrastructure/print/Get-PrintServerHealth.ps1
+++ b/scripts/infrastructure/print/Get-PrintServerHealth.ps1
@@ -328,7 +328,7 @@ Write-Host ""
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\PrintServerHealth_$timestamp.html"
+    $htmlPath = "$ReportDir\PrintServerHealth_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -384,7 +384,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\PrintServerHealth_$timestamp.csv"
+    $csvPath = "$ReportDir\PrintServerHealth_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
+++ b/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
@@ -311,7 +311,7 @@ Write-Host ""
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\HyperVHealth_$timestamp.html"
+    $htmlPath = "$ReportDir\HyperVHealth_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -366,7 +366,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\HyperVHealth_$timestamp.csv"
+    $csvPath = "$ReportDir\HyperVHealth_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
+++ b/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
@@ -71,6 +71,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== Hyper-V Health Check ===" -ForegroundColor Cyan
 Write-Host "Host: $env:COMPUTERNAME" -ForegroundColor Yellow
 Write-Host "Timestamp: $(Get-Date)" -ForegroundColor Gray

--- a/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
@@ -400,7 +400,7 @@ if ($results.Recommendations.Count -gt 0) {
 
 # Export HTML Report
 if ($ExportHTML) {
-    $reportPath = "$env:USERPROFILE\Desktop\IIS_HealthCheck_${computerName}_${timestamp}.html"
+    $reportPath = "$ReportDir\IIS_HealthCheck_${computerName}_${timestamp}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -488,7 +488,7 @@ if ($ExportHTML) {
 
 # Export CSV
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\IIS_HealthCheck_${computerName}_${timestamp}.csv"
+    $csvPath = "$ReportDir\IIS_HealthCheck_${computerName}_${timestamp}.csv"
     $results.Websites | Export-Csv -Path $csvPath -NoTypeInformation
     Write-StatusMessage "CSV export saved to: $csvPath" -Status Success
 }

--- a/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
@@ -82,6 +82,20 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $computerName = $env:COMPUTERNAME
+
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $results = @{
     Timestamp = Get-Date
     ComputerName = $computerName

--- a/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
@@ -72,6 +72,19 @@ param(
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $cutoffDate = (Get-Date).AddDays(-$DaysToAnalyze)
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== IIS Log Analyzer ===" -ForegroundColor Cyan
 Write-Host "Analyzing logs from: $LogPath" -ForegroundColor White
 Write-Host "Date range: Last $DaysToAnalyze days`n" -ForegroundColor White

--- a/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
@@ -224,7 +224,7 @@ if ($IncludeSecurityAnalysis -and $analysis.SecurityThreats.Count -gt 0) {
 
 # Export HTML
 if ($ExportHTML) {
-    $reportPath = "$env:USERPROFILE\Desktop\IIS_LogAnalysis_${timestamp}.html"
+    $reportPath = "$ReportDir\IIS_LogAnalysis_${timestamp}.html"
 
     $html = @"
 <!DOCTYPE html>

--- a/scripts/infrastructure/windows/active-directory/Find-InactiveADComputers.ps1
+++ b/scripts/infrastructure/windows/active-directory/Find-InactiveADComputers.ps1
@@ -83,6 +83,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -Modules ActiveDirectory
 
 $script:report = @{
@@ -309,7 +321,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\InactiveComputers_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\InactiveComputers_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -424,7 +436,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\InactiveComputers_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\InactiveComputers_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.InactiveComputers | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/active-directory/Get-ADHealthCheck.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ADHealthCheck.ps1
@@ -67,6 +67,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -Modules ActiveDirectory
 
 $script:report = @{
@@ -446,7 +458,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\ADHealthCheck_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\ADHealthCheck_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $healthColor = switch($script:report.HealthStatus) {
         'Critical' { '#dc3545' }

--- a/scripts/infrastructure/windows/active-directory/Get-ADUserAudit.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ADUserAudit.ps1
@@ -46,7 +46,7 @@ param(
     [int]$InactiveDays = 90,
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\ADUserAudit_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IncludeDisabledAccounts,
@@ -60,11 +60,23 @@ param(
 
 #Requires -Module ActiveDirectory
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Active Directory User Account Audit ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -274,16 +286,16 @@ try {
 
         foreach ($category in $auditResults.Keys) {
             if ($auditResults[$category].Count -gt 0) {
-                $csvPath = Join-Path -Path $OutputPath -ChildPath "$category.csv"
+                $csvPath = Join-Path -Path $OutputPath -ChildPath "${category}_${RunTimestamp}_${RunId}.csv"
                 $auditResults[$category] | Export-Csv -Path $csvPath -NoTypeInformation
-                Write-Host "  Exported: $category.csv ($($auditResults[$category].Count) records)" -ForegroundColor Green
+                Write-Host "  Exported: ${category}_${RunTimestamp}_${RunId}.csv ($($auditResults[$category].Count) records)" -ForegroundColor Green
             }
         }
     }
 
     # Generate HTML report
     Write-Host "`nGenerating HTML report..." -ForegroundColor Yellow
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "ADUserAuditReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "ADUserAuditReport_${RunTimestamp}_${RunId}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -307,8 +319,8 @@ try {
 <body>
     <h1>Active Directory User Audit Report</h1>
     <div class="info">
-        <strong>Domain:</strong> $domainName<br>
-        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
+        <strong>Domain:</strong> $([System.Net.WebUtility]::HtmlEncode("$domainName"))<br>
+        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
         <strong>Total Users Analyzed:</strong> $totalUsers
     </div>
 
@@ -328,7 +340,7 @@ try {
     if ($auditResults.InactiveAccounts.Count -gt 0) {
         $html += "<h2>Inactive Accounts (Top 20)</h2><table><tr><th>Username</th><th>Display Name</th><th>Last Logon</th><th>Days Inactive</th><th>Department</th></tr>"
         foreach ($user in ($auditResults.InactiveAccounts | Sort-Object -Property DaysInactive -Descending | Select-Object -First 20)) {
-            $html += "<tr><td>$($user.SamAccountName)</td><td>$($user.DisplayName)</td><td>$($user.LastLogon)</td><td>$($user.DaysInactive)</td><td>$($user.Department)</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($user.SamAccountName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.DisplayName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.LastLogon)"))</td><td>$($user.DaysInactive)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.Department)"))</td></tr>"
         }
         $html += "</table>"
     }
@@ -336,7 +348,7 @@ try {
     if ($auditResults.PasswordNeverExpires.Count -gt 0) {
         $html += "<h2>Password Never Expires (Top 20)</h2><table><tr><th>Username</th><th>Display Name</th><th>Last Password Set</th><th>Department</th></tr>"
         foreach ($user in ($auditResults.PasswordNeverExpires | Select-Object -First 20)) {
-            $html += "<tr><td>$($user.SamAccountName)</td><td>$($user.DisplayName)</td><td>$($user.LastPasswordSet)</td><td>$($user.Department)</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($user.SamAccountName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.DisplayName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.LastPasswordSet)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.Department)"))</td></tr>"
         }
         $html += "</table>"
     }
@@ -346,7 +358,7 @@ try {
         foreach ($user in ($auditResults.PrivilegedAccounts | Sort-Object -Property GroupName, SamAccountName)) {
             $pwdNeverExpires = if ($user.PasswordNeverExpires) { "<span class='warning'>Yes</span>" } else { "No" }
             $smartcard = if ($user.SmartcardRequired) { "<span class='good'>Yes</span>" } else { "<span class='warning'>No</span>" }
-            $html += "<tr><td>$($user.SamAccountName)</td><td>$($user.DisplayName)</td><td>$($user.GroupName)</td><td>$pwdNeverExpires</td><td>$smartcard</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($user.SamAccountName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.DisplayName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($user.GroupName)"))</td><td>$pwdNeverExpires</td><td>$smartcard</td></tr>"
         }
         $html += "</table>"
     }
@@ -355,9 +367,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "HTML report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/active-directory/Get-ServiceAccountAudit.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ServiceAccountAudit.ps1
@@ -40,7 +40,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\ServiceAccountAudit_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$IncludeSPNAnalysis,
@@ -54,11 +54,23 @@ param(
 
 #Requires -Module ActiveDirectory
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Service Account Audit ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -304,16 +316,16 @@ try {
 
         foreach ($category in $auditResults.Keys) {
             if ($auditResults[$category].Count -gt 0) {
-                $csvPath = Join-Path -Path $OutputPath -ChildPath "$category.csv"
+                $csvPath = Join-Path -Path $OutputPath -ChildPath "${category}_${RunTimestamp}_${RunId}.csv"
                 $auditResults[$category] | Export-Csv -Path $csvPath -NoTypeInformation
-                Write-Host "  Exported: $category.csv" -ForegroundColor Green
+                Write-Host "  Exported: ${category}_${RunTimestamp}_${RunId}.csv" -ForegroundColor Green
             }
         }
     }
 
     # Generate HTML report
     Write-Host "`nGenerating HTML report..." -ForegroundColor Yellow
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "ServiceAccountAuditReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "ServiceAccountAuditReport_${RunTimestamp}_${RunId}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -337,8 +349,8 @@ try {
 <body>
     <h1>Service Account Audit Report</h1>
     <div class="info">
-        <strong>Domain:</strong> $domainName<br>
-        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
+        <strong>Domain:</strong> $([System.Net.WebUtility]::HtmlEncode("$domainName"))<br>
+        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
         <strong>Total Service Accounts:</strong> $($auditResults.StandardServiceAccounts.Count)
     </div>
 
@@ -358,7 +370,7 @@ try {
         $html += "<h2>Privileged Service Accounts (HIGH RISK)</h2><table><tr><th>Account</th><th>Display Name</th><th>Privileged Groups</th><th>Enabled</th><th>Issues</th></tr>"
         foreach ($account in $auditResults.PrivilegedServiceAccounts) {
             $rowClass = if ($account.Enabled) { "critical" } else { "warning" }
-            $html += "<tr class='$rowClass'><td>$($account.SamAccountName)</td><td>$($account.DisplayName)</td><td>$($account.PrivilegedGroups)</td><td>$($account.Enabled)</td><td>$($account.Issues)</td></tr>"
+            $html += "<tr class='$rowClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($account.SamAccountName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($account.DisplayName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($account.PrivilegedGroups)"))</td><td>$($account.Enabled)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($account.Issues)"))</td></tr>"
         }
         $html += "</table>"
     }
@@ -367,7 +379,7 @@ try {
     if ($auditResults.SecurityIssues.Count -gt 0) {
         $html += "<h2>Service Accounts with Security Issues</h2><table><tr><th>Account</th><th>Description</th><th>Password Age</th><th>Issues</th></tr>"
         foreach ($account in ($auditResults.SecurityIssues | Select-Object -First 50)) {
-            $html += "<tr class='warning'><td>$($account.SamAccountName)</td><td>$($account.Description)</td><td>$($account.PasswordAge) days</td><td>$($account.Issues)</td></tr>"
+            $html += "<tr class='warning'><td>$([System.Net.WebUtility]::HtmlEncode("$($account.SamAccountName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($account.Description)"))</td><td>$($account.PasswordAge) days</td><td>$([System.Net.WebUtility]::HtmlEncode("$($account.Issues)"))</td></tr>"
         }
         $html += "</table>"
     }
@@ -376,7 +388,7 @@ try {
     if ($auditResults.GroupManagedServiceAccounts.Count -gt 0) {
         $html += "<h2>Group Managed Service Accounts (Recommended)</h2><table><tr><th>Name</th><th>Enabled</th><th>Created</th><th>SPNs</th></tr>"
         foreach ($gmsa in $auditResults.GroupManagedServiceAccounts) {
-            $html += "<tr><td>$($gmsa.Name)</td><td>$($gmsa.Enabled)</td><td>$($gmsa.Created)</td><td>$($gmsa.SPNs)</td></tr>"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($gmsa.Name)"))</td><td>$($gmsa.Enabled)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($gmsa.Created)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($gmsa.SPNs)"))</td></tr>"
         }
         $html += "</table>"
     }
@@ -398,9 +410,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "HTML report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/backup-recovery/Get-BackupStatus.ps1
+++ b/scripts/infrastructure/windows/backup-recovery/Get-BackupStatus.ps1
@@ -65,6 +65,17 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$SMTPServer
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 Write-Host "`n=== Windows Server Backup Status Report ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
@@ -287,7 +298,7 @@ try {
     $issuesHtml = if ($report.Issues.Count -gt 0) {
         "<h2>Issues Detected</h2><ul>"
         foreach ($issue in $report.Issues) {
-            $issuesHtml += "<li>$issue</li>"
+            $issuesHtml += "<li>$([System.Net.WebUtility]::HtmlEncode("$issue"))</li>"
         }
         $issuesHtml += "</ul>"
     } else {
@@ -300,7 +311,7 @@ try {
         foreach ($bk in $report.RecentBackups) {
             $statusClass = if ($bk.Success) { "success" } else { "failed" }
             $statusText = if ($bk.Success) { "Success" } else { "Failed" }
-            $backupsTableHtml += "<tr><td>$($bk.BackupTime)</td><td class='$statusClass'>$statusText</td><td>$($bk.BackupTarget)</td></tr>"
+            $backupsTableHtml += "<tr><td>$($bk.BackupTime)</td><td class='$statusClass'>$statusText</td><td>$([System.Net.WebUtility]::HtmlEncode("$($bk.BackupTarget)"))</td></tr>"
         }
         $backupsTableHtml += "</table>"
     }
@@ -309,7 +320,7 @@ try {
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Backup Status Report - $env:COMPUTERNAME</title>
+    <title>Backup Status Report - $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; background-color: #f5f5f5; }
         h1 { color: #0066cc; }
@@ -328,9 +339,9 @@ try {
 <body>
     <h1>Windows Server Backup Status</h1>
     <div class="info">
-        <strong>Server:</strong> $env:COMPUTERNAME<br>
+        <strong>Server:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
         <strong>Report Time:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
-        <strong>Status:</strong> $($report.Status)
+        <strong>Status:</strong> $([System.Net.WebUtility]::HtmlEncode("$($report.Status)"))
     </div>
 
     <h2>Configuration</h2>
@@ -356,7 +367,7 @@ try {
     # Email report if requested
     if ($EmailReport -and $EmailTo -and $SMTPServer) {
         try {
-            $emailSubject = "Backup Status Report - $env:COMPUTERNAME - $($report.Status)"
+            $emailSubject = "Backup Status Report - $($env:COMPUTERNAME) - $($report.Status)"
             $emailBody = Get-Content -Path $htmlPath -Raw
 
             Send-MailMessage -To $EmailTo -Subject $emailSubject -Body $emailBody -BodyAsHtml `
@@ -368,9 +379,6 @@ try {
             Write-Warning "Failed to send email: $_"
         }
     }
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/backup-recovery/Test-BackupIntegrity.ps1
+++ b/scripts/infrastructure/windows/backup-recovery/Test-BackupIntegrity.ps1
@@ -75,6 +75,20 @@ $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $cutoffDate = (Get-Date).AddDays(-$DaysToCheck)
 
+# Reports directory (internal output location)
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== Backup Integrity Verification ===" -ForegroundColor Cyan
 Write-Host "Server: $env:COMPUTERNAME" -ForegroundColor Yellow
 Write-Host "Checking backups from: $($cutoffDate.ToShortDateString())" -ForegroundColor Yellow
@@ -304,7 +318,7 @@ Write-Host ""
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\BackupIntegrityReport_$timestamp.html"
+    $htmlPath = Join-Path $ReportDir "BackupIntegrityReport_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -328,7 +342,7 @@ if ($ExportHTML) {
 <body>
     <h1>Backup Integrity Verification Report</h1>
     <div class="summary">
-        <strong>Server:</strong> $env:COMPUTERNAME<br>
+        <strong>Server:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
         <strong>Generated:</strong> $(Get-Date)<br>
         <strong>Health Score:</strong> <span class="score">$healthScore%</span><br>
         <strong>Passed:</strong> $successCount | <strong>Failed:</strong> $failCount | <strong>Warnings:</strong> $warningCount
@@ -343,9 +357,9 @@ if ($ExportHTML) {
         $statusClass = $result.Status.ToLower()
         $html += @"
         <tr>
-            <td>$($result.Check)</td>
-            <td><span class="$statusClass">$($result.Status)</span></td>
-            <td>$($result.Details)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Check)"))</td>
+            <td><span class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$($result.Status)"))</span></td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Details)"))</td>
             <td>$($result.Timestamp)</td>
         </tr>
 "@
@@ -358,7 +372,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\BackupIntegrityReport_$timestamp.csv"
+    $csvPath = Join-Path $ReportDir "BackupIntegrityReport_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/windows/group-policy/Backup-GroupPolicies.ps1
+++ b/scripts/infrastructure/windows/group-policy/Backup-GroupPolicies.ps1
@@ -63,12 +63,23 @@ param(
 
 #Requires -Module GroupPolicy
 
+# Validate BackupPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($BackupPath) -or
+    $BackupPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $BackupPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe BackupPath: $BackupPath. BackupPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$BackupPath = [System.IO.Path]::GetFullPath($BackupPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Group Policy Backup Utility ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create backup directory structure
-$timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
-$backupFolder = Join-Path -Path $BackupPath -ChildPath "GPO_Backup_$timestamp"
+$backupFolder = Join-Path -Path $BackupPath -ChildPath "GPO_Backup_${RunTimestamp}_${RunId}"
 
 try {
     if (-not (Test-Path -Path $BackupPath)) {
@@ -218,11 +229,11 @@ try {
 <body>
     <h1>Group Policy Backup Report</h1>
     <div class="info">
-        <strong>Domain:</strong> $domainName<br>
-        <strong>Backup Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
-        <strong>Backup Location:</strong> $backupFolder<br>
-        <strong>Performed By:</strong> $env:USERDOMAIN\$env:USERNAME<br>
-        <strong>Comment:</strong> $Comment
+        <strong>Domain:</strong> $([System.Net.WebUtility]::HtmlEncode("$domainName"))<br>
+        <strong>Backup Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
+        <strong>Backup Location:</strong> $([System.Net.WebUtility]::HtmlEncode("$backupFolder"))<br>
+        <strong>Performed By:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:USERDOMAIN\$env:USERNAME"))<br>
+        <strong>Comment:</strong> $([System.Net.WebUtility]::HtmlEncode("$Comment"))
     </div>
 
     <h2>Backup Summary</h2>
@@ -247,9 +258,9 @@ try {
         $statusClass = if ($entry.Status -eq "Success") { "success" } else { "failed" }
         $htmlReport += @"
         <tr>
-            <td>$($entry.GPOName)</td>
-            <td class="$statusClass">$($entry.Status)</td>
-            <td>$($entry.BackupID)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($entry.GPOName)"))</td>
+            <td class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$($entry.Status)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($entry.BackupID)"))</td>
             <td>$($entry.Modified.ToString('yyyy-MM-dd HH:mm'))</td>
             <td>$($entry.LinkCount)</td>
         </tr>
@@ -318,9 +329,7 @@ try {
         Write-Host "Failed: $failCount" -ForegroundColor Red
     }
     Write-Host "`nBackup Location: $backupFolder" -ForegroundColor Cyan
-
-    # Open report
-    Start-Process $reportPath
+    Write-Host "[+] HTML report saved to: $reportPath" -ForegroundColor Green
 
 }
 catch {

--- a/scripts/infrastructure/windows/group-policy/Find-GPOConflicts.ps1
+++ b/scripts/infrastructure/windows/group-policy/Find-GPOConflicts.ps1
@@ -60,6 +60,17 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$CheckDuplicateSettings
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 #Requires -Module GroupPolicy
 #Requires -Module ActiveDirectory
@@ -315,8 +326,11 @@ try {
     # Combine all findings
     $allFindings = $issues + $warnings
 
+    $RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
     # Export results to CSV
-    $csvPath = Join-Path -Path $OutputPath -ChildPath "GPOConflicts_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $csvPath = Join-Path -Path $OutputPath -ChildPath "GPOConflicts_${RunTimestamp}_${RunId}.csv"
     $allFindings | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "`nResults exported to: $csvPath" -ForegroundColor Green
 
@@ -414,9 +428,6 @@ try {
     Write-Host "  Medium Severity: $(($allFindings | Where-Object Severity -eq 'Medium').Count)" -ForegroundColor Yellow
     Write-Host "  Warnings: $(($allFindings | Where-Object Severity -eq 'Warning').Count)" -ForegroundColor Yellow
     Write-Host "  Low Priority: $(($allFindings | Where-Object Severity -eq 'Low').Count)" -ForegroundColor Cyan
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/group-policy/Get-GPOReport.ps1
+++ b/scripts/infrastructure/windows/group-policy/Get-GPOReport.ps1
@@ -39,7 +39,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\GPOReports_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'XML', 'Both')]
@@ -54,6 +54,17 @@ param(
     [Parameter(Mandatory = $false)]
     [switch]$ExportToCSV
 )
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 # Requires GroupPolicy module
 #Requires -Module GroupPolicy
@@ -69,6 +80,9 @@ if (-not (Test-Path -Path $OutputPath)) {
         exit 1
     }
 }
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
 Write-Host "`n=== Group Policy Object Report Generator ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
@@ -182,7 +196,7 @@ try {
     # Export CSV summary
     if ($ExportToCSV) {
         Write-Host "`nExporting CSV summary..." -ForegroundColor Yellow
-        $csvPath = Join-Path -Path $OutputPath -ChildPath "GPO_Summary_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+        $csvPath = Join-Path -Path $OutputPath -ChildPath "GPO_Summary_${RunTimestamp}_${RunId}.csv"
         $gpoSummary | Export-Csv -Path $csvPath -NoTypeInformation
         Write-Host "CSV exported to: $csvPath" -ForegroundColor Green
     }
@@ -195,7 +209,7 @@ try {
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Group Policy Report - $domainName</title>
+    <title>Group Policy Report - $([System.Net.WebUtility]::HtmlEncode("$domainName"))</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; background-color: #f5f5f5; }
         h1 { color: #0066cc; }
@@ -214,7 +228,7 @@ try {
 <body>
     <h1>Group Policy Object Report</h1>
     <div class="info">
-        <strong>Domain:</strong> $domainName<br>
+        <strong>Domain:</strong> $([System.Net.WebUtility]::HtmlEncode("$domainName"))<br>
         <strong>Report Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
         <strong>Total GPOs:</strong> $totalGPOs
     </div>
@@ -247,8 +261,8 @@ try {
 
         $html += @"
         <tr>
-            <td>$($gpo.Name)</td>
-            <td class="$statusClass">$statusText</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($gpo.Name)"))</td>
+            <td class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$statusText"))</td>
             <td>$($gpo.LinkCount)</td>
             <td>$($gpo.Modified.ToString('yyyy-MM-dd HH:mm'))</td>
             <td>
@@ -274,7 +288,7 @@ try {
     if ($unlinkedGPOs.Count -gt 0) {
         $html += "<h3>Unlinked GPOs ($($unlinkedGPOs.Count))</h3><ul>"
         foreach ($gpo in $unlinkedGPOs | Sort-Object DisplayName) {
-            $html += "<li>$($gpo.DisplayName)</li>"
+            $html += "<li>$([System.Net.WebUtility]::HtmlEncode("$($gpo.DisplayName)"))</li>"
         }
         $html += "</ul>"
     }
@@ -282,7 +296,7 @@ try {
     if ($emptyGPOs.Count -gt 0) {
         $html += "<h3>Empty GPOs ($($emptyGPOs.Count))</h3><ul>"
         foreach ($gpo in $emptyGPOs | Sort-Object DisplayName) {
-            $html += "<li>$($gpo.DisplayName)</li>"
+            $html += "<li>$([System.Net.WebUtility]::HtmlEncode("$($gpo.DisplayName)"))</li>"
         }
         $html += "</ul>"
     }
@@ -290,7 +304,7 @@ try {
     if ($disabledGPOs.Count -gt 0) {
         $html += "<h3>Disabled GPOs ($($disabledGPOs.Count))</h3><ul>"
         foreach ($gpo in $disabledGPOs | Sort-Object DisplayName) {
-            $html += "<li>$($gpo.DisplayName) - $($gpo.GpoStatus)</li>"
+            $html += "<li>$([System.Net.WebUtility]::HtmlEncode("$($gpo.DisplayName) - $($gpo.GpoStatus)"))</li>"
         }
         $html += "</ul>"
     }
@@ -315,9 +329,6 @@ try {
     if ($emptyGPOs.Count -gt 0) {
         Write-Host "WARNING: $($emptyGPOs.Count) empty GPOs found. Consider removing these to reduce clutter." -ForegroundColor Yellow
     }
-
-    # Open index file
-    Start-Process $indexPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/monitoring/Get-EventLogReport.ps1
+++ b/scripts/infrastructure/windows/monitoring/Get-EventLogReport.ps1
@@ -83,6 +83,18 @@ param(
     [switch]$GroupBySource
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:report = @{
@@ -299,7 +311,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\EventLogReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\EventLogReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -403,7 +415,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\EventLogReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\EventLogReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.AllEvents | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/monitoring/Get-PerformanceReport.ps1
+++ b/scripts/infrastructure/windows/monitoring/Get-PerformanceReport.ps1
@@ -70,6 +70,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:report = @{
@@ -367,7 +379,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\PerformanceReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\PerformanceReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     # Generate CPU chart data
     $cpuChartData = ($script:report.CPU.Samples | ForEach-Object { $_ }) -join ','
@@ -481,7 +493,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\PerformanceData_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\PerformanceData_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $csvData = @()
     for($i = 0; $i -lt $script:report.CPU.Samples.Count; $i++) {

--- a/scripts/infrastructure/windows/monitoring/Monitor-ServerHealth.ps1
+++ b/scripts/infrastructure/windows/monitoring/Monitor-ServerHealth.ps1
@@ -213,6 +213,18 @@ param(
     [int]$CertificateWarningDays = 30
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 # Define alert thresholds
@@ -1459,7 +1471,7 @@ function Export-JSONReport {
         Exports health report to JSON format.
     #>
 
-    $reportPath = "$env:USERPROFILE\Desktop\ServerHealth_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').json"
+    $reportPath = "$ReportDir\ServerHealth_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').json"
 
     try {
         $json = $script:healthReport | ConvertTo-Json -Depth 10
@@ -1568,7 +1580,7 @@ function Send-EmailReport {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\ServerHealth_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\ServerHealth_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $statusColor = switch($script:healthReport.Status) {
         'Critical' { '#dc3545' }

--- a/scripts/infrastructure/windows/network/Get-FirewallRulesReport.ps1
+++ b/scripts/infrastructure/windows/network/Get-FirewallRulesReport.ps1
@@ -73,6 +73,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:report = @{
@@ -265,7 +277,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\FirewallRules_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\FirewallRules_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -401,7 +413,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\FirewallRules_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\FirewallRules_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.Rules | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/network/Get-NetworkConfiguration.ps1
+++ b/scripts/infrastructure/windows/network/Get-NetworkConfiguration.ps1
@@ -61,6 +61,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:report = @{
@@ -289,7 +301,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\NetworkConfig_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\NetworkConfig_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -432,7 +444,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\NetworkConfig_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\NetworkConfig_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.IPConfig | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/network/Test-ServerConnectivity.ps1
+++ b/scripts/infrastructure/windows/network/Test-ServerConnectivity.ps1
@@ -75,6 +75,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $script:report = @{
     TestTime = Get-Date
     SourceServer = $env:COMPUTERNAME
@@ -329,7 +341,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\ConnectivityReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\ConnectivityReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -441,7 +453,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\ConnectivityReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\ConnectivityReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $csvData = @()
     foreach($result in $script:report.Results) {

--- a/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
+++ b/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
@@ -299,7 +299,7 @@ if ($allFindings | Where-Object { $_.Category -eq "Failed Logins & Lockouts" }) 
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\SecurityEventAudit_$timestamp.html"
+    $htmlPath = "$ReportDir\SecurityEventAudit_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -376,7 +376,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\SecurityEventAudit_$timestamp.csv"
+    $csvPath = "$ReportDir\SecurityEventAudit_$timestamp.csv"
     $allFindings | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
+++ b/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
@@ -96,6 +96,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Calculate time range
 if ($Days) {
     $startTime = (Get-Date).AddDays(-$Days)

--- a/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
+++ b/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
@@ -106,6 +106,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Initialize results
 $results = @()
 $riskCount = 0

--- a/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
+++ b/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
@@ -264,7 +264,7 @@ try {
 
         'Export' {
             if (-not $ExportPath) {
-                $ExportPath = "$env:USERPROFILE\Desktop\FirewallBackup_$timestamp"
+                $ExportPath = "$ReportDir\FirewallBackup_$timestamp"
             }
 
             if (-not (Test-Path $ExportPath)) {
@@ -369,7 +369,7 @@ try {
 
     # Export results if requested
     if ($ExportHTML) {
-        $htmlPath = "$env:USERPROFILE\Desktop\FirewallAudit_$timestamp.html"
+        $htmlPath = "$ReportDir\FirewallAudit_$timestamp.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -445,7 +445,7 @@ try {
     }
 
     if ($ExportCSV) {
-        $csvPath = "$env:USERPROFILE\Desktop\FirewallAudit_$timestamp.csv"
+        $csvPath = "$ReportDir\FirewallAudit_$timestamp.csv"
         $results | Export-Csv -Path $csvPath -NoTypeInformation
         Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
     }

--- a/scripts/infrastructure/windows/security/Test-CertificateExpiration.ps1
+++ b/scripts/infrastructure/windows/security/Test-CertificateExpiration.ps1
@@ -86,6 +86,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 $script:report = @{
     ServerName = $env:COMPUTERNAME
     ScanTime = Get-Date
@@ -334,7 +346,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\CertificateReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\CertificateReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -439,7 +451,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\CertificateReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\CertificateReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.Certificates | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
+++ b/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
@@ -72,6 +72,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Resolve report output directory (default: MyDocuments\Reports) and validate against traversal/UNC paths
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== Server Hardening Compliance Check ===" -ForegroundColor Cyan
 Write-Host "Baseline: $Baseline" -ForegroundColor Yellow
 Write-Host "Server: $env:COMPUTERNAME" -ForegroundColor Yellow

--- a/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
+++ b/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
@@ -368,7 +368,7 @@ if ($failCount -gt 0) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\ServerHardeningReport_$timestamp.html"
+    $htmlPath = "$ReportDir\ServerHardeningReport_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -424,7 +424,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\ServerHardeningReport_$timestamp.csv"
+    $csvPath = "$ReportDir\ServerHardeningReport_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/windows/storage/Get-DiskReport.ps1
+++ b/scripts/infrastructure/windows/storage/Get-DiskReport.ps1
@@ -58,6 +58,18 @@ param(
     [int]$MinimumFolderSizeMB = 100
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:reportData = @{
@@ -329,7 +341,7 @@ function Show-CleanupSuggestions {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\DiskReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\DiskReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $volumesHTML = ""
     foreach ($volume in $script:reportData.Volumes) {

--- a/scripts/infrastructure/windows/storage/Get-LargeFilesReport.ps1
+++ b/scripts/infrastructure/windows/storage/Get-LargeFilesReport.ps1
@@ -76,6 +76,18 @@ param(
     [switch]$ExportCSV
 )
 
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report path: $ReportDir. Report path must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 #Requires -RunAsAdministrator
 
 $script:report = @{
@@ -291,7 +303,7 @@ function Show-Summary {
 }
 
 function Export-HTMLReport {
-    $reportPath = "$env:USERPROFILE\Desktop\LargeFilesReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $reportPath = "$ReportDir\LargeFilesReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
     $html = @"
 <!DOCTYPE html>
@@ -393,7 +405,7 @@ function Export-HTMLReport {
 }
 
 function Export-CSVReport {
-    $reportPath = "$env:USERPROFILE\Desktop\LargeFiles_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+    $reportPath = "$ReportDir\LargeFiles_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $script:report.LargeFiles | Export-Csv -Path $reportPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report exported to: $reportPath" -Level Success

--- a/scripts/infrastructure/windows/system/Check-SystemIntegrity.ps1
+++ b/scripts/infrastructure/windows/system/Check-SystemIntegrity.ps1
@@ -246,7 +246,24 @@ function Get-CriticalEventLogErrors {
 }
 
 function New-IntegrityReport {
-    $reportPath = "$env:USERPROFILE\Desktop\SystemIntegrityReport_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
+    $RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
+    # Reports directory (internal output location)
+    $reportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($reportDir) -or
+        $reportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $reportDir -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $reportDir. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $reportDir = [System.IO.Path]::GetFullPath($reportDir)
+    if (-not (Test-Path -LiteralPath $reportDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+    }
+
+    $reportPath = Join-Path $reportDir "SystemIntegrityReport_$($env:COMPUTERNAME)_${RunTimestamp}_${RunId}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -271,17 +288,17 @@ function New-IntegrityReport {
     <div class="container">
         <h1>System Integrity Report</h1>
         <table class="info-table">
-            <tr><th>Server Name</th><td>$($script:results.ServerName)</td></tr>
-            <tr><th>Scan Date</th><td>$($script:results.ScanDate)</td></tr>
-            <tr><th>OS Version</th><td>$($script:results.OSVersion)</td></tr>
+            <tr><th>Server Name</th><td>$([System.Net.WebUtility]::HtmlEncode("$($script:results.ServerName)"))</td></tr>
+            <tr><th>Scan Date</th><td>$($script:results.ScanDate) | Run ID: $RunId</td></tr>
+            <tr><th>OS Version</th><td>$([System.Net.WebUtility]::HtmlEncode("$($script:results.OSVersion)"))</td></tr>
         </table>
 
         <h2>Integrity Check Results</h2>
         <table class="info-table">
             <tr><th>Check Type</th><th>Result</th></tr>
-            <tr><td>System File Checker (SFC)</td><td class="$(if($script:results.SFCResult -match 'PASSED|REPAIRED'){'passed'}elseif($script:results.SFCResult -match 'FAILED'){'failed'}else{'warning'})">$($script:results.SFCResult)</td></tr>
-            <tr><td>DISM Component Store</td><td class="$(if($script:results.DISMResult -match 'PASSED|REPAIRED'){'passed'}elseif($script:results.DISMResult -match 'FAILED'){'failed'}else{'warning'})">$($script:results.DISMResult)</td></tr>
-            <tr><td>Disk Health</td><td class="$(if($script:results.CHKDSKResult -match 'healthy'){'passed'}else{'warning'})">$($script:results.CHKDSKResult)</td></tr>
+            <tr><td>System File Checker (SFC)</td><td class="$(if($script:results.SFCResult -match 'PASSED|REPAIRED'){'passed'}elseif($script:results.SFCResult -match 'FAILED'){'failed'}else{'warning'})">$([System.Net.WebUtility]::HtmlEncode("$($script:results.SFCResult)"))</td></tr>
+            <tr><td>DISM Component Store</td><td class="$(if($script:results.DISMResult -match 'PASSED|REPAIRED'){'passed'}elseif($script:results.DISMResult -match 'FAILED'){'failed'}else{'warning'})">$([System.Net.WebUtility]::HtmlEncode("$($script:results.DISMResult)"))</td></tr>
+            <tr><td>Disk Health</td><td class="$(if($script:results.CHKDSKResult -match 'healthy'){'passed'}else{'warning'})">$([System.Net.WebUtility]::HtmlEncode("$($script:results.CHKDSKResult)"))</td></tr>
         </table>
 
         <h2>Critical Event Log Errors (Last 24 Hours)</h2>
@@ -290,8 +307,8 @@ function New-IntegrityReport {
 "@
 
     if ($script:results.EventLogErrors.Count -gt 0) {
-        foreach ($err in $script:results.EventLogErrors) {
-            $html += "<tr><td>$($err.Time)</td><td>$($err.Log)</td><td>$($err.Source)</td><td>$($err.EventID)</td><td>$($err.Message)</td></tr>"
+foreach ($err in $script:results.EventLogErrors) {
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Time)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Log)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Source)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.EventID)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Message)"))</td></tr>"
         }
     }
     else {
@@ -307,9 +324,7 @@ function New-IntegrityReport {
 
     $html | Out-File -FilePath $reportPath -Encoding UTF8
     Write-Log "Report generated: $reportPath" "SUCCESS"
-
-    # Open report in default browser
-    Start-Process $reportPath
+    Write-Host "[+] HTML report saved to: $reportPath" -ForegroundColor Green
 }
 
 # Main execution

--- a/scripts/infrastructure/windows/user-management/Get-InactiveUserReport.ps1
+++ b/scripts/infrastructure/windows/user-management/Get-InactiveUserReport.ps1
@@ -86,6 +86,20 @@ $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $cutoffDate = (Get-Date).AddDays(-$DaysInactive)
 
+# Reports directory (internal output location)
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 Write-Host "`n=== Inactive User Account Report ===" -ForegroundColor Cyan
 Write-Host "Inactivity Threshold: $DaysInactive days (since $($cutoffDate.ToShortDateString()))" -ForegroundColor Yellow
 Write-Host "Domain: $env:USERDNSDOMAIN" -ForegroundColor Yellow
@@ -243,7 +257,7 @@ try {
 
     # Export results
     if ($ExportHTML) {
-        $htmlPath = "$env:USERPROFILE\Desktop\InactiveUsers_$timestamp.html"
+        $htmlPath = Join-Path $ReportDir "InactiveUsers_$timestamp.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -291,14 +305,14 @@ try {
             $rowClass = if ($result.IsPrivileged) { "privileged" } elseif (-not $result.Enabled) { "disabled" } else { "" }
             $html += @"
         <tr class="$rowClass">
-            <td>$($result.SamAccountName)</td>
-            <td>$($result.Name)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.SamAccountName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Name)"))</td>
             <td>$($result.Enabled)</td>
             <td>$($result.LastLogon)</td>
             <td>$($result.DaysSinceLogon)</td>
             <td>$($result.IsPrivileged)</td>
-            <td>$($result.PrivilegedGroups)</td>
-            <td>$($result.Description)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.PrivilegedGroups)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Description)"))</td>
         </tr>
 "@
         }
@@ -310,7 +324,7 @@ try {
     }
 
     if ($ExportCSV) {
-        $csvPath = "$env:USERPROFILE\Desktop\InactiveUsers_$timestamp.csv"
+        $csvPath = Join-Path $ReportDir "InactiveUsers_$timestamp.csv"
         $results | Export-Csv -Path $csvPath -NoTypeInformation
         Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
     }

--- a/scripts/infrastructure/windows/user-management/Get-UserAccessReport.ps1
+++ b/scripts/infrastructure/windows/user-management/Get-UserAccessReport.ps1
@@ -51,7 +51,7 @@ param(
     [switch]$CheckLocalAdmin,
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\UserAccessReport_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$ExportToCSV
@@ -59,11 +59,23 @@ param(
 
 #Requires -Module ActiveDirectory
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== User Access Report ===" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -147,14 +159,14 @@ try {
     # Export to CSV
     if ($ExportToCSV) {
         Write-Host "`nExporting to CSV..." -ForegroundColor Yellow
-        $csvPath = Join-Path -Path $OutputPath -ChildPath "UserAccessReport.csv"
+        $csvPath = Join-Path -Path $OutputPath -ChildPath "UserAccessReport_${RunTimestamp}_${RunId}.csv"
         $accessReports | Export-Csv -Path $csvPath -NoTypeInformation
         Write-Host "CSV exported to: $csvPath" -ForegroundColor Green
     }
 
     # Generate HTML report
     Write-Host "`nGenerating HTML report..." -ForegroundColor Yellow
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "UserAccessReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "UserAccessReport_${RunTimestamp}_${RunId}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -176,8 +188,8 @@ try {
 <body>
     <h1>User Access Report</h1>
     <div class="info">
-        <strong>Domain:</strong> $domainName<br>
-        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
+        <strong>Domain:</strong> $([System.Net.WebUtility]::HtmlEncode("$domainName"))<br>
+        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
         <strong>Users Audited:</strong> $($users.Count)<br>
         <strong>Privileged Users:</strong> $(($accessReports | Where-Object IsPrivileged).Count)
     </div>
@@ -200,12 +212,12 @@ try {
 
         $html += @"
         <tr class="$rowClass">
-            <td>$($report.SamAccountName)</td>
-            <td>$($report.DisplayName)</td>
-            <td>$($report.Department)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($report.SamAccountName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($report.DisplayName)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($report.Department)"))</td>
             <td>$($report.GroupCount)</td>
-            <td>$privStatus</td>
-            <td>$($report.LastLogon)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$privStatus"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($report.LastLogon)"))</td>
         </tr>
 "@
     }
@@ -218,9 +230,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "HTML report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/infrastructure/windows/user-management/Get-UserLockoutReport.ps1
+++ b/scripts/infrastructure/windows/user-management/Get-UserLockoutReport.ps1
@@ -79,6 +79,20 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
+# Reports directory (internal output location)
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
+
 # Calculate time range
 if ($Days) {
     $startTime = (Get-Date).AddDays(-$Days)
@@ -255,7 +269,7 @@ if ($DetectBruteForce) {
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\UserLockoutReport_$timestamp.html"
+    $htmlPath = Join-Path $ReportDir "UserLockoutReport_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -288,7 +302,7 @@ if ($ExportHTML) {
 "@
 
     foreach ($lockout in ($lockouts | Sort-Object TimeCreated -Descending)) {
-        $html += "<tr><td>$($lockout.TimeCreated)</td><td>$($lockout.Username)</td><td>$($lockout.SourceComputer)</td><td>$($lockout.DomainController)</td></tr>`n"
+        $html += "<tr><td>$($lockout.TimeCreated)</td><td>$([System.Net.WebUtility]::HtmlEncode("$($lockout.Username)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($lockout.SourceComputer)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($lockout.DomainController)"))</td></tr>`n"
     }
 
     $html += "</table></body></html>"
@@ -298,7 +312,7 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\UserLockoutReport_$timestamp.csv"
+    $csvPath = Join-Path $ReportDir "UserLockoutReport_$timestamp.csv"
     $lockouts | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }

--- a/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
+++ b/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
@@ -29,7 +29,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .EXAMPLE
     Connect-AzAccount
@@ -70,8 +70,23 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
 $results = @{
     Timestamp = Get-Date
@@ -192,7 +207,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "MDE-DeviceHealth-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "MDE-DeviceHealth-${RunTimestamp}_${RunId}.html"
 
         $html = @"
 <!DOCTYPE html>
@@ -212,8 +227,8 @@ switch ($OutputFormat) {
 <body>
     <h1>Microsoft Defender for Endpoint - Device Health Report</h1>
     <div class="summary">
-        <strong>Tenant ID:</strong> $TenantId<br>
-        <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
+        <strong>Tenant ID:</strong> $([System.Net.WebUtility]::HtmlEncode("$TenantId"))<br>
+        <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
         <strong>Status:</strong> MDE Monitoring Framework Ready
     </div>
 
@@ -245,11 +260,10 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "MDE-DeviceHealth-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "MDE-DeviceHealth-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON framework saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/security/compliance/frameworks/Get-ExpiredCertificates.ps1
+++ b/scripts/security/compliance/frameworks/Get-ExpiredCertificates.ps1
@@ -236,16 +236,30 @@ if ($Results.Count -gt 0) {
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # CSV Export
-    $CSVPath = Join-Path $ReportPath "ExpiredCertificates_$Timestamp.csv"
+    $CSVPath = Join-Path $ReportPath "ExpiredCertificates_${TimestampRunId}.csv"
     $Results | Export-Csv -Path $CSVPath -NoTypeInformation
     Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "ExpiredCertificates_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "ExpiredCertificates_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -269,8 +283,8 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Certificate Expiration Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
     <p><strong>Expiration Threshold:</strong> $DaysToExpire days</p>
 
     <div class="summary">
@@ -305,14 +319,14 @@ if ($ExportReport) {
 
             $HTML += @"
         <tr>
-            <td class="$StatusClass">$($Cert.Status)</td>
-            <td>$($Cert.Subject)</td>
-            <td>$($Cert.Issuer)</td>
-            <td>$($Cert.NotAfter)</td>
+            <td class="$StatusClass">$([System.Net.WebUtility]::HtmlEncode("$($Cert.Status)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Cert.Subject)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Cert.Issuer)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Cert.NotAfter)"))</td>
             <td>$($Cert.DaysUntilExpiry)</td>
-            <td>$($Cert.StoreLocation)\$($Cert.StoreName)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Cert.StoreLocation)"))\$([System.Net.WebUtility]::HtmlEncode("$($Cert.StoreName)"))</td>
             <td class="$SelfSignedClass">$SelfSignedText</td>
-            <td class="thumbprint">$($Cert.Thumbprint)</td>
+            <td class="thumbprint">$([System.Net.WebUtility]::HtmlEncode("$($Cert.Thumbprint)"))</td>
         </tr>
 "@
         }

--- a/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
+++ b/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
@@ -328,18 +328,32 @@ if ($FailedLogins.Count -gt 0 -or $Lockouts.Count -gt 0) {
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # CSV Export - Failed Logins
     if ($FailedLogins.Count -gt 0) {
-        $CSVPath = Join-Path $ReportPath "FailedLogins_$Timestamp.csv"
+        $CSVPath = Join-Path $ReportPath "FailedLogins_${TimestampRunId}.csv"
         $FailedLogins | Export-Csv -Path $CSVPath -NoTypeInformation
         Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
     }
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "FailedLoginReport_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "FailedLoginReport_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -364,9 +378,9 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Failed Login Analysis Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
-    <p><strong>Time Range:</strong> $($StartTime.ToString('yyyy-MM-dd HH:mm')) to $((Get-Date).ToString('yyyy-MM-dd HH:mm'))</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
+    <p><strong>Time Range:</strong> $([System.Net.WebUtility]::HtmlEncode("$($StartTime.ToString('yyyy-MM-dd HH:mm'))")) to $([System.Net.WebUtility]::HtmlEncode("$((Get-Date).ToString('yyyy-MM-dd HH:mm'))"))</p>
 
     <div class="summary">
         <div class="summary-item"><strong>Total Failed Login Attempts:</strong> <span style="color: #c62828;">$($FailedLogins.Count)</span></div>
@@ -411,7 +425,7 @@ if ($ExportReport) {
             $HTML += @"
         <tr>
             <td>$Rank</td>
-            <td><strong>$($User.Name)</strong></td>
+            <td><strong>$([System.Net.WebUtility]::HtmlEncode("$($User.Name)"))</strong></td>
             <td>$($User.Count)</td>
             <td class="$RiskClass">$RiskText</td>
         </tr>

--- a/scripts/security/compliance/frameworks/Get-LocalAdminAudit.ps1
+++ b/scripts/security/compliance/frameworks/Get-LocalAdminAudit.ps1
@@ -244,8 +244,22 @@ if ($HighRisk -gt 0 -or $MediumRisk -gt 0) {
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # Prepare export data
     $ExportData = $Results | Select-Object Name, SID, AccountType, PrincipalSource, Enabled, LastLogon, PasswordExpires, PasswordLastSet, Risk, @{
@@ -254,12 +268,12 @@ if ($ExportReport) {
     }
 
     # CSV Export
-    $CSVPath = Join-Path $ReportPath "LocalAdminAudit_$Timestamp.csv"
+    $CSVPath = Join-Path $ReportPath "LocalAdminAudit_${TimestampRunId}.csv"
     $ExportData | Export-Csv -Path $CSVPath -NoTypeInformation
     Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "LocalAdminAudit_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "LocalAdminAudit_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -283,8 +297,8 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Local Administrator Audit Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
 
     <div class="summary">
         <div class="summary-item"><strong>Total Administrators:</strong> $($Results.Count)</div>
@@ -315,13 +329,13 @@ if ($ExportReport) {
         $NotesText = ($Result.Notes -join '; ')
         $HTML += @"
         <tr>
-            <td>$($Result.Name)</td>
-            <td>$($Result.AccountType)</td>
-            <td>$($Result.Enabled)</td>
-            <td>$($Result.LastLogon)</td>
-            <td>$($Result.PasswordExpires)</td>
-            <td class="$RiskClass">$($Result.Risk)</td>
-            <td>$NotesText</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Name)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.AccountType)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Enabled)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.LastLogon)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.PasswordExpires)"))</td>
+            <td class="$RiskClass">$([System.Net.WebUtility]::HtmlEncode("$($Result.Risk)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$NotesText"))</td>
         </tr>
 "@
     }

--- a/scripts/security/compliance/frameworks/Get-OpenPortScan.ps1
+++ b/scripts/security/compliance/frameworks/Get-OpenPortScan.ps1
@@ -305,16 +305,30 @@ if ($CriticalCount -gt 0 -or $HighCount -gt 0) {
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # CSV Export
-    $CSVPath = Join-Path $ReportPath "OpenPortScan_$Timestamp.csv"
+    $CSVPath = Join-Path $ReportPath "OpenPortScan_${TimestampRunId}.csv"
     $Results | Export-Csv -Path $CSVPath -NoTypeInformation
     Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "OpenPortScan_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "OpenPortScan_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -339,8 +353,8 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Open Port Security Scan Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
 
     <div class="summary">
         <div class="summary-item"><strong>Total Open Ports:</strong> $($Results.Count)</div>
@@ -374,14 +388,14 @@ if ($ExportReport) {
 
         $HTML += @"
         <tr>
-            <td>$($Result.Protocol)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Protocol)"))</td>
             <td><strong>$($Result.Port)</strong></td>
-            <td>$($Result.Service)</td>
-            <td>$AddressDisplay</td>
-            <td>$($Result.ProcessName)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Service)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$AddressDisplay"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.ProcessName)"))</td>
             <td>$($Result.PID)</td>
-            <td class="$RiskClass">$($Result.RiskLevel)</td>
-            <td>$($Result.Reason)</td>
+            <td class="$RiskClass">$([System.Net.WebUtility]::HtmlEncode("$($Result.RiskLevel)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Reason)"))</td>
         </tr>
 "@
     }

--- a/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
+++ b/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
@@ -400,16 +400,30 @@ Write-Host "`nCompliance Score: $CompliancePercent%" -ForegroundColor $(if ($Com
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # CSV Export
-    $CSVPath = Join-Path $ReportPath "SecurityBaseline_$Timestamp.csv"
+    $CSVPath = Join-Path $ReportPath "SecurityBaseline_${TimestampRunId}.csv"
     $Results | Export-Csv -Path $CSVPath -NoTypeInformation
     Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "SecurityBaseline_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "SecurityBaseline_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -437,9 +451,9 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Security Baseline Verification Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
-    <p><strong>Baseline Type:</strong> $BaselineType</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
+    <p><strong>Baseline Type:</strong> $([System.Net.WebUtility]::HtmlEncode("$BaselineType"))</p>
 
     <div class="summary">
         <div class="summary-item"><strong>Total Checks:</strong> $TotalChecks</div>
@@ -467,11 +481,11 @@ if ($ExportReport) {
         $StatusClass = $Result.Status.ToLower()
         $HTML += @"
         <tr>
-            <td>$($Result.Category)</td>
-            <td>$($Result.Setting)</td>
-            <td>$($Result.Expected)</td>
-            <td>$($Result.Actual)</td>
-            <td class="$StatusClass">$($Result.Status)</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Category)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Setting)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Expected)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Actual)"))</td>
+            <td class="$StatusClass">$([System.Net.WebUtility]::HtmlEncode("$($Result.Status)"))</td>
         </tr>
 "@
     }
@@ -486,7 +500,7 @@ if ($ExportReport) {
     # Add recommendations for failed items
     $FailedItems = $Results | Where-Object { $_.Status -eq 'FAIL' }
     foreach ($Item in $FailedItems) {
-        $HTML += "<li><strong>$($Item.Category) - $($Item.Setting):</strong> Configure to meet baseline requirement: $($Item.Expected)</li>"
+        $HTML += "<li><strong>$([System.Net.WebUtility]::HtmlEncode("$($Item.Category)")) - $([System.Net.WebUtility]::HtmlEncode("$($Item.Setting)")):</strong> Configure to meet baseline requirement: $([System.Net.WebUtility]::HtmlEncode("$($Item.Expected)"))</li>"
     }
 
     if ($FailedItems.Count -eq 0) {

--- a/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
+++ b/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
@@ -16,7 +16,7 @@
     Export results to an HTML report on the desktop.
 
 .PARAMETER OutputPath
-    Custom output path for HTML report. Default: Desktop
+    Custom output path for HTML report. Default: MyDocuments\Reports
 
 .EXAMPLE
     .\Test-CISBenchmark.ps1
@@ -48,7 +48,7 @@ param(
     [switch]$ExportHTML,
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop')
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
 
 # Helper function to parse secedit output

--- a/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
+++ b/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
@@ -51,6 +51,21 @@ param(
     [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
 )
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 # Helper function to parse secedit output
 function Get-SecurityPolicy {
     [CmdletBinding()]
@@ -365,7 +380,7 @@ Write-Host "==================================================================`n
 
 # Export HTML report if requested
 if ($ExportHTML) {
-    $htmlFile = Join-Path $OutputPath "CIS-Benchmark-Report_Level$($Level)_$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+    $htmlFile = Join-Path $OutputPath "CIS-Benchmark-Report_Level$($Level)_${RunTimestamp}_${RunId}.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -395,9 +410,9 @@ if ($ExportHTML) {
     <div class="container">
         <h1>CIS Microsoft Windows Server Benchmark Report</h1>
         <div class="summary">
-            <strong>System:</strong> $env:COMPUTERNAME<br>
-            <strong>Level:</strong> $Level<br>
-            <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+            <strong>System:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
+            <strong>Level:</strong> $([System.Net.WebUtility]::HtmlEncode("$Level"))<br>
+            <strong>Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId
 
             <div class="summary-grid">
                 <div class="summary-item">
@@ -437,10 +452,10 @@ if ($ExportHTML) {
         $statusClass = $result.Status.ToLower()
         $html += @"
             <tr>
-                <td>$($result.ControlID)</td>
-                <td>$($result.Description)</td>
-                <td class="$statusClass">$($result.Status)</td>
-                <td>$($result.Recommendation)</td>
+                <td>$([System.Net.WebUtility]::HtmlEncode("$($result.ControlID)"))</td>
+                <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Description)"))</td>
+                <td class="$statusClass">$([System.Net.WebUtility]::HtmlEncode("$($result.Status)"))</td>
+                <td>$([System.Net.WebUtility]::HtmlEncode("$($result.Recommendation)"))</td>
             </tr>
 "@
     }
@@ -460,11 +475,6 @@ if ($ExportHTML) {
     try {
         $html | Out-File -FilePath $htmlFile -Encoding UTF8 -ErrorAction Stop
         Write-Host "HTML report saved to: $htmlFile" -ForegroundColor Green
-
-        # Open report in browser
-        if (Test-Path $htmlFile) {
-            Start-Process $htmlFile
-        }
     }
     catch {
         Write-Warning "Failed to save HTML report: $($_.Exception.Message)"

--- a/scripts/security/compliance/frameworks/Test-SecurityFeatures.ps1
+++ b/scripts/security/compliance/frameworks/Test-SecurityFeatures.ps1
@@ -351,16 +351,30 @@ if ($ShowRecommendations -or $DisabledFeatures -gt 0) {
 
 # Export reports if requested
 if ($ExportReport) {
-    $ReportPath = [Environment]::GetFolderPath('Desktop')
+    $ReportPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports')
+    # Validate report directory: reject '..' traversal and UNC remote paths before resolution
+    if ([string]::IsNullOrWhiteSpace($ReportPath) -or
+        $ReportPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+        $ReportPath -match '^(\\\\|//)') {
+        Write-Error "Unsafe report directory: $ReportPath. Report directory must be a local absolute path without '..' traversal."
+        exit 1
+    }
+    $ReportPath = [System.IO.Path]::GetFullPath($ReportPath)
+    if (-not (Test-Path -LiteralPath $ReportPath -PathType Container)) {
+        New-Item -ItemType Directory -Path $ReportPath -Force | Out-Null
+    }
+
     $Timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+    $TimestampRunId = "${Timestamp}_${RunId}"
 
     # CSV Export
-    $CSVPath = Join-Path $ReportPath "SecurityFeatures_$Timestamp.csv"
+    $CSVPath = Join-Path $ReportPath "SecurityFeatures_${TimestampRunId}.csv"
     $Results | Export-Csv -Path $CSVPath -NoTypeInformation
     Write-Host "`nCSV Report: $CSVPath" -ForegroundColor Green
 
     # HTML Export
-    $HTMLPath = Join-Path $ReportPath "SecurityFeatures_$Timestamp.html"
+    $HTMLPath = Join-Path $ReportPath "SecurityFeatures_${TimestampRunId}.html"
     $HTML = @"
 <!DOCTYPE html>
 <html>
@@ -387,8 +401,8 @@ if ($ExportReport) {
 </head>
 <body>
     <h1>Security Features Assessment Report</h1>
-    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")</p>
-    <p><strong>Computer:</strong> $env:COMPUTERNAME</p>
+    <p><strong>Generated:</strong> $(Get-Date -Format "yyyy-MM-dd HH:mm:ss") | <strong>Run ID:</strong> $RunId</p>
+    <p><strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))</p>
 
     <div class="summary">
         <div class="summary-item"><strong>Total Features:</strong> $TotalFeatures</div>
@@ -419,10 +433,10 @@ if ($ExportReport) {
 
         $HTML += @"
         <tr>
-            <td><strong>$($Result.Feature)</strong></td>
-            <td class="$StatusClass">$($Result.Status)</td>
-            <td>$($Result.Details)</td>
-            <td>$($Result.Recommendation)</td>
+            <td><strong>$([System.Net.WebUtility]::HtmlEncode("$($Result.Feature)"))</strong></td>
+            <td class="$StatusClass">$([System.Net.WebUtility]::HtmlEncode("$($Result.Status)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Details)"))</td>
+            <td>$([System.Net.WebUtility]::HtmlEncode("$($Result.Recommendation)"))</td>
         </tr>
 "@
     }

--- a/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
+++ b/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
@@ -26,7 +26,7 @@
     Output format: 'Console', 'HTML', 'CSV', or 'JSON'. Default: 'HTML'
 
 .PARAMETER OutputPath
-    Path for output files. Default: Desktop
+    Path for output files. Default: MyDocuments\Reports
 
 .PARAMETER RemediationGuidance
     Include detailed remediation steps in report
@@ -68,11 +68,23 @@ param(
     [string]$OutputFormat = 'HTML',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = [Environment]::GetFolderPath('Desktop'),
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$RemediationGuidance
 )
+
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
 
 $results = @{
     Timestamp = Get-Date
@@ -324,6 +336,8 @@ $results.Summary = @{
 }
 
 # Output results
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 switch ($OutputFormat) {
     'Console' {
         Write-Host "`n=== Security Compliance Scan Results ===" -ForegroundColor Cyan
@@ -351,7 +365,7 @@ switch ($OutputFormat) {
     }
 
     'HTML' {
-        $htmlFile = Join-Path $OutputPath "Security-Compliance-$(Get-Date -Format 'yyyyMMdd-HHmmss').html"
+        $htmlFile = Join-Path $OutputPath "Security-Compliance-${RunTimestamp}_${RunId}.html"
         $scoreColor = if ($results.Summary.ComplianceScore -ge 80) { '#107c10' } elseif ($results.Summary.ComplianceScore -ge 60) { '#ff8c00' } else { '#d13438' }
 
         $html = @"
@@ -376,8 +390,8 @@ switch ($OutputFormat) {
 <body>
     <h1>Security Compliance Report</h1>
     <div class="summary">
-        <strong>Framework:</strong> $Framework | <strong>System:</strong> $TargetSystem<br>
-        <strong>Computer:</strong> $($results.ComputerName) | <strong>Scan Time:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        <strong>Framework:</strong> $([System.Net.WebUtility]::HtmlEncode("$Framework")) | <strong>System:</strong> $([System.Net.WebUtility]::HtmlEncode("$TargetSystem"))<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$($results.ComputerName)")) | <strong>Scan Time:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
         <div class="score">$($results.Summary.ComplianceScore)%</div>
         <p style="text-align: center;">Compliance Score</p>
         <p>Critical: $criticalCount | High: $highCount | Medium: $mediumCount | Low: $lowCount</p>
@@ -388,9 +402,9 @@ switch ($OutputFormat) {
 "@
         foreach ($finding in ($results.Findings | Sort-Object { @('Critical','High','Medium','Low').IndexOf($_.Severity) })) {
             $severityClass = $finding.Severity.ToLower()
-            $html += "<tr class='$severityClass'><td>$($finding.ControlID)</td><td>$($finding.Title)</td><td>$($finding.Severity)</td><td>$($finding.Status)</td><td>$($finding.CurrentValue)</td><td>$($finding.ExpectedValue)</td>"
+            $html += "<tr class='$severityClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.ControlID)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Title)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Severity)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Status)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.CurrentValue)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.ExpectedValue)"))</td>"
             if ($RemediationGuidance) {
-                $html += "<td>$($finding.Remediation)</td>"
+                $html += "<td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Remediation)"))</td>"
             }
             $html += "</tr>"
         }
@@ -398,17 +412,16 @@ switch ($OutputFormat) {
 
         $html | Out-File -FilePath $htmlFile -Encoding UTF8
         Write-Host "`nHTML report saved to: $htmlFile" -ForegroundColor Green
-        Start-Process $htmlFile
     }
 
     'CSV' {
-        $csvFile = Join-Path $OutputPath "Security-Compliance-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
+        $csvFile = Join-Path $OutputPath "Security-Compliance-${RunTimestamp}_${RunId}.csv"
         $results.Findings | Export-Csv -Path $csvFile -NoTypeInformation
         Write-Host "`nCSV report saved to: $csvFile" -ForegroundColor Green
     }
 
     'JSON' {
-        $jsonFile = Join-Path $OutputPath "Security-Compliance-$(Get-Date -Format 'yyyyMMdd-HHmmss').json"
+        $jsonFile = Join-Path $OutputPath "Security-Compliance-${RunTimestamp}_${RunId}.json"
         $results | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonFile
         Write-Host "`nJSON saved to: $jsonFile" -ForegroundColor Green
     }

--- a/scripts/security/monitoring/Get-BatteryHealth.ps1
+++ b/scripts/security/monitoring/Get-BatteryHealth.ps1
@@ -36,7 +36,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\BatteryHealth_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$GenerateDetailedReport,
@@ -48,12 +48,24 @@ param(
     [switch]$ExportToCSV
 )
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Battery Health Monitor ===" -ForegroundColor Cyan
 Write-Host "Computer: $env:COMPUTERNAME" -ForegroundColor Gray
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -177,7 +189,7 @@ try {
     if ($GenerateDetailedReport) {
         Write-Host "`nGenerating detailed battery report..." -ForegroundColor Yellow
 
-        $batteryReportPath = Join-Path -Path $OutputPath -ChildPath "battery-report.html"
+        $batteryReportPath = Join-Path -Path $OutputPath -ChildPath "battery-report_${RunTimestamp}_${RunId}.html"
 
         try {
             $result = Start-Process -FilePath "powercfg" -ArgumentList "/batteryreport", "/output", "`"$batteryReportPath`"" -Wait -NoNewWindow -PassThru
@@ -212,14 +224,14 @@ try {
 
     # Export to CSV
     if ($ExportToCSV) {
-        $csvPath = Join-Path -Path $OutputPath -ChildPath "BatteryHealth_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
+        $csvPath = Join-Path -Path $OutputPath -ChildPath "BatteryHealth_${RunTimestamp}_${RunId}.csv"
         $batteryRecord | Export-Csv -Path $csvPath -NoTypeInformation -Append
         Write-Host "`nData exported to: $csvPath" -ForegroundColor Green
     }
 
     # Generate HTML report
     Write-Host "`nGenerating summary report..." -ForegroundColor Yellow
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "BatteryHealthReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "BatteryHealthReport_${RunTimestamp}_${RunId}.html"
 
     $healthColor = if ([int]$batteryHealth -ge 80) { "green" } elseif ([int]$batteryHealth -ge 60) { "orange" } else { "red" }
     $statusIcon = if ([int]$batteryHealth -ge 80) { "✓" } elseif ([int]$batteryHealth -ge 60) { "⚠" } else { "✗" }
@@ -246,9 +258,9 @@ try {
 <body>
     <h1>Battery Health Report</h1>
     <div class="info">
-        <strong>Computer:</strong> $env:COMPUTERNAME<br>
-        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')<br>
-        <strong>Battery:</strong> $($battery.Name)
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
+        <strong>Report Date:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId<br>
+        <strong>Battery:</strong> $([System.Net.WebUtility]::HtmlEncode("$($battery.Name)"))
     </div>
 
     <div class="status-icon">$statusIcon</div>
@@ -257,11 +269,11 @@ try {
 
     <h2>Battery Information</h2>
     <table>
-        <tr><td><strong>Name</strong></td><td>$($battery.Name)</td></tr>
-        <tr><td><strong>Chemistry</strong></td><td>$batteryChemistry</td></tr>
-        <tr><td><strong>Status</strong></td><td>$batteryStatus</td></tr>
+        <tr><td><strong>Name</strong></td><td>$([System.Net.WebUtility]::HtmlEncode("$($battery.Name)"))</td></tr>
+        <tr><td><strong>Chemistry</strong></td><td>$([System.Net.WebUtility]::HtmlEncode("$batteryChemistry"))</td></tr>
+        <tr><td><strong>Status</strong></td><td>$([System.Net.WebUtility]::HtmlEncode("$batteryStatus"))</td></tr>
         <tr><td><strong>Current Charge</strong></td><td>$currentCapacity%</td></tr>
-        <tr><td><strong>Estimated Runtime</strong></td><td>$estimatedRunTimeText</td></tr>
+        <tr><td><strong>Estimated Runtime</strong></td><td>$([System.Net.WebUtility]::HtmlEncode("$estimatedRunTimeText"))</td></tr>
     </table>
 
     <h2>Health Metrics</h2>
@@ -299,10 +311,10 @@ try {
 "@
     }
 
-    if ($GenerateDetailedReport -and (Test-Path (Join-Path -Path $OutputPath -ChildPath "battery-report.html"))) {
+    if ($GenerateDetailedReport -and (Test-Path (Join-Path -Path $OutputPath -ChildPath "battery-report_${RunTimestamp}_${RunId}.html"))) {
         $html += @"
     <h2>Additional Reports</h2>
-    <p><a href="battery-report.html">View Detailed Windows Battery Report</a></p>
+    <p><a href="battery-report_${RunTimestamp}_${RunId}.html">View Detailed Windows Battery Report</a></p>
 "@
     }
 
@@ -313,9 +325,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "Summary report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/security/monitoring/Get-PerformanceTrends.ps1
+++ b/scripts/security/monitoring/Get-PerformanceTrends.ps1
@@ -45,7 +45,7 @@ param(
     [int]$SampleInterval = 30,
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputPath = "$env:TEMP\PerformanceTrends_$(Get-Date -Format 'yyyyMMdd_HHmmss')",
+    [string]$OutputPath = (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'),
 
     [Parameter(Mandatory = $false)]
     [switch]$MonitorProcesses,
@@ -58,6 +58,18 @@ param(
     }
 )
 
+# Validate OutputPath: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($OutputPath) -or
+    $OutputPath -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $OutputPath -match '^(\\\\|//)') {
+    Write-Error "Unsafe OutputPath: $OutputPath. OutputPath must be a local absolute path without '..' traversal."
+    exit 1
+}
+$OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
+
 Write-Host "`n=== Performance Trend Monitor ===" -ForegroundColor Cyan
 Write-Host "Computer: $env:COMPUTERNAME" -ForegroundColor Gray
 Write-Host "Duration: $DurationMinutes minutes" -ForegroundColor Cyan
@@ -65,7 +77,7 @@ Write-Host "Sample Interval: $SampleInterval seconds" -ForegroundColor Cyan
 Write-Host "Start Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')" -ForegroundColor Gray
 
 # Create output directory
-if (-not (Test-Path -Path $OutputPath)) {
+if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
 }
 
@@ -215,31 +227,31 @@ try {
     # Export data
     Write-Host "`nExporting data..." -ForegroundColor Yellow
 
-    $csvPath = Join-Path -Path $OutputPath -ChildPath "PerformanceData.csv"
+    $csvPath = Join-Path -Path $OutputPath -ChildPath "PerformanceData_${RunTimestamp}_${RunId}.csv"
     $performanceData | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "Performance data exported to: $csvPath" -ForegroundColor Green
 
     if ($alerts.Count -gt 0) {
-        $alertsPath = Join-Path -Path $OutputPath -ChildPath "Alerts.csv"
+        $alertsPath = Join-Path -Path $OutputPath -ChildPath "Alerts_${RunTimestamp}_${RunId}.csv"
         $alerts | Export-Csv -Path $alertsPath -NoTypeInformation
         Write-Host "Alerts exported to: $alertsPath" -ForegroundColor Green
     }
 
     if ($MonitorProcesses -and $processData.Count -gt 0) {
-        $processPath = Join-Path -Path $OutputPath -ChildPath "ProcessData.csv"
+        $processPath = Join-Path -Path $OutputPath -ChildPath "ProcessData_${RunTimestamp}_${RunId}.csv"
         $processData | Export-Csv -Path $processPath -NoTypeInformation
         Write-Host "Process data exported to: $processPath" -ForegroundColor Green
     }
 
     # Generate HTML report
     Write-Host "`nGenerating HTML report..." -ForegroundColor Yellow
-    $htmlPath = Join-Path -Path $OutputPath -ChildPath "PerformanceTrendReport.html"
+    $htmlPath = Join-Path -Path $OutputPath -ChildPath "PerformanceTrendReport_${RunTimestamp}_${RunId}.html"
 
     $alertsHtml = ""
     if ($alerts.Count -gt 0) {
         $alertsHtml = "<h2>Alerts ($($alerts.Count))</h2><table><tr><th>Time</th><th>Type</th><th>Value</th><th>Threshold</th></tr>"
         foreach ($alert in $alerts) {
-            $alertsHtml += "<tr class='warning'><td>$($alert.Timestamp.ToString('HH:mm:ss'))</td><td>$($alert.Type)</td><td>$($alert.Value)%</td><td>$($alert.Threshold)%</td></tr>"
+            $alertsHtml += "<tr class='warning'><td>$([System.Net.WebUtility]::HtmlEncode("$($alert.Timestamp.ToString('HH:mm:ss'))"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($alert.Type)"))</td><td>$($alert.Value)%</td><td>$($alert.Threshold)%</td></tr>"
         }
         $alertsHtml += "</table>"
     }
@@ -267,10 +279,10 @@ try {
 <body>
     <h1>Performance Trend Report</h1>
     <div class="info">
-        <strong>Computer:</strong> $env:COMPUTERNAME<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
         <strong>Monitoring Duration:</strong> $DurationMinutes minutes<br>
         <strong>Samples Collected:</strong> $currentSample<br>
-        <strong>Report Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+        <strong>Report Generated:</strong> $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') | <strong>Run ID:</strong> $RunId
     </div>
 
     <h2>Performance Statistics</h2>
@@ -355,15 +367,15 @@ try {
 
     <h2>Data Files</h2>
     <ul>
-        <li><a href="PerformanceData.csv">Performance Data (CSV)</a></li>
+        <li><a href="PerformanceData_${RunTimestamp}_${RunId}.csv">Performance Data (CSV)</a></li>
 "@
 
     if ($alerts.Count -gt 0) {
-        $html += "<li><a href='Alerts.csv'>Alert Log (CSV)</a></li>"
+        $html += "<li><a href='Alerts_${RunTimestamp}_${RunId}.csv'>Alert Log (CSV)</a></li>"
     }
 
     if ($MonitorProcesses) {
-        $html += "<li><a href='ProcessData.csv'>Process Data (CSV)</a></li>"
+        $html += "<li><a href='ProcessData_${RunTimestamp}_${RunId}.csv'>Process Data (CSV)</a></li>"
     }
 
     $html += @"
@@ -374,9 +386,6 @@ try {
 
     $html | Out-File -FilePath $htmlPath -Encoding UTF8
     Write-Host "HTML report saved to: $htmlPath" -ForegroundColor Green
-
-    # Open report
-    Start-Process $htmlPath
 
 }
 catch {

--- a/scripts/utilities/Get-SoftwareInventory.ps1
+++ b/scripts/utilities/Get-SoftwareInventory.ps1
@@ -78,7 +78,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
-Write-Host "`n=== Software Inventory Report ===" -ForegroundColor Cyan
+# Reports directory (internal output location)
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 Write-Host "Computer: $env:COMPUTERNAME" -ForegroundColor Yellow
 Write-Host "Generated: $(Get-Date)" -ForegroundColor Gray
 Write-Host ""
@@ -272,7 +284,7 @@ $inventory.InstalledApplications | Select-Object -First 10 Name, Version, Publis
 
 # Export results
 if ($ExportHTML) {
-    $htmlPath = "$env:USERPROFILE\Desktop\SoftwareInventory_$timestamp.html"
+    $htmlPath = Join-Path $ReportDir "SoftwareInventory_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -293,7 +305,7 @@ if ($ExportHTML) {
 <body>
     <h1>Software Inventory Report</h1>
     <div class="summary">
-        <strong>Computer:</strong> $env:COMPUTERNAME<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
         <strong>Generated:</strong> $(Get-Date)<br>
         <strong>Total Applications:</strong> $($inventory.InstalledApplications.Count)
     </div>
@@ -304,7 +316,7 @@ if ($ExportHTML) {
 "@
 
     foreach ($app in ($inventory.InstalledApplications | Sort-Object Name)) {
-        $html += "<tr><td>$($app.Name)</td><td>$($app.Version)</td><td>$($app.Publisher)</td><td>$($app.InstallDate)</td></tr>`n"
+        $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Version)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Publisher)"))</td><td>$($app.InstallDate)</td></tr>`n"
     }
 
     $html += "</table>"
@@ -312,7 +324,7 @@ if ($ExportHTML) {
     if ($IncludeStoreApps -and $inventory.StoreApps.Count -gt 0) {
         $html += "<h2>Microsoft Store Apps</h2><table><tr><th>Name</th><th>Version</th><th>Publisher</th></tr>"
         foreach ($app in ($inventory.StoreApps | Sort-Object Name)) {
-            $html += "<tr><td>$($app.Name)</td><td>$($app.Version)</td><td>$($app.Publisher)</td></tr>`n"
+            $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Name)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Version)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($app.Publisher)"))</td></tr>`n"
         }
         $html += "</table>"
     }
@@ -324,13 +336,13 @@ if ($ExportHTML) {
 }
 
 if ($ExportCSV) {
-    $csvPath = "$env:USERPROFILE\Desktop\SoftwareInventory_$timestamp.csv"
+    $csvPath = Join-Path $ReportDir "SoftwareInventory_$timestamp.csv"
     $inventory.InstalledApplications | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }
 
 if ($ExportJSON) {
-    $jsonPath = "$env:USERPROFILE\Desktop\SoftwareInventory_$timestamp.json"
+    $jsonPath = Join-Path $ReportDir "SoftwareInventory_$timestamp.json"
     $inventory | ConvertTo-Json -Depth 10 | Out-File -FilePath $jsonPath -Encoding UTF8
     Write-Host "[+] JSON export saved to: $jsonPath" -ForegroundColor Green
 }

--- a/scripts/utilities/Optimize-WindowsServices.ps1
+++ b/scripts/utilities/Optimize-WindowsServices.ps1
@@ -76,7 +76,19 @@ param(
 $ErrorActionPreference = "Stop"
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
-Write-Host "`n=== Windows Service Optimizer ===" -ForegroundColor Cyan
+# Reports directory (internal output location)
+$ReportDir = Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'Reports'
+# Validate report directory: reject '..' traversal and UNC remote paths before resolution
+if ([string]::IsNullOrWhiteSpace($ReportDir) -or
+    $ReportDir -match '(^|[\\/])\.\.([\\/]|$)' -or
+    $ReportDir -match '^(\\\\|//)') {
+    Write-Error "Unsafe report directory: $ReportDir. Report directory must be a local absolute path without '..' traversal."
+    exit 1
+}
+$ReportDir = [System.IO.Path]::GetFullPath($ReportDir)
+if (-not (Test-Path -LiteralPath $ReportDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $ReportDir -Force | Out-Null
+}
 Write-Host "Mode: $Mode" -ForegroundColor Yellow
 Write-Host "Profile: $Profile" -ForegroundColor Yellow
 Write-Host ""
@@ -187,7 +199,7 @@ elseif ($Mode -eq 'Optimize') {
 
     # Create backup first
     if (-not $BackupPath) {
-        $BackupPath = "$env:USERPROFILE\Desktop\ServiceBackup_$timestamp.xml"
+        $BackupPath = Join-Path $ReportDir "ServiceBackup_$timestamp.xml"
     }
 
     Write-Host "[*] Creating backup at: $BackupPath" -ForegroundColor Cyan
@@ -299,7 +311,7 @@ elseif ($Mode -eq 'Restore') {
 
 # Export results
 if ($ExportHTML -and $results.Count -gt 0) {
-    $htmlPath = "$env:USERPROFILE\Desktop\ServiceOptimization_$timestamp.html"
+    $htmlPath = Join-Path $ReportDir "ServiceOptimization_$timestamp.html"
 
     $html = @"
 <!DOCTYPE html>
@@ -319,7 +331,7 @@ if ($ExportHTML -and $results.Count -gt 0) {
 <body>
     <h1>Service Optimization Report</h1>
     <div class="summary">
-        <strong>Computer:</strong> $env:COMPUTERNAME<br>
+        <strong>Computer:</strong> $([System.Net.WebUtility]::HtmlEncode("$env:COMPUTERNAME"))<br>
         <strong>Generated:</strong> $(Get-Date)<br>
         <strong>Mode:</strong> $Mode<br>
         <strong>Profile:</strong> $Profile<br>
@@ -332,7 +344,7 @@ if ($ExportHTML -and $results.Count -gt 0) {
 "@
 
     foreach ($result in $results) {
-        $html += "<tr><td>$($result.ServiceName)</td><td>$($result.DisplayName)</td><td>$($result.CurrentStartup)$($result.OldStartup)</td><td>$($result.RecommendedStartup)$($result.NewStartup)</td></tr>`n"
+        $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($result.ServiceName)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($result.DisplayName)"))</td><td>$($result.CurrentStartup)$($result.OldStartup)</td><td>$($result.RecommendedStartup)$($result.NewStartup)</td></tr>`n"
     }
 
     $html += "</table></body></html>"
@@ -342,7 +354,7 @@ if ($ExportHTML -and $results.Count -gt 0) {
 }
 
 if ($ExportCSV -and $results.Count -gt 0) {
-    $csvPath = "$env:USERPROFILE\Desktop\ServiceOptimization_$timestamp.csv"
+    $csvPath = Join-Path $ReportDir "ServiceOptimization_$timestamp.csv"
     $results | Export-Csv -Path $csvPath -NoTypeInformation
     Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
 }


### PR DESCRIPTION
Fixes #72 #73 #74 #79 #82 (report-sweep hardens remaining HTML-report scripts: batch 1 + batch 2 + batch 3 Desktop-default sweep)

- Removes HTML auto-open (Start-Process $html / 'Open report') in all remaining report scripts
- Validates OutputPath (#73) - rejects traversal/UNC
- HtmlEncode dynamic user data (#74)
- Single RunTimestamp+RunId (#79)
- Defaults report/export output to Documents/Reports instead of Desktop (#82) across 74 files

Completes the report-script hardening started in #102. Closes these issues for the FULL repo (the 16-file group is in `fix/security-report-hardening`, the remaining 74 here).

## Summary by Sourcery

Harden remaining reporting and monitoring scripts by securing output locations, sanitizing HTML content, standardizing run identifiers, and stopping automatic report launching.

Bug Fixes:
- Validate and normalize report output paths to prevent directory traversal and disallow UNC/remote destinations before creating files.

Enhancements:
- Default all report and export outputs from Desktop or temp locations to a consolidated MyDocuments/Reports directory across scripts.
- Introduce per-run timestamp and short GUID identifiers in report and export filenames to avoid collisions and aid traceability.
- HTML-encode dynamic or user-derived values in generated reports to mitigate injection risks in UI output.
- Remove automatic opening of generated HTML reports to avoid unexpected UI behavior and align with hardened security posture.