### PR TITLE
fix: security scan controls read documented keys, WMI to CIM, honest help

### DIFF
--- a/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
+++ b/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
@@ -101,20 +101,20 @@ $results = @{
 Write-Host "Monitoring Microsoft Defender for Endpoint devices..." -ForegroundColor Cyan
 
 # WARNING: This script is a FRAMEWORK TEMPLATE and requires implementation of actual MDE API calls
-# It will NOT produce real data without Microsoft Graph API or WindowsDefenderATP API integration
+# It will NOT produce real data without Microsoft Graph API or Microsoft Defender for Endpoint API integration
 #
 # Required implementation:
 # - Microsoft Graph API: DeviceManagement.Read.All permission
-# - Or Windows Defender ATP API: Machine.Read.All permission
+# - Or Microsoft Defender for Endpoint API: Machine.Read.All / Machine.ReadWrite.All permission
 #
 # Example API call:
 # $headers = @{ Authorization = "Bearer $token" }
-# $devices = Invoke-RestMethod -Uri "https://api.securitycenter.microsoft.com/api/machines" -Headers $headers
+# $devices = Invoke-RestMethod -Uri "https://api.security.microsoft.com/api/machines" -Headers $headers
 
 try {
     Write-Host "`nWARNING: This script is a framework template - no live API data available" -ForegroundColor Yellow
     Write-Host "`nAuthenticating to Microsoft Defender API..." -ForegroundColor Yellow
-    Write-Host "Note: Full implementation requires Microsoft Graph or WindowsDefenderATP API access" -ForegroundColor Gray
+    Write-Host "Note: Full implementation requires Microsoft Graph or Microsoft Defender for Endpoint API access" -ForegroundColor Gray
 
     # Simulated device health analysis
     Write-Host "`nRetrieving device inventory..." -ForegroundColor Yellow
@@ -201,9 +201,9 @@ switch ($OutputFormat) {
         Write-Host "Status: MDE monitoring framework ready" -ForegroundColor Green
         Write-Host "`nNext Steps:" -ForegroundColor Yellow
         Write-Host "1. Configure Microsoft Graph API access" -ForegroundColor White
-        Write-Host "2. Grant DeviceManagement.Read.All permission (or Machine.Read.All for WindowsDefenderATP API)" -ForegroundColor White
+        Write-Host "2. Grant DeviceManagement.Read.All permission (or Machine.Read.All / Machine.ReadWrite.All for the Microsoft Defender for Endpoint API)" -ForegroundColor White
         Write-Host "3. Implement API authentication" -ForegroundColor White
-        Write-Host "4. Connect to https://api.securitycenter.microsoft.com" -ForegroundColor White
+        Write-Host "4. Connect to https://api.security.microsoft.com" -ForegroundColor White
     }
 
     'HTML' {
@@ -237,9 +237,9 @@ switch ($OutputFormat) {
         <p>This script provides the framework for MDE device monitoring. To enable live data:</p>
         <ol>
             <li>Register an Azure AD application</li>
-            <li>Grant <strong>DeviceManagement.Read.All</strong> (Microsoft Graph) or <strong>Machine.Read.All</strong> (WindowsDefenderATP API) permission</li>
+            <li>Grant <strong>DeviceManagement.Read.All</strong> (Microsoft Graph) or <strong>Machine.Read.All</strong> / <strong>Machine.ReadWrite.All</strong> (Microsoft Defender for Endpoint API) permission</li>
             <li>Implement OAuth2 authentication</li>
-            <li>Connect to Microsoft Defender ATP API: <code>https://api.securitycenter.microsoft.com</code></li>
+            <li>Connect to Microsoft Defender for Endpoint API: <code>https://api.security.microsoft.com</code></li>
         </ol>
         <p><strong>Sample API Endpoints:</strong></p>
         <ul>

--- a/scripts/security/compliance/frameworks/Get-AntivirusStatus.ps1
+++ b/scripts/security/compliance/frameworks/Get-AntivirusStatus.ps1
@@ -103,11 +103,17 @@ try {
 
         # Get threat history
         try {
-            $threats = Get-MpThreatDetection -ErrorAction SilentlyContinue | Select-Object -First 10
+            $threats = @(Get-MpThreatDetection -ErrorAction SilentlyContinue | Select-Object -First 10)
+            # Get-MpThreatDetection does not expose ThreatName; resolve names via
+            # Get-MpThreat keyed by ThreatID (cache the lookup).
+            $threatLookup = @{}
+            if ($threats.Count -gt 0) {
+                Get-MpThreat -ErrorAction SilentlyContinue | ForEach-Object { $threatLookup[$_.ThreatID] = $_.ThreatName }
+            }
             $avStatus.WindowsDefender.RecentThreats = $threats.Count
             $avStatus.WindowsDefender.ThreatHistory = $threats | ForEach-Object {
                 [PSCustomObject]@{
-                    ThreatName = $_.ThreatName
+                    ThreatName = if ($threatLookup.ContainsKey($_.ThreatID)) { $threatLookup[$_.ThreatID] } else { "Unknown (ThreatID $($_.ThreatID))" }
                     DetectionTime = $_.InitialDetectionTime
                     ActionSuccess = $_.ActionSuccess
                 }
@@ -132,7 +138,7 @@ if ($CheckThirdParty) {
     try {
         # Check using Windows Security Center (Windows 10/11)
         $namespace = "root\SecurityCenter2"
-        $avProducts = Get-WmiObject -Namespace $namespace -Class AntiVirusProduct -ErrorAction SilentlyContinue
+        $avProducts = Get-CimInstance -Namespace $namespace -ClassName AntiVirusProduct -ErrorAction SilentlyContinue
 
         if ($avProducts) {
             foreach ($av in $avProducts) {

--- a/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
+++ b/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
@@ -130,7 +130,10 @@ foreach ($Event in $FailedLoginEvents) {
         $WorkstationName = ($EventData | Where-Object { $_.Name -eq 'WorkstationName' }).'#text'
         $IpAddress = ($EventData | Where-Object { $_.Name -eq 'IpAddress' }).'#text'
         $LogonType = ($EventData | Where-Object { $_.Name -eq 'LogonType' }).'#text'
-        $FailureReason = ($EventData | Where-Object { $_.Name -eq 'SubStatus' }).'#text'
+        # 4625: the failure status code is documented in 'Status'; 'SubStatus' is
+        # retained as supplementary detail (usually the same value).
+        $FailureReason = ($EventData | Where-Object { $_.Name -eq 'Status' }).'#text'
+        $FailureSubStatus = ($EventData | Where-Object { $_.Name -eq 'SubStatus' }).'#text'
 
         # Map logon type to friendly name
         $LogonTypeDescription = switch ($LogonType) {
@@ -169,6 +172,7 @@ foreach ($Event in $FailedLoginEvents) {
             SourceIP = $IpAddress
             LogonType = $LogonTypeDescription
             FailureReason = $FailureDescription
+            SubStatus = $FailureSubStatus
             EventID = $Event.Id
         }
 

--- a/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
+++ b/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
@@ -93,9 +93,10 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 
 # 1. PASSWORD POLICY
 Write-Host "[1/9] Checking Password Policy..." -ForegroundColor Yellow
+$secpolFile = Join-Path $env:TEMP ("secpol_{0}.cfg" -f [Guid]::NewGuid().ToString('N'))
 try {
-    $SecPol = secedit /export /cfg "$env:TEMP\secpol.cfg" /quiet
-    $SecPolContent = Get-Content "$env:TEMP\secpol.cfg"
+    $null = secedit /export /cfg $secpolFile /quiet
+    $SecPolContent = Get-Content -LiteralPath $secpolFile
 
     # Parse password policy
     $MinPasswordLength = ($SecPolContent | Select-String "MinimumPasswordLength").ToString().Split('=')[1].Trim()
@@ -139,11 +140,14 @@ try {
         Write-CheckResult "Password history: $PasswordHistorySize passwords (should be 24+)" "FAIL"
         Add-Result "Password Policy" "History Size" "24+" "$PasswordHistorySize" "FAIL"
     }
-
-    Remove-Item "$env:TEMP\secpol.cfg" -Force -ErrorAction SilentlyContinue
 } catch {
     Write-CheckResult "Failed to check password policy: $($_.Exception.Message)" "FAIL"
     Add-Result "Password Policy" "Check" "Success" "Failed" "FAIL"
+} finally {
+    # Always clean up the exported policy file, even on parse failure
+    if (Test-Path -LiteralPath $secpolFile) {
+        Remove-Item -LiteralPath $secpolFile -Force -ErrorAction SilentlyContinue
+    }
 }
 
 # 2. ACCOUNT LOCKOUT POLICY
@@ -294,11 +298,25 @@ try {
 Write-Host "`n[7/9] Checking SMB Security..." -ForegroundColor Yellow
 try {
     $SMB1 = Get-WindowsOptionalFeature -Online -FeatureName SMB1Protocol -ErrorAction SilentlyContinue
+    $SMBServerConfig = Get-SmbServerConfiguration -ErrorAction SilentlyContinue
 
-    if ($SMB1.State -eq 'Disabled') {
+    # Prefer the live SMB server configuration; fall back to the optional-feature
+    # state when Get-SmbServerConfiguration is unavailable.
+    if ($null -ne $SMBServerConfig) {
+        $SMB1Enabled = $SMBServerConfig.EnableSMB1Protocol
+    } elseif ($SMB1.State -eq 'Enabled') {
+        $SMB1Enabled = $true
+    } elseif ($SMB1.State -eq 'Disabled') {
+        $SMB1Enabled = $false
+    } else {
+        # Feature absent and no server configuration: SMBv1 is not active
+        $SMB1Enabled = $false
+    }
+
+    if ($SMB1Enabled -eq $false) {
         Write-CheckResult "SMBv1: Disabled (Secure)" "PASS"
         Add-Result "SMB Security" "SMBv1" "Disabled" "Disabled" "PASS"
-    } elseif ($SMB1.State -eq 'Enabled') {
+    } elseif ($SMB1Enabled -eq $true) {
         Write-CheckResult "SMBv1: Enabled (Security Risk)" "FAIL"
         Add-Result "SMB Security" "SMBv1" "Disabled" "Enabled" "FAIL"
     } else {
@@ -307,8 +325,7 @@ try {
     }
 
     # Check SMB encryption
-    $SMBServerConfig = Get-SmbServerConfiguration -ErrorAction SilentlyContinue
-    if ($SMBServerConfig.EncryptData) {
+    if ($SMBServerConfig -and $SMBServerConfig.EncryptData) {
         Write-CheckResult "SMB encryption: Enabled" "PASS"
         Add-Result "SMB Security" "Encryption" "Enabled" "Enabled" "PASS"
     } else {
@@ -395,7 +412,12 @@ Write-Host "Passed: $PassedChecks" -ForegroundColor Green
 Write-Host "Failed: $FailedChecks" -ForegroundColor Red
 Write-Host "Warnings: $WarningChecks" -ForegroundColor Yellow
 
-$CompliancePercent = [math]::Round(($PassedChecks / $TotalChecks) * 100, 2)
+if ($TotalChecks -eq 0) {
+    Write-Warning "No checks were performed; compliance score cannot be computed."
+    $CompliancePercent = 0
+} else {
+    $CompliancePercent = [math]::Round(($PassedChecks / $TotalChecks) * 100, 2)
+}
 Write-Host "`nCompliance Score: $CompliancePercent%" -ForegroundColor $(if ($CompliancePercent -ge 80) { 'Green' } elseif ($CompliancePercent -ge 60) { 'Yellow' } else { 'Red' })
 
 # Export reports if requested

--- a/scripts/security/compliance/frameworks/Get-SoftwareLicenseCompliance.ps1
+++ b/scripts/security/compliance/frameworks/Get-SoftwareLicenseCompliance.ps1
@@ -86,7 +86,7 @@ foreach ($path in $registryPaths) {
                 # Check for Office license
                 if ($productName -match "Microsoft Office|Microsoft 365") {
                     try {
-                        $officeLicense = Get-WmiObject -Query "SELECT * FROM SoftwareLicensingProduct WHERE ApplicationID = '0ff1ce15-a989-479d-af46-f275c6370663' AND LicenseStatus = 1" -ErrorAction SilentlyContinue
+                        $officeLicense = Get-CimInstance -Query "SELECT * FROM SoftwareLicensingProduct WHERE ApplicationID = '0ff1ce15-a989-479d-af46-f275c6370663' AND LicenseStatus = 1" -ErrorAction SilentlyContinue
                         if ($officeLicense) {
                             $licenseKey = $officeLicense.ProductKeyID
                             $licenseStatus = "Licensed"
@@ -101,7 +101,7 @@ foreach ($path in $registryPaths) {
                 # Check for Windows license
                 if ($productName -match "Windows|Microsoft Windows") {
                     try {
-                        $windowsLicense = Get-WmiObject -Query "SELECT * FROM SoftwareLicensingProduct WHERE ApplicationID = '55c92734-d682-4d71-983e-d6ec3f16059f' AND LicenseStatus = 1" -ErrorAction SilentlyContinue
+                        $windowsLicense = Get-CimInstance -Query "SELECT * FROM SoftwareLicensingProduct WHERE ApplicationID = '55c92734-d682-4d71-983e-d6ec3f16059f' AND LicenseStatus = 1" -ErrorAction SilentlyContinue
                         if ($windowsLicense) {
                             $licenseKey = $windowsLicense.ProductKeyID
                             $licenseStatus = "Licensed"

--- a/scripts/security/compliance/frameworks/Get-USBDeviceAudit.ps1
+++ b/scripts/security/compliance/frameworks/Get-USBDeviceAudit.ps1
@@ -66,8 +66,8 @@ $results = @()
 Write-Host "=== USB Device Audit ===" -ForegroundColor Cyan
 Write-Host "Scanning for USB devices..." -ForegroundColor Yellow
 
-# Get currently connected USB devices via WMI
-$connectedDevices = Get-WmiObject -Class Win32_PnPEntity | Where-Object {
+# Get currently connected USB devices via CIM
+$connectedDevices = Get-CimInstance -ClassName Win32_PnPEntity | Where-Object {
     $_.DeviceID -match "^USB"
 }
 

--- a/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
+++ b/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
@@ -3,21 +3,18 @@
     Performs comprehensive security compliance scanning against industry frameworks.
 
 .DESCRIPTION
-    Multi-framework security compliance scanner that validates systems against:
-    - CIS Benchmarks (Windows, Linux)
+    Multi-framework security compliance scanner that validates Windows systems against:
+    - CIS Benchmarks (Windows)
     - NIST 800-53 controls
     - PCI-DSS requirements
-    - HIPAA security rule
-    - SOC 2 Type II controls
-    - ISO 27001 requirements
 
     Generates detailed compliance reports with remediation guidance.
 
 .PARAMETER Framework
-    Compliance framework to test against: 'CIS', 'NIST', 'PCI-DSS', 'HIPAA', 'SOC2', 'ISO27001', 'All'
+    Compliance framework to test against: 'CIS', 'NIST', 'PCI-DSS', 'All'
 
 .PARAMETER TargetSystem
-    Target system type: 'Windows', 'Linux', 'Cloud', 'Network'
+    Target system type: 'Windows' (the implemented checks use Windows-only cmdlets)
 
 .PARAMETER Severity
     Minimum severity to report: 'Critical', 'High', 'Medium', 'Low', 'All'. Default: 'All'
@@ -52,11 +49,11 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('CIS', 'NIST', 'PCI-DSS', 'HIPAA', 'SOC2', 'ISO27001', 'All')]
+    [ValidateSet('CIS', 'NIST', 'PCI-DSS', 'All')]
     [string]$Framework,
 
     [Parameter(Mandatory = $true)]
-    [ValidateSet('Windows', 'Linux', 'Cloud', 'Network')]
+    [ValidateSet('Windows')]
     [string]$TargetSystem,
 
     [Parameter(Mandatory = $false)]
@@ -168,18 +165,19 @@ function Test-CISWindowsCompliance {
         }
     }
 
-    # CIS 18.3.1 - LAPS AdmPwd GPO Extension
-    $lapsInstalled = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\{D76B9641-3288-4f75-942D-087DE603E3EA}' -ErrorAction SilentlyContinue
-    if (-not $lapsInstalled) {
+    # CIS 18.3.1 - LAPS AdmPwd GPO Extension (legacy) / Windows LAPS
+    $legacyLapsInstalled = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\{D76B9641-3288-4f75-942D-087DE603E3EA}' -ErrorAction SilentlyContinue
+    $windowsLapsConfigured = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\LAPS' -ErrorAction SilentlyContinue
+    if (-not $legacyLapsInstalled -and -not $windowsLapsConfigured) {
         $findings += @{
             ControlID = "CIS-18.3.1"
             Title = "LAPS Installation"
-            Description = "Local Administrator Password Solution (LAPS) should be installed"
+            Description = "Local Administrator Password Solution (LAPS) should be installed and configured"
             Severity = "High"
             Status = "Non-Compliant"
             CurrentValue = "Not Installed"
             ExpectedValue = "Installed"
-            Remediation = "Install LAPS from Microsoft Download Center"
+            Remediation = "Deploy Windows LAPS (built into Windows 10 20H2+/Server 20H2+, enabled via the ADMX-backed policy under HKLM:\SOFTWARE\Policies\Microsoft\Windows\LAPS) - https://learn.microsoft.com/en-us/windows-server/identity/laps/laps-overview"
         }
     }
 
@@ -206,15 +204,15 @@ function Test-NISTCompliance {
     }
 
     # AC-7 - Unsuccessful Logon Attempts
-    $lockoutThreshold = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters' -ErrorAction SilentlyContinue).LockoutThreshold
-    if ($lockoutThreshold -gt 5 -or $lockoutThreshold -eq 0) {
+    $lockoutBadCount = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters' -ErrorAction SilentlyContinue).LockoutBadCount
+    if ($lockoutBadCount -gt 5 -or $lockoutBadCount -eq 0) {
         $findings += @{
             ControlID = "NIST-AC-7"
             Title = "Account Lockout Threshold"
             Description = "Account lockout threshold should be 5 or fewer invalid logon attempts"
             Severity = "High"
             Status = "Non-Compliant"
-            CurrentValue = $lockoutThreshold
+            CurrentValue = $lockoutBadCount
             ExpectedValue = "5 or less"
             Remediation = "Configure account lockout policy in Group Policy"
         }
@@ -236,6 +234,48 @@ function Test-NISTCompliance {
     }
 
     return $findings
+}
+
+# Helper function to read a value from the exported security policy (secedit INI)
+function Get-SecurityPolicyValue {
+    [CmdletBinding()]
+    param(
+        [string]$Section,
+        [string]$Name
+    )
+
+    $tempFile = Join-Path $env:TEMP ("secpol_{0}.cfg" -f [Guid]::NewGuid().ToString('N'))
+
+    try {
+        $null = secedit /export /cfg $tempFile /quiet
+
+        if (-not (Test-Path -LiteralPath $tempFile)) {
+            throw "Failed to export security policy"
+        }
+
+        $content = Get-Content -LiteralPath $tempFile -ErrorAction Stop
+        $currentSection = ""
+        foreach ($line in $content) {
+            if ($line -match '^\[(.+)\]$') {
+                $currentSection = $matches[1]
+            }
+            elseif ($line -match '^(.+?)\s*=\s*(.*)$' -and $currentSection -eq $Section) {
+                if ($matches[1].Trim() -eq $Name) {
+                    return $matches[2].Trim()
+                }
+            }
+        }
+        return $null
+    }
+    catch {
+        Write-Verbose "Failed to read security policy value '$Section\$Name': $($_.Exception.Message)"
+        return $null
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempFile) {
+            Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 # PCI-DSS Requirements
@@ -261,23 +301,34 @@ function Test-PCIDSSCompliance {
     }
 
     # Requirement 2.2.4 - Configure system security parameters
-    $tlsVersion = [Net.ServicePointManager]::SecurityProtocol
-    if ($tlsVersion -notmatch "Tls12|Tls13") {
+    # TLS enforcement is determined by the Schannel registry policy, not the
+    # process-local [Net.ServicePointManager]::SecurityProtocol default.
+    $schannelBase = 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols'
+    $tls12Client = Get-ItemProperty -Path (Join-Path $schannelBase 'TLS 1.2\Client') -ErrorAction SilentlyContinue
+    $tls13Client = Get-ItemProperty -Path (Join-Path $schannelBase 'TLS 1.3\Client') -ErrorAction SilentlyContinue
+
+    $tls12Enabled = ($tls12Client.Enabled -eq 1 -and $tls12Client.DisabledByDefault -eq 0)
+    # TLS 1.3 is absent on older Windows; when the key is present it must also be enabled
+    $tls13Compliant = if ($null -eq $tls13Client) { $true } else { ($tls13Client.Enabled -eq 1 -and $tls13Client.DisabledByDefault -eq 0) }
+
+    if (-not ($tls12Enabled -and $tls13Compliant)) {
         $findings += @{
             ControlID = "PCI-DSS-2.2.4"
             Title = "TLS Configuration"
-            Description = "TLS 1.2 or higher should be enforced"
+            Description = "TLS 1.2 or higher should be enforced at the operating system level (Schannel)"
             Severity = "Critical"
             Status = "Non-Compliant"
-            CurrentValue = $tlsVersion
-            ExpectedValue = "TLS 1.2 or TLS 1.3"
-            Remediation = "Configure TLS 1.2+ in registry and disable older protocols"
+            CurrentValue = "TLS 1.2 enforced: $tls12Enabled; TLS 1.3 compliant: $tls13Compliant"
+            ExpectedValue = "TLS 1.2 enabled (and TLS 1.3 where present) with Enabled = 1 and DisabledByDefault = 0"
+            Remediation = "Set 'Enabled' = 1 and 'DisabledByDefault' = 0 under 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client' (and 'TLS 1.3\Client' where supported), then disable older protocols"
         }
     }
 
     # Requirement 8.2.3 - Password complexity
-    $passComplexity = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Lsa' -ErrorAction SilentlyContinue).PasswordComplexity
-    if ($passComplexity -ne 1) {
+    # 'PasswordComplexity' is not a documented value under HKLM\...\Control\Lsa;
+    # read it from the exported security policy the same way Test-CISBenchmark.ps1 does.
+    $passComplexity = Get-SecurityPolicyValue -Section 'System Access' -Name 'PasswordComplexity'
+    if ($passComplexity -ne '1') {
         $findings += @{
             ControlID = "PCI-DSS-8.2.3"
             Title = "Password Complexity"
@@ -286,7 +337,7 @@ function Test-PCIDSSCompliance {
             Status = "Non-Compliant"
             CurrentValue = "Disabled"
             ExpectedValue = "Enabled"
-            Remediation = "Enable password complexity in Group Policy"
+            Remediation = "Enable password complexity in Group Policy (Security Options > Accounts: Limit local account use of blank passwords / Password Policy > Password must meet complexity requirements)"
         }
     }
 

--- a/scripts/security/monitoring/Get-BatteryHealth.ps1
+++ b/scripts/security/monitoring/Get-BatteryHealth.ps1
@@ -73,7 +73,7 @@ try {
     # Check if system has a battery
     Write-Host "`nDetecting battery..." -ForegroundColor Yellow
 
-    $battery = Get-WmiObject -Class Win32_Battery -ErrorAction SilentlyContinue
+    $battery = Get-CimInstance -ClassName Win32_Battery -ErrorAction SilentlyContinue
 
     if (-not $battery) {
         Write-Host "No battery detected. This appears to be a desktop system." -ForegroundColor Yellow
@@ -126,10 +126,11 @@ try {
         $wearLevel = "N/A"
     }
 
-    # Estimate runtime
+    # Estimate runtime: EstimatedRunTime is meaningless while on AC power (WMI/CIM
+    # reports a sentinel value); use BatteryStatus (2 = On AC Power) instead.
     $estimatedRunTime = $battery.EstimatedRunTime
-    if ($estimatedRunTime -eq 71582788) {
-        $estimatedRunTimeText = "On AC Power / Fully Charged"
+    if ($battery.BatteryStatus -eq 2) {
+        $estimatedRunTimeText = "On AC Power"
     }
     elseif ($estimatedRunTime) {
         $hours = [math]::Floor($estimatedRunTime / 60)
@@ -161,8 +162,8 @@ try {
         Write-Host "  Recommendation: Consider battery replacement" -ForegroundColor Yellow
     }
 
-    # Get additional battery details from WMI
-    $portableBattery = Get-WmiObject -Class Win32_PortableBattery -ErrorAction SilentlyContinue
+    # Get additional battery details from CIM
+    $portableBattery = Get-CimInstance -ClassName Win32_PortableBattery -ErrorAction SilentlyContinue
 
     if ($portableBattery) {
         $manufacturer = $portableBattery.Manufacturer

--- a/scripts/security/monitoring/Get-SystemResourceTrends.ps1
+++ b/scripts/security/monitoring/Get-SystemResourceTrends.ps1
@@ -1,19 +1,19 @@
 <#
 .SYNOPSIS
-    System resource trend analysis and capacity planning.
+    Samples current system resource utilization (CPU, memory, disk).
 .DESCRIPTION
-    Analyzes historical performance data to identify trends and predict capacity needs.
+    Samples live performance counters to report current CPU, memory, and disk utilization.
 .EXAMPLE
-    .\Get-SystemResourceTrends.ps1 -DaysToAnalyze 30 -ExportHTML
+    .\Get-SystemResourceTrends.ps1 -ExportHTML
 .NOTES
-    Analyzes performance counters over time for trend identification
+    Samples live performance counters for utilization reporting
 #>
 [CmdletBinding()]
-param([int]$DaysToAnalyze = 30, [switch]$ExportHTML)
+param([switch]$ExportHTML)
 
 Write-Host "`n=== System Resource Trends ===" -ForegroundColor Cyan
 
-Write-Host "[*] Collecting performance data for last $DaysToAnalyze days..." -ForegroundColor Cyan
+Write-Host "[*] Sampling performance data..." -ForegroundColor Cyan
 
 # CPU trend
 $cpuCounters = Get-Counter "\Processor(_Total)\% Processor Time" -SampleInterval 5 -MaxSamples 12
@@ -30,4 +30,4 @@ $diskCounters = Get-Counter "\PhysicalDisk(_Total)\% Idle Time" -SampleInterval 
 $avgDisk = ($diskCounters.CounterSamples.CookedValue | Measure-Object -Average).Average
 Write-Host "[+] Average Disk Idle: $([math]::Round($avgDisk, 2))%" -ForegroundColor Green
 
-Write-Host "`nTrend analysis complete!`n" -ForegroundColor Green
+Write-Host "`nSampling complete!`n" -ForegroundColor Green


### PR DESCRIPTION
Closes #121
Closes #124
Closes #152
Closes #157
Closes #158
Closes #159
Closes #160
Closes #164
Closes #182
Closes #183
Closes #217
Closes #218
Closes #219
Closes #221

Fixes from the 2026-08-08 Microsoft Learn alignment review (MSLEARN-REVIEW.md).

## Summary by Sourcery

Align security compliance and monitoring scripts with documented Windows behaviors and modern APIs, focusing the tooling on Windows-only checks and clarifying template guidance.

Bug Fixes:
- Correct NIST account lockout evaluation to use the documented LockoutBadCount registry value.
- Fix PCI-DSS password complexity detection and remediation messaging to align with the exported security policy and Group Policy settings.
- Ensure password policy export/import and temporary file cleanup in Get-SecurityBaseline.ps1 are robust, including a guard for zero total checks.
- Improve SMBv1 and SMB encryption assessment by preferring live server configuration and handling environments without SMB server configuration.
- Report failed logon status using the documented Status field while retaining SubStatus for additional context.

Enhancements:
- Update LAPS compliance checks to recognize both legacy and Windows LAPS configuration with modern remediation guidance.
- Introduce a reusable helper to read security policy settings from secedit exports for consistent registry-based control evaluation.
- Harden TLS configuration checks to validate Schannel protocol policy for TLS 1.2/1.3 rather than process-local defaults.
- Refine the Defender for Endpoint monitoring template to reference the current Microsoft Defender API endpoints and permission scopes.
- Clarify and simplify system resource monitoring to report current utilization instead of implying historical trend analysis.
- Improve battery health reporting by using CIM instead of WMI and providing more accurate runtime interpretation when on AC power.
- Enhance Windows Defender threat history reporting by resolving human-readable threat names via Get-MpThreat and switching Security Center queries to CIM.
- Standardize USB device and licensing queries on CIM instead of WMI for better reliability and forward compatibility.

Documentation:
- Update script parameter and synopsis documentation to reflect Windows-only support and the reduced set of supported compliance frameworks.