### PR TITLE
fix: 15 remediation checks — driver deny-list layout, autopatch policies, DISM language packs

### DIFF
--- a/scripts/endpoints/devices/autopatch/README.md
+++ b/scripts/endpoints/devices/autopatch/README.md
@@ -1,0 +1,28 @@
+# Autopatch Remediation Scripts (V1–V5)
+
+Detect/remediate pairs that keep Windows Update behavior aligned with Autopatch
+expectations on Windows 10 and later / Windows Server 2016 and later.
+
+## Policy change (2026-08)
+
+The `DisableWindowsUpdateAccess` value ("Remove access to use all Windows Update
+features", managed at `HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`)
+is **not supported on Windows 10 and later versions and Windows Server 2016 and
+later versions** (see the WSUS Group Policy reference).
+
+All pairs that previously detected/removed that value now manage the supported
+WUaaS policy instead:
+
+- `HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate`
+
+(per [waas-wu-settings](https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings)).
+`NoAutoUpdate = 1` disables Automatic Updates; detect exits 1 when the value is
+present and remediate removes it, exactly as the old pair did for
+`DisableWindowsUpdateAccess`.
+
+- `V1/DisableWindowsUpdateAccess/` — the dedicated pair now detects/removes `NoAutoUpdate`.
+- `V2`–`V5` — the `DisableWindowsUpdateAccess` array entry was dropped; the
+  supported `NoAutoUpdate` entry at the `AU` path was already present in each pair.
+
+Other policies managed by these pairs (`DoNotConnectToWindowsUpdateInternetLocations`,
+`WUServer`, `UseWUServer`) are unchanged.

--- a/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Detect.ps1
@@ -1,4 +1,10 @@
-if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'DisableWindowsUpdateAccess') {
+# Detect: the policy "Remove access to use all Windows Update features"
+# (DisableWindowsUpdateAccess) is NOT supported on Windows 10 and later or
+# Windows Server 2016 and later. This pair instead detects the supported
+# WUaaS policy NoAutoUpdate under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+# (per waas-wu-settings). Exit 1 when the policy value is present (remediation needed).
+# See https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains 'NoAutoUpdate') {
     exit 1
 } else {
     exit 0

--- a/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Remediate.ps1
@@ -1,3 +1,8 @@
-if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'DisableWindowsUpdateAccess') {
-    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DisableWindowsUpdateAccess"
+# Remediate: remove the NoAutoUpdate policy (see Detect.ps1 for the policy
+# rationale - DisableWindowsUpdateAccess is unsupported on Windows 10+ /
+# Server 2016+, so this pair manages the supported WUaaS policy NoAutoUpdate
+# under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU).
+# See https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
+if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains 'NoAutoUpdate') {
+    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate"
 }

--- a/scripts/endpoints/devices/autopatch/V2/AP_Detection.ps1
+++ b/scripts/endpoints/devices/autopatch/V2/AP_Detection.ps1
@@ -16,8 +16,10 @@ Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
 # initialize the array
 [PsObject[]]$regkeys = @()
 # populate the array with each object
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 $regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
-$regkeys += [PsObject]@{ Name = "DisableWindowsUpdateAccess"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
 $regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\"}
 
 

--- a/scripts/endpoints/devices/autopatch/V2/AP_Remediation.ps1
+++ b/scripts/endpoints/devices/autopatch/V2/AP_Remediation.ps1
@@ -16,8 +16,10 @@ Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
 # initialize the array
 [PsObject[]]$regkeys = @()
 # populate the array with each object
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 $regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
-$regkeys += [PsObject]@{ Name = "DisableWindowsUpdateAccess"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
 $regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\"}
 
 foreach ($setting in $regkeys)

--- a/scripts/endpoints/devices/autopatch/V3/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V3/detect.ps1
@@ -9,9 +9,11 @@ Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 $RemediationNeeded = $false
 
 # Define registry keys to check
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 $regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 )
 

--- a/scripts/endpoints/devices/autopatch/V3/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V3/remediate.ps1
@@ -7,9 +7,11 @@ try { Stop-Transcript | Out-Null } catch {}
 Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 
 # Define registry keys to remove
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 $regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 )
 

--- a/scripts/endpoints/devices/autopatch/V4/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V4/detect.ps1
@@ -8,9 +8,11 @@ try { Stop-Transcript | Out-Null } catch {}
 Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 
 # Define problematic registry values
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 $regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" },
     @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" },
     @{ Name = "WUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" }

--- a/scripts/endpoints/devices/autopatch/V4/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V4/remediate.ps1
@@ -8,7 +8,6 @@ Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 
 $regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" },
     @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" },
     @{ Name = "WUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" }

--- a/scripts/endpoints/devices/autopatch/V5/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V5/detect.ps1
@@ -8,12 +8,14 @@ try { Stop-Transcript | Out-Null } catch [System.InvalidOperationException] {}
 Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 
 # Initialize the array
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 [PsObject[]]$regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" },
     @{ Name = "WUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" }
+    @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 )
 
 $RemediationNeeded = $false

--- a/scripts/endpoints/devices/autopatch/V5/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V5/remediate.ps1
@@ -8,12 +8,14 @@ try { Stop-Transcript | Out-Null } catch [System.InvalidOperationException] {}
 Start-Transcript -Path "$TranscriptPath\$TranscriptName" -Append
 
 # Initialize the array
+# NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
+# is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
+# NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
 [PsObject[]]$regkeys = @(
     @{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "DisableWindowsUpdateAccess"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
     @{ Name = "NoAutoUpdate"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" },
     @{ Name = "WUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" },
-    @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" }
+    @{ Name = "UseWUServer"; Path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 )
 
 foreach ($setting in $regkeys) {

--- a/scripts/endpoints/devices/bitlocker/Fix_BitLockerKeyBackup.ps1
+++ b/scripts/endpoints/devices/bitlocker/Fix_BitLockerKeyBackup.ps1
@@ -5,6 +5,7 @@ function Backup-BitLockerKeyToAAD {
 
     .DESCRIPTION
         Script retrieves the BitLocker recovery key of the local computer and then attempts to backup the key to Azure Active Directory.
+        Exits 1 if any key fails to escrow so Intune reports the remediation as failed.
 
     .NOTES
         Run this script as an administrator.
@@ -15,6 +16,7 @@ function Backup-BitLockerKeyToAAD {
 
     Begin {
         Write-Host "Starting BitLocker Key Backup process to Azure AD." -ForegroundColor Cyan
+        $script:BackupFailed = $false
     }
 
     Process {
@@ -35,8 +37,14 @@ function Backup-BitLockerKeyToAAD {
 
                 foreach ($KeyProtectorId in $KeyProtectorIds) {
                     # Backup the BitLocker Key to Azure AD
-                    BackupToAAD-BitLockerKeyProtector -MountPoint $BitLockerVolume.MountPoint -KeyProtectorId $KeyProtectorId
-                    Write-Host "Successfully backed up BitLocker Key for volume $($BitLockerVolume.MountPoint) to Azure AD." -ForegroundColor Green
+                    try {
+                        BackupToAAD-BitLockerKeyProtector -MountPoint $BitLockerVolume.MountPoint -KeyProtectorId $KeyProtectorId -ErrorAction Stop
+                        Write-Host "Successfully backed up BitLocker Key for volume $($BitLockerVolume.MountPoint) to Azure AD." -ForegroundColor Green
+                    }
+                    catch {
+                        Write-Host "Failed to backup BitLocker Key for volume $($BitLockerVolume.MountPoint) to Azure AD: $_" -ForegroundColor Red
+                        $script:BackupFailed = $true
+                    }
                 }
             }
 
@@ -46,6 +54,7 @@ function Backup-BitLockerKeyToAAD {
         }
         catch {
             Write-Host "Failed to backup BitLocker Key to Azure AD: $_" -ForegroundColor Red
+            $script:BackupFailed = $true
         }
     }
 
@@ -53,6 +62,12 @@ function Backup-BitLockerKeyToAAD {
         Write-Host "`n`n"
         Write-Host "BitLocker Key Backup process to Azure AD completed." -ForegroundColor Cyan
         Write-Host $driveInfoString
+
+        # Escrow failure must yield a non-zero exit so Intune does not report success
+        if ($script:BackupFailed) {
+            exit 1
+        }
+        exit 0
     }
 }
 

--- a/scripts/endpoints/devices/drivers/BlockAMDDriver.ps1
+++ b/scripts/endpoints/devices/drivers/BlockAMDDriver.ps1
@@ -1,14 +1,35 @@
-# Define the registry path and value
-$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceIDs"
+# Block the AMD Radeon driver (DeviceInstallation policy)
+#
+# Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
+# DeviceInstall_IDs_Deny): a REG value named "DenyDeviceIDs" directly under
+# HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions.
+# DenyDeviceIDsRetroactive (REG_DWORD 1) additionally blocks already-installed devices.
+# See https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation
+
+# Documented registry location
+$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions"
+$RegValueName = "DenyDeviceIDs"
 $RegValue = "PCIVEN_1002&DEV_1681"
 
-# Ensure the registry key exists
+# Ensure the Restrictions key exists
 if (!(Test-Path $RegPath)) {
     New-Item -Path $RegPath -Force | Out-Null
 }
 
-# Apply the registry setting
-Set-ItemProperty -Path $RegPath -Name "1" -Value $RegValue -Type String -Force
+# Merge the hardware ID into the existing DenyDeviceIDs value (REG_MULTI_SZ)
+$denyList = @()
+$current = (Get-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue).$RegValueName
+if ($current) {
+    $denyList = @($current)
+}
+
+if ($denyList -notcontains $RegValue) {
+    $denyList += $RegValue
+    Set-ItemProperty -Path $RegPath -Name $RegValueName -Value $denyList -Type MultiString -Force
+}
+
+# Retroactive flag so already-installed devices are also blocked
+Set-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -Value 1 -Type DWord -Force
 
 Write-Output "AMD Radeon driver block policy applied."
 Exit 0

--- a/scripts/endpoints/devices/drivers/UnblockAMDDriver.ps1
+++ b/scripts/endpoints/devices/drivers/UnblockAMDDriver.ps1
@@ -1,27 +1,35 @@
-# Define the registry path
-$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceIDs"
+# Unblock the AMD Radeon driver (DeviceInstallation policy)
+#
+# Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
+# DeviceInstall_IDs_Deny): a REG value named "DenyDeviceIDs" directly under
+# HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions.
+# See https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation
 
-# Check if the key exists
+# Documented registry location
+$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions"
+$RegValueName = "DenyDeviceIDs"
+$RegValue = "PCIVEN_1002&DEV_1681"
+
 if (Test-Path $RegPath) {
-    # Get all existing properties under the key
-    $props = Get-ItemProperty -Path $RegPath
+    # Read the DenyDeviceIDs value (REG_MULTI_SZ array, or a single REG_SZ string)
+    $denyList = @((Get-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue).$RegValueName | Where-Object { $_ })
 
-    # Loop through each named value (excluding system properties)
-    foreach ($name in $props.PSObject.Properties.Name) {
-        $value = $props.$name
+    # Remove the AMD hardware ID from the list
+    $remaining = @($denyList | Where-Object { $_ -ne $RegValue })
 
-        # Check if it matches the AMD device ID and remove it
-        if ($value -eq "PCIVEN_1002&DEV_1681") {
-            Remove-ItemProperty -Path $RegPath -Name $name -ErrorAction SilentlyContinue
-            Write-Output "Removed driver block for AMD device: $name"
-        }
+    if ($remaining.Count -gt 0) {
+        Set-ItemProperty -Path $RegPath -Name $RegValueName -Value $remaining -Type MultiString -Force
+        Write-Output "Removed AMD device block: $RegValue"
+    } elseif ($denyList.Count -gt 0) {
+        # The list only contained the AMD ID - remove the value entirely
+        Remove-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue
+        Write-Output "Removed AMD device block: $RegValue"
+    } else {
+        Write-Output "AMD device block was not present."
     }
 
-    # If the key is now empty, remove it
-    if ((Get-ItemProperty -Path $RegPath).PSObject.Properties.Count -eq 0) {
-        Remove-Item -Path $RegPath -Force
-        Write-Output "Registry key removed as it was empty."
-    }
+    # Clear the retroactive flag so previously blocked devices are no longer denied
+    Remove-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -ErrorAction SilentlyContinue
 } else {
     Write-Output "Registry path does not exist. No action needed."
 }

--- a/scripts/endpoints/devices/drivers/detect.ps1
+++ b/scripts/endpoints/devices/drivers/detect.ps1
@@ -1,4 +1,11 @@
-# Detect if the device model matches
+# Detect if the AMD Radeon driver block (DeviceInstallation policy) is applied
+#
+# Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
+# DeviceInstall_IDs_Deny): a REG value named "DenyDeviceIDs" directly under
+# HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions.
+# The OS policy engine never reads a "DenyDeviceIDs" subkey.
+# See https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation
+
 $DeviceModel = (Get-CimInstance -ClassName Win32_ComputerSystem).Model
 
 if ($DeviceModel -ne "21L8S0VP00") {
@@ -6,11 +13,18 @@ if ($DeviceModel -ne "21L8S0VP00") {
     Exit 0
 }
 
-# Check if the registry key exists
-$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceIDs"
+# Documented registry location
+$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions"
+$RegValueName = "DenyDeviceIDs"
 $RegValue = "PCIVEN_1002&DEV_1681"
 
-if ((Test-Path $RegPath) -and ((Get-ItemProperty -Path $RegPath).1 -eq $RegValue)) {
+# Read the DenyDeviceIDs value (REG_MULTI_SZ array, or a single REG_SZ string)
+$denyList = @()
+if (Test-Path $RegPath) {
+    $denyList = @((Get-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue).$RegValueName | Where-Object { $_ })
+}
+
+if ($denyList -contains $RegValue) {
     Write-Output "Driver block is already applied."
     Exit 0
 } else {

--- a/scripts/endpoints/devices/drivers/remediate.ps1
+++ b/scripts/endpoints/devices/drivers/remediate.ps1
@@ -1,3 +1,11 @@
+# Remediate: apply the AMD Radeon driver block (DeviceInstallation policy)
+#
+# Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
+# DeviceInstall_IDs_Deny): a REG value named "DenyDeviceIDs" directly under
+# HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions.
+# DenyDeviceIDsRetroactive (REG_DWORD 1) additionally blocks already-installed devices.
+# See https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation
+
 # Get the device model
 $DeviceModel = (Get-CimInstance -ClassName Win32_ComputerSystem).Model
 
@@ -6,17 +14,29 @@ if ($DeviceModel -ne "21L8S0VP00") {
     Exit 0
 }
 
-# Define the registry path and values
-$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceIDs"
+# Documented registry location
+$RegPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions"
+$RegValueName = "DenyDeviceIDs"
 $RegValue = "PCIVEN_1002&DEV_1681"
 
-# Ensure the registry key exists
+# Ensure the Restrictions key exists
 if (!(Test-Path $RegPath)) {
     New-Item -Path $RegPath -Force | Out-Null
 }
 
-# Apply the registry setting
-Set-ItemProperty -Path $RegPath -Name "1" -Value $RegValue -Type String -Force
+# Merge the hardware ID into the existing DenyDeviceIDs value (REG_MULTI_SZ)
+$denyList = @()
+$current = (Get-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue).$RegValueName
+if ($current) {
+    $denyList = @($current)
+}
+if ($denyList -notcontains $RegValue) {
+    $denyList += $RegValue
+    Set-ItemProperty -Path $RegPath -Name $RegValueName -Value $denyList -Type MultiString -Force
+}
+
+# Retroactive flag so already-installed devices are also blocked
+Set-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -Value 1 -Type DWord -Force
 
 Write-Output "AMD Radeon driver block policy applied."
 Exit 0

--- a/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.ps1
@@ -163,18 +163,22 @@ try {
         }
     }
 
-    # Check for thermal/overheating issues
-    $thermalEvents = Get-WinEvent -FilterHashtable @{
+    # Check for processor speed throttling by firmware (Event 37, Warning level)
+    # Documented provider is Microsoft-Windows-Kernel-Processor-Power, not Kernel-Power:
+    # "The speed of processor x in group y is being limited by system firmware".
+    # See https://learn.microsoft.com/en-us/troubleshoot/windows-server/setup-upgrade-and-drivers/event-id-37-windows-kernel-processor-power
+    $throttleEvents = Get-WinEvent -FilterHashtable @{
         LogName = 'System'
-        ProviderName = 'Microsoft-Windows-Kernel-Power'
-        ID = 37  # Thermal event
+        ProviderName = 'Microsoft-Windows-Kernel-Processor-Power'
+        ID = 37
+        Level = 3  # Warning
         StartTime = (Get-Date).AddDays(-$daysToCheck)
     } -MaxEvents 10 -ErrorAction SilentlyContinue
 
-    if ($thermalEvents) {
-        $thermalCount = $thermalEvents.Count
-        Write-Host "  Thermal/overheating events: $thermalCount"
-        $issues += "System overheating detected: $thermalCount thermal events"
+    if ($throttleEvents) {
+        $throttleCount = $throttleEvents.Count
+        Write-Host "  Processor speed limited by firmware: $throttleCount"
+        $issues += "Processor speed is being limited by system firmware: $throttleCount event(s) (Warning - check firmware power capping policy)"
     }
 
     # Check for PCI/PCIe errors

--- a/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/remediate.ps1
@@ -24,7 +24,7 @@ try {
     Write-Host "   ⚠ BACK UP ALL CRITICAL DATA IMMEDIATELY"
     Write-Host "   - Use cloud backup or external drive"
     Write-Host "   - Do not delay - disk can fail at any time"
-    Write-Host "   - Check SMART status: wmic diskdrive get status"
+    Write-Host "   - Check SMART status: Get-PhysicalDisk | Get-StorageReliabilityCounter"
     Write-Host "   - Prepare for disk replacement"
     Write-Host ""
     Write-Host "2. MEMORY (RAM) ERRORS"

--- a/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/detect.ps1
@@ -46,8 +46,14 @@ try {
                 }
             }
 
-            # Check if it's an Azure AD account (typically approved)
-            if ($member.PrincipalSource -eq "AzureAD") {
+            # Check if it's a cloud-directory account (typically approved).
+            # Documented PrincipalSource values are "Local", "Active Directory",
+            # "Microsoft Entra group", and "Microsoft Account" (see Get-LocalGroupMember
+            # docs); runtime values on some builds have historically been "AzureAD".
+            # Match case-insensitively against the legacy "AzureAD" value and the
+            # "Microsoft Entra ID"-era values; do not auto-approve Local/AD/MSA sources.
+            # See https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/get-localgroupmember?view=powershell-5.1
+            if ($member.PrincipalSource -match '^(?i)(AzureAD|Microsoft Entra group|Microsoft Entra ID)$') {
                 $isApproved = $true
             }
 

--- a/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/detect.ps1
@@ -3,19 +3,38 @@
     Checks page file configuration.
 
 .DESCRIPTION
-    Verifies that page file is properly configured (not disabled) and
-    sized appropriately for system memory.
+    Verifies that the page file is properly configured (not disabled) and, for
+    explicitly custom-configured page files, that the initial size is not below
+    a configurable floor.
+
+    Current guidance: page file sizing depends on the system crash dump setting
+    and the peak system commit charge, and "can't be generalized" - a fixed
+    "1.5x RAM" rule is a legacy rule of thumb that false-positives intentional
+    custom configurations. System-managed page files are always considered
+    compliant; custom page files are only flagged when their initial size is
+    below the -MinRatio floor (default 1.0x RAM).
+
+    See https://learn.microsoft.com/en-us/troubleshoot/windows-client/performance/how-to-determine-the-appropriate-page-file-size-for-64-bit-versions-of-windows
 
 .NOTES
     Author: Intune Admin
-    Version: 1.0
+    Version: 1.1
     Intune Context: SYSTEM
     Exit 0: Page file properly configured
     Exit 1: Issues detected
+
+.PARAMETER MinRatio
+    Minimum initial size of a custom-configured page file, as a ratio of
+    physical RAM (default: 1.0). Only applies to explicitly custom page files.
 #>
+
+param(
+    [double]$MinRatio = 1.0
+)
 
 try {
     $issues = @()
+    $notes = @()
 
     # Get page file configuration
     $pageFile = Get-WmiObject -Class Win32_PageFileSetting -ErrorAction SilentlyContinue
@@ -27,18 +46,19 @@ try {
             $issues += "Page file is disabled (not recommended)"
         }
     } else {
-        # Check page file size
+        # Explicitly configured (custom) page file - report as informational;
+        # only flag when the initial size is below the configurable ratio.
         $totalRAM = (Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory / 1GB
+        $recommendedMin = [math]::Ceiling($totalRAM * $MinRatio) * 1024  # Convert to MB
 
         foreach ($pf in $pageFile) {
             $initialSize = $pf.InitialSize
             $maximumSize = $pf.MaximumSize
 
-            # Page file should be at least 1.5x RAM (minimum recommendation)
-            $recommendedMin = [math]::Ceiling($totalRAM * 1.5) * 1024  # Convert to MB
+            $notes += "Custom page file configured (initial $initialSize MB, maximum $maximumSize MB) - sizing can't be generalized, informational only"
 
             if ($initialSize -lt $recommendedMin) {
-                $issues += "Page file initial size ($initialSize MB) is smaller than recommended ($recommendedMin MB)"
+                $issues += "Custom page file initial size ($initialSize MB) is below the configured minimum ($recommendedMin MB at ${MinRatio}x RAM)"
             }
         }
     }
@@ -60,6 +80,10 @@ try {
             Write-Host "  - $issue"
         }
         exit 1
+    }
+
+    foreach ($note in $notes) {
+        Write-Host "  - $note"
     }
 
     Write-Host "Page file is properly configured"

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/remediate.ps1
@@ -22,7 +22,7 @@ try {
     Write-Host ""
     Write-Host "1. Disk errors (Event IDs 7, 11, 51, 153, 55)"
     Write-Host "   - Run: chkdsk /f /r (requires reboot)"
-    Write-Host "   - Check SMART status: wmic diskdrive get status"
+    Write-Host "   - Check SMART status: Get-PhysicalDisk | Get-StorageReliabilityCounter"
     Write-Host "   - Back up critical data immediately"
     Write-Host "   - Consider disk replacement if errors persist"
     Write-Host ""

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/detect.ps1
@@ -3,108 +3,56 @@
     Checks Windows Reliability Monitor stability index score.
 
 .DESCRIPTION
-    Uses Windows Reliability Monitor (RAC) to calculate system stability index.
-    The stability index ranges from 1 (least stable) to 10 (most stable) and
-    provides a quantifiable health metric for reporting.
+    Uses the documented Reliability Analysis Component (RAC) metric
+    Win32_ReliabilityStabilityMetrics.SystemStabilityIndex (namespace
+    root\cimv2, RacWmiProv provider). The stability index ranges from 1
+    (least stable) to 10 (most stable) and provides a quantifiable health
+    metric for reporting.
+
+    If RAC data is unavailable (for example the "Configure Reliability WMI
+    Providers" policy is disabled, which is the default on Windows Server),
+    the check reports that no index can be calculated and exits compliant.
 
 .NOTES
     Author: Intune Admin
-    Version: 1.0
+    Version: 1.1
     Intune Context: SYSTEM
     Exit 0: System stability is acceptable
     Exit 1: Low stability index detected
 
 .CONFIGURATION
     $minStabilityIndex: Minimum acceptable stability score (default: 5.0)
-    $daysToAnalyze: Days of history to analyze (default: 7)
 #>
 
 try {
     # Configuration
     $minStabilityIndex = 5.0
-    $daysToAnalyze = 7
 
     $issues = @()
 
     Write-Host "Analyzing Windows Reliability Monitor data..."
 
-    # Query Reliability Monitor WMI data
-    $stabilityData = Get-CimInstance -Namespace "root\WMI" -ClassName "MSAcpi_ThermalZoneTemperature" -ErrorAction SilentlyContinue
+    # Documented RAC metric (Win32_ReliabilityStabilityMetrics, root\cimv2).
+    # See https://learn.microsoft.com/en-us/previous-versions/windows/desktop/racwmiprov/win32-reliabilitystabilitymetrics
+    $stabilityData = Get-CimInstance -Namespace "root\cimv2" -ClassName "Win32_ReliabilityStabilityMetrics" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
 
-    # Use Performance Counter for Reliability data
-    $reliabilityMetrics = @{
-        ApplicationFailures = 0
-        WindowsFailures = 0
-        MiscFailures = 0
-        Warnings = 0
-        InformationalEvents = 0
+    if (-not $stabilityData) {
+        # RAC data unavailable - report and exit compliant instead of fabricating a score.
+        Write-Host "Reliability Monitor (RAC) stability data is not available on this system."
+        Write-Host "No stability index can be calculated - treating as compliant."
+        exit 0
     }
 
-    # Count reliability events from last N days
-    $startTime = (Get-Date).AddDays(-$daysToAnalyze)
+    $stabilityIndex = [double]$stabilityData.SystemStabilityIndex
 
-    # Application crashes
-    $appCrashes = Get-WinEvent -FilterHashtable @{
-        LogName = 'Application'
-        Level = 2
-        StartTime = $startTime
-    } -MaxEvents 100 -ErrorAction SilentlyContinue
-
-    if ($appCrashes) {
-        $reliabilityMetrics.ApplicationFailures = $appCrashes.Count
-    }
-
-    # Windows failures
-    $windowsFailures = Get-WinEvent -FilterHashtable @{
-        LogName = 'System'
-        Level = 2
-        StartTime = $startTime
-    } -MaxEvents 100 -ErrorAction SilentlyContinue
-
-    if ($windowsFailures) {
-        $reliabilityMetrics.WindowsFailures = $windowsFailures.Count
-    }
-
-    # Warnings
-    $warnings = Get-WinEvent -FilterHashtable @{
-        LogName = 'System', 'Application'
-        Level = 3
-        StartTime = $startTime
-    } -MaxEvents 200 -ErrorAction SilentlyContinue
-
-    if ($warnings) {
-        $reliabilityMetrics.Warnings = $warnings.Count
-    }
-
-    # Calculate simplified stability index (0-10 scale)
-    # Based on frequency of errors and warnings
-    $baseScore = 10.0
-
-    # Deduct points for failures
-    $baseScore -= ([Math]::Min($reliabilityMetrics.ApplicationFailures / 10, 3))
-    $baseScore -= ([Math]::Min($reliabilityMetrics.WindowsFailures / 5, 3))
-    $baseScore -= ([Math]::Min($reliabilityMetrics.Warnings / 50, 2))
-
-    $stabilityIndex = [Math]::Max([Math]::Round($baseScore, 1), 1.0)
-
-    Write-Host "System Stability Analysis (Last $daysToAnalyze days):"
+    Write-Host "System Stability (Reliability Monitor):"
     Write-Host "  Stability Index: $stabilityIndex / 10.0"
-    Write-Host "  Application Failures: $($reliabilityMetrics.ApplicationFailures)"
-    Write-Host "  Windows Failures: $($reliabilityMetrics.WindowsFailures)"
-    Write-Host "  Warnings: $($reliabilityMetrics.Warnings)"
+    Write-Host "  Measurement period: $($stabilityData.StartMeasurementDate) to $($stabilityData.EndMeasurementDate)"
 
     if ($stabilityIndex -lt $minStabilityIndex) {
         $issues += "System stability index is $stabilityIndex (threshold: $minStabilityIndex)"
         $issues += "Frequent failures indicate system instability"
-    }
-
-    # Check for critical reliability events
-    if ($reliabilityMetrics.ApplicationFailures -gt 20) {
-        $issues += "Excessive application crashes detected ($($reliabilityMetrics.ApplicationFailures) events)"
-    }
-
-    if ($reliabilityMetrics.WindowsFailures -gt 10) {
-        $issues += "Frequent Windows component failures ($($reliabilityMetrics.WindowsFailures) events)"
     }
 
     if ($issues.Count -gt 0) {

--- a/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/detect.ps1
@@ -42,10 +42,9 @@ try {
         $issues += "TPM is not ready for use"
     }
 
-    # Check TPM ownership (for BitLocker)
-    if ($tpm.TpmOwned -eq $false) {
-        $issues += "TPM is not owned (required for BitLocker)"
-    }
+    # TPM ownership is intentionally NOT checked: since Windows 10 version 1607, Windows
+    # automatically initializes and takes ownership of the TPM, so TpmOwned=$false is not a
+    # failure. See https://learn.microsoft.com/en-us/windows/security/hardware-security/tpm/initialize-and-configure-ownership-of-the-tpm
 
     # Check TPM version (TPM 2.0 is preferred)
     $tpmVersion = (Get-WmiObject -Namespace "root\cimv2\Security\MicrosoftTpm" -Class Win32_Tpm -ErrorAction SilentlyContinue).SpecVersion

--- a/scripts/endpoints/devices/proactive-remediations/keyboard-layout/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/keyboard-layout/detect.ps1
@@ -1,10 +1,14 @@
-# Detect if UK keyboard layout is the primary input method
+# Detect if a UK keyboard layout is the primary input method
 # Exit 0 if compliant, Exit 1 if non-compliant
+#
+# Keyboard layout identifiers (Microsoft keyboard reference):
+#   00000809 = United Kingdom (standard)   https://learn.microsoft.com/en-us/globalization/keyboards/kbduk
+#   00000452 = United Kingdom Extended     https://learn.microsoft.com/en-us/globalization/keyboards/kbdukx
 
 $ErrorActionPreference = 'Stop'
 
-# Required keyboard layout
-$requiredLayout = '00000809'  # United Kingdom Extended
+# Required keyboard layouts (either standard UK or UK Extended is compliant)
+$requiredLayouts = @('00000809', '00000452')
 
 try {
     # Get current input language list
@@ -14,9 +18,9 @@ try {
     $primaryLanguage = $languageList[0]
     $primaryInputMethod = $primaryLanguage.InputMethodTips[0]
 
-    # Expected formats: "0809:00000809" for UK keyboard
-    if ($primaryInputMethod -notlike "*00000809*") {
-        Write-Host "Non-compliant: Primary keyboard is $primaryInputMethod (expected UK: 00000809)"
+    # Expected formats: "0809:00000809" for standard UK, "0809:00000452" for UK Extended
+    if ($primaryInputMethod -notmatch '00000809|00000452') {
+        Write-Host "Non-compliant: Primary keyboard is $primaryInputMethod (expected UK: 00000809 or UK Extended: 00000452)"
         exit 1
     }
 

--- a/scripts/endpoints/devices/proactive-remediations/keyboard-layout/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/keyboard-layout/remediate.ps1
@@ -1,5 +1,9 @@
 # Remediate keyboard layout to UK English
 # Exit 0 if successful, Exit 1 if failed
+#
+# Keyboard layout identifiers (Microsoft keyboard reference):
+#   00000809 = United Kingdom (standard)   https://learn.microsoft.com/en-us/globalization/keyboards/kbduk
+#   00000452 = United Kingdom Extended     https://learn.microsoft.com/en-us/globalization/keyboards/kbdukx
 
 $ErrorActionPreference = 'Stop'
 
@@ -21,9 +25,12 @@ try {
         $ukLanguage = $languageList | Where-Object { $_.LanguageTag -eq 'en-GB' }
     }
 
-    # Ensure UK keyboard layout is set
+    # Ensure UK keyboard layouts are set:
+    #   0809:00000809 = United Kingdom (standard) - kept as the standard-UK path
+    #   0809:00000452 = United Kingdom Extended
     $ukLanguage.InputMethodTips.Clear()
-    $ukLanguage.InputMethodTips.Add('0809:00000809')  # UK Extended keyboard
+    $ukLanguage.InputMethodTips.Add('0809:00000809')  # UK (standard) keyboard
+    $ukLanguage.InputMethodTips.Add('0809:00000452')  # UK Extended keyboard
 
     # Move en-GB to the first position
     $newLanguageList = New-Object System.Collections.Generic.List[Microsoft.InternationalSettings.Commands.WinUserLanguage]

--- a/scripts/endpoints/devices/proactive-remediations/language-pack-audit/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/language-pack-audit/detect.ps1
@@ -1,5 +1,10 @@
 # Detect unnecessary language packs installed on the system
 # Exit 0 if only essential language packs are installed, Exit 1 if unnecessary packs found
+#
+# NOTE: installed OS language packs are system components managed via DISM
+# (Get-WindowsPackage / Dism /Online /Get-Packages). Get-WinUserLanguageList
+# manages the per-user language list and is NOT used here.
+# See https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/hh825679(v=win.10)
 
 $ErrorActionPreference = 'Stop'
 
@@ -7,17 +12,27 @@ $ErrorActionPreference = 'Stop'
 $allowedLanguages = @('en-GB', 'en-US')  # en-US is Windows default, often required
 
 try {
-    # Get installed language packs
-    $installedLanguages = Get-WinUserLanguageList
+    # Enumerate installed OS language packs via DISM (requires elevation; Intune runs as SYSTEM)
+    $languagePacks = Get-WindowsPackage -Online -ErrorAction Stop |
+        Where-Object { $_.PackageName -match 'LanguagePack' }
+
+    if (-not $languagePacks) {
+        Write-Host "No installed language packs found via DISM"
+        exit 0
+    }
+
+    # Extract the language tag from each package name, e.g.
+    # Microsoft-Windows-Client-LanguagePack-Package~31bf3856ad364e35~amd64~~en-GB~10.0.19041.1
+    $installedLanguages = @($languagePacks | ForEach-Object {
+        if ($_.PackageName -match '~([a-zA-Z]{2}-[a-zA-Z]{2})~') {
+            $Matches[1]
+        }
+    } | Sort-Object -Unique)
+
+    Write-Host "Installed language packs: $($installedLanguages -join ', ')"
 
     # Check for non-allowed languages
-    $unnecessaryLanguages = @()
-
-    foreach ($lang in $installedLanguages) {
-        if ($lang.LanguageTag -notin $allowedLanguages) {
-            $unnecessaryLanguages += $lang.LanguageTag
-        }
-    }
+    $unnecessaryLanguages = @($installedLanguages | Where-Object { $_ -notin $allowedLanguages })
 
     if ($unnecessaryLanguages.Count -gt 0) {
         Write-Host "Unnecessary language packs found: $($unnecessaryLanguages -join ', ')"

--- a/scripts/endpoints/devices/proactive-remediations/language-pack-audit/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/language-pack-audit/remediate.ps1
@@ -1,5 +1,15 @@
-# Remediate by removing unnecessary language packs
+# Remediate by removing unnecessary language packs via DISM
 # Exit 0 if successful, Exit 1 if failed
+#
+# NOTE: installed OS language packs are system components removed with
+# Remove-WindowsPackage / Dism /Online /Remove-Package. Get/Set-WinUserLanguageList
+# manage the per-user language list and are NOT touched by this script.
+# See https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/hh825679(v=win.10)
+
+#Requires -RunAsAdministrator
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param()
 
 $ErrorActionPreference = 'Stop'
 
@@ -7,44 +17,42 @@ $ErrorActionPreference = 'Stop'
 $allowedLanguages = @('en-GB', 'en-US')
 
 try {
-    # Get current language list
-    $currentLanguages = Get-WinUserLanguageList
-
-    # Create new list with only allowed languages
-    $newLanguageList = New-Object System.Collections.Generic.List[Microsoft.InternationalSettings.Commands.WinUserLanguage]
-
-    # Ensure en-GB is first
-    $ukLanguage = $currentLanguages | Where-Object { $_.LanguageTag -eq 'en-GB' }
-    if ($ukLanguage) {
-        $newLanguageList.Add($ukLanguage)
-    }
-    else {
-        # Add en-GB if it doesn't exist
-        Write-Host "Adding en-GB..."
-        $lang = New-WinUserLanguageList -Language 'en-GB'
-        $newLanguageList.Add($lang[0])
+    # Admin check (belt-and-braces; #Requires also enforces it)
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Host "Administrator privileges are required to remove language packs"
+        exit 1
     }
 
-    # Add en-US if it exists (often required for Windows)
-    $usLanguage = $currentLanguages | Where-Object { $_.LanguageTag -eq 'en-US' }
-    if ($usLanguage) {
-        $newLanguageList.Add($usLanguage)
-    }
+    # Enumerate installed OS language packs via DISM
+    $languagePacks = Get-WindowsPackage -Online -ErrorAction Stop |
+        Where-Object { $_.PackageName -match 'LanguagePack' }
 
-    # Count removed languages
-    $removedCount = $currentLanguages.Count - $newLanguageList.Count
+    $removedCount = 0
     $removed = @()
 
-    foreach ($lang in $currentLanguages) {
-        if ($lang.LanguageTag -notin $allowedLanguages) {
-            $removed += $lang.LanguageTag
+    foreach ($package in $languagePacks) {
+        if ($package.PackageName -match '~([a-zA-Z]{2}-[a-zA-Z]{2})~') {
+            $lang = $Matches[1]
+            if ($lang -notin $allowedLanguages) {
+                Write-Host "Removing language pack $lang ($($package.PackageName))..."
+                # -WhatIf-safe: Remove-WindowsPackage honours -WhatIf from SupportsShouldProcess
+                Remove-WindowsPackage -Online -PackageName $package.PackageName -NoRestart -WhatIf:$WhatIfPreference -ErrorAction Stop
+                if (-not $WhatIfPreference) {
+                    $removed += $lang
+                    $removedCount++
+                }
+            }
         }
     }
 
+    if ($WhatIfPreference) {
+        Write-Host "WhatIf: $removedCount language pack(s) would be removed ($($removed -join ', '))"
+        exit 0
+    }
+
     if ($removedCount -gt 0) {
-        Write-Host "Removing unnecessary language packs: $($removed -join ', ')"
-        Set-WinUserLanguageList -LanguageList $newLanguageList -Force
-        Write-Host "Removed $removedCount language pack(s). Sign out required for full effect."
+        Write-Host "Removed $removedCount unnecessary language pack(s): $($removed -join ', ')"
         exit 0
     }
     else {

--- a/scripts/endpoints/devices/sccm/detect.ps1
+++ b/scripts/endpoints/devices/sccm/detect.ps1
@@ -1,14 +1,23 @@
 # Detection script for SCCM
+#
+# The installed SCCM client is the SMS Agent Host (CcmExec) service. The
+# ccmsetup folder (%windir%\ccmsetup) holds setup/bootstrap files and can
+# exist after a failed install, so it is NOT a reliable indicator.
+# See https://learn.microsoft.com/en-us/mem/configmgr/core/clients/deploy/about-client-installation-properties
 
-# Define the path to ccmsetup.exe
-$ccmSetupPath = "$env:windir\ccmsetup\ccmsetup.exe"
+# Check for the SMS Agent Host service (running)
+$ccmService = Get-Service -Name "CcmExec" -ErrorAction SilentlyContinue
 
-# Check if ccmsetup.exe exists
-if (Test-Path $ccmSetupPath) {
+if ($ccmService -and $ccmService.Status -eq "Running") {
     Write-Output " SCCM client is installed."
     Exit 0
 }
-else {
-    Write-Output " SCCM client is NOT installed."
-    Exit 1
+
+# Fallback: check for the installed client's data folder
+if (Test-Path "C:\Windows\CCM\ServiceData") {
+    Write-Output " SCCM client is installed."
+    Exit 0
 }
+
+Write-Output " SCCM client is NOT installed."
+Exit 1

--- a/scripts/endpoints/devices/uptime/detect.ps1
+++ b/scripts/endpoints/devices/uptime/detect.ps1
@@ -1,15 +1,19 @@
-# Detection Script - Check if machine has been on for 4 or more days
+# Detection Script - Check if machine has not been restarted for 4 or more days
+# NOTE: OSUptime derives from Win32_OperatingSystem.LastBootUpTime, i.e. time since the
+# OS was last restarted. Sleep/hibernate time does not count, so this measures "time since
+# last restart", not cumulative time powered on.
+# See https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-operatingsystem
 
 try {
     $Uptime = (Get-ComputerInfo).OSUptime
     $UptimeDays = [math]::Floor($Uptime.TotalDays)
     
     if ($UptimeDays -ge 4) {
-        Write-Output "Device has been on for $UptimeDays days. Needs restart."
+        Write-Output "Device has not been restarted in $UptimeDays days. Needs restart."
         Exit 1 # Non-compliant (trigger remediation)
     }
     else {
-        Write-Output "Device has only been on for $UptimeDays days. No action needed."
+        Write-Output "Device has been restarted within the last $UptimeDays days. No action needed."
         Exit 0 # Compliant (no remediation)
     }
 }

--- a/scripts/endpoints/devices/uptime/remediate.ps1
+++ b/scripts/endpoints/devices/uptime/remediate.ps1
@@ -72,15 +72,17 @@ else {
     Write-Log "Logo image already exists: $LogoImage"
 }
 
-# Get system uptime for notification text
-try {
-    $Uptime = (Get-ComputerInfo).OSUptime
-    $UptimeDays = [math]::Floor($Uptime.TotalDays)
-}
-catch {
-    Write-Log "Failed to get uptime: $_"
-    $UptimeDays = "unknown"
-}
+    # Get time since last restart for notification text
+    # NOTE: OSUptime derives from Win32_OperatingSystem.LastBootUpTime (time since the OS
+    # was last restarted); sleep/hibernate time does not count.
+    try {
+        $Uptime = (Get-ComputerInfo).OSUptime
+        $UptimeDays = [math]::Floor($Uptime.TotalDays)
+    }
+    catch {
+        Write-Log "Failed to get uptime: $_"
+        $UptimeDays = "unknown"
+    }
 
 # Show toast notification with buttons
 try {
@@ -92,7 +94,7 @@ try {
 
     # Show toast with buttons
     New-BurntToastNotification `
-        -Text "Restart Required", "Your device has been running for $UptimeDays days.", "Restart for better performance and security." `
+        -Text "Restart Required", "Your device has not been restarted in $UptimeDays days.", "Restart for better performance and security." `
         -AppLogo $LogoImage `
         -Button $btnRestart, $btnRemind
 


### PR DESCRIPTION
Closes #137
Closes #138
Closes #163
Closes #178
Closes #179
Closes #180
Closes #181
Closes #190
Closes #193
Closes #199
Closes #202
Closes #203
Closes #204
Closes #211
Closes #212

Fixes from the 2026-08-08 Microsoft Learn alignment review (MSLEARN-REVIEW.md).

## Summary by Sourcery

Align multiple device remediation scripts with current Microsoft guidance for stability monitoring, paging, BitLocker key escrow, language/keyboard configuration, hardware error checks, SCCM detection, and Windows Update Autopatch policies.

Bug Fixes:
- Use the documented RAC WMI provider to read SystemStabilityIndex and treat missing RAC data as compliant instead of fabricating a score.
- Update page file checks to follow current sizing guidance, only flag disabled or undersized custom page files, and expose a configurable minimum ratio.
- Ensure BitLocker key escrow to Azure AD reports failure via non-zero exit when any protector backup fails.
- Audit and remove OS language packs using DISM rather than per-user language lists, and add an elevation check in remediation.
- Treat either standard UK or UK Extended keyboard layouts as compliant and configure both for en-GB during remediation.
- Correct hardware error detection to use Kernel-Processor-Power Event 37 (firmware throttling) instead of Kernel-Power thermal events and update SMART guidance to modern PowerShell cmdlets.
- Clarify uptime checks and notifications to reflect time since last restart rather than generic runtime.
- Detect SCCM client presence via the CcmExec service or CCM data folder instead of the ccmsetup setup directory.
- Adjust TPM health checks to stop flagging non-owned TPMs as failures on modern Windows versions.
- Fix Windows Update Autopatch scripts to manage the supported NoAutoUpdate WUaaS policy and correct UseWUServer paths instead of using unsupported DisableWindowsUpdateAccess.
- Make local admin membership checks robust against both legacy "AzureAD" and newer "Microsoft Entra" PrincipalSource values.
- Implement correct DeviceInstall driver deny-list layout using the documented DenyDeviceIDs value and retroactive flag, and ensure unblock scripts cleanly remove the AMD hardware ID and retroactive setting.

Enhancements:
- Add documentation and versioned comments across remediations to reference relevant Microsoft Learn articles and clarify policy rationale.
- Extend keyboard remediation to configure both standard UK and UK Extended layouts for en-GB.
- Add Autopatch README describing the August 2026 policy change and the shift from DisableWindowsUpdateAccess to NoAutoUpdate across versions V1–V5.

Documentation:
- Introduce an Autopatch remediation README explaining supported Windows Update policies on Windows 10+ and Server 2016+, and the updated handling of NoAutoUpdate vs DisableWindowsUpdateAccess.