### PR TITLE
fix: winget module-first migration, --exact matching, exit-code-based success

### DIFF
--- a/scripts/endpoints/devices/winget/_templates/detect.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect.ps1
@@ -4,6 +4,47 @@ $name = 'APPNAME'
 $ID = 'WINGETID'
 #Name of the running process (so you don't force close it)
 $AppProcess = "PROCESS"
+
+# Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+# the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+# winget.exe CLI when the module is unavailable.
+# Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+    try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+    if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+        $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        #check if there's an available update
+        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        if ($package.IsUpdateAvailable -and $process -ne $null) {
+            $verinstalled = $package.InstalledVersion
+            $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+            Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            [pscustomobject] @{
+                Name = $Name
+                InstalledVersion = $verInstalled
+                AvailableVersion = $verAvailable
+            }
+            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            exit 1
+        }
+        if ($package.IsUpdateAvailable -and $process -eq $null) {
+            $verinstalled = $package.InstalledVersion
+            $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+            Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            [pscustomobject] @{
+                Name = $Name
+                InstalledVersion = $verInstalled
+                AvailableVersion = $verAvailable
+            }
+            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            exit 1
+        }
+        Write-Host "$name upgraded to $($package.InstalledVersion), or $name was already up to date."
+        exit 0
+    }
+}
+
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
     if ($wingetexe){
@@ -12,7 +53,7 @@ $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInst
 #create the sysget alias so winget can be ran as system
 new-alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 try {
 $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
 #check if there's an available update
@@ -44,7 +85,7 @@ if ($lines -eq "No installed package found matching input criteria.") {write-hos
 exit 0
 }else{
 #rechecks the version if it installed and creates values for final output.
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 if ($Lines -match '\d+(\.\d+)+') {
 $versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
 }

--- a/scripts/endpoints/devices/winget/_templates/detect_v1_legacy.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v1_legacy.ps1
@@ -4,6 +4,47 @@ $name = 'APPNAME'
 $ID = 'WINGETID'
 #Name of the running process (so you don't force close it)
 $AppProcess = "PROCESS"
+
+# Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+# the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+# winget.exe CLI when the module is unavailable.
+# Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+    try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+    if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+        $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        #check if there's an available update
+        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        if ($package.IsUpdateAvailable -and $process -ne $null) {
+            $verinstalled = $package.InstalledVersion
+            $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+            Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            [pscustomobject] @{
+                Name = $Name
+                InstalledVersion = $verInstalled
+                AvailableVersion = $verAvailable
+            }
+            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            exit 1
+        }
+        if ($package.IsUpdateAvailable -and $process -eq $null) {
+            $verinstalled = $package.InstalledVersion
+            $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+            Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            [pscustomobject] @{
+                Name = $Name
+                InstalledVersion = $verInstalled
+                AvailableVersion = $verAvailable
+            }
+            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            exit 1
+        }
+        Write-Host "$name upgraded to $($package.InstalledVersion), or $name was already up to date."
+        exit 0
+    }
+}
+
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
     if ($wingetexe){
@@ -12,7 +53,7 @@ $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInst
 #create the sysget alias so winget can be ran as system
 new-alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 try {
 $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
 #check if there's an available update
@@ -44,7 +85,7 @@ if ($lines -eq "No installed package found matching input criteria.") {write-hos
 exit 0
 }else{
 #rechecks the version if it installed and creates values for final output.
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 if ($Lines -match '\d+(\.\d+)+') {
 $versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
 }

--- a/scripts/endpoints/devices/winget/_templates/detect_v2.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v2.ps1
@@ -6,6 +6,9 @@
     This template checks if an app update is available via winget.
     Returns exit code 1 if update is available (triggers remediation).
     Returns exit code 0 if app is up to date or not installed (no action needed).
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name.
@@ -31,13 +34,58 @@ $name = $null     # Leave as $null to auto-detect from winget, or set manually: 
 
 #region Script - DO NOT MODIFY BELOW THIS LINE
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                }
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Host "$name is already up to date (version $versionInstalled)"
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                }
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
     # Locate winget executable
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $SystemContext = $wingetexe[-1].Path
     New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information
-    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+    # Get package information (exact ID match)
+    $packageInfo = sysget list --exact --id $ID --accept-source-agreements 2>$null
 
     # Auto-detect name if not provided
     if (-not $name) {

--- a/scripts/endpoints/devices/winget/_templates/detect_v3.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v3.ps1
@@ -3,7 +3,10 @@
     Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    This template checks if an app update is available via winget with enhanced features:
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
     - Retry logic with exponential backoff
     - Better error handling and logging
     - Network connectivity validation
@@ -20,14 +23,15 @@
     - Optional logging to file or event log
     - Network connectivity checks before querying winget
     - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .CONFIGURATION
     1. Set the $ID variable to your winget package ID
     2. (Optional) Customize retry, logging, and other advanced settings
 
 .EXAMPLE
-    # For Microsoft Teams:
-    $ID = 'Microsoft.Teams'
+    # For your application:
+    $ID = 'WINGETID'
 
     # Enable logging:
     $EnableLogging = $true
@@ -98,7 +102,7 @@ function Invoke-WingetWithRetry {
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
@@ -116,15 +120,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
 
-            if ($stdout -and -not ($stdout -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
                 return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -156,6 +169,65 @@ try {
         Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
     Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
@@ -170,9 +242,9 @@ try {
 
     New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information with retry logic
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {

--- a/scripts/endpoints/devices/winget/_templates/remediate.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate.ps1
@@ -4,6 +4,38 @@ $name = 'APPNAME'
 $ID = 'WINGETID'
 #Name of the running process (so you don't force close it)
 $AppProcess = "PROCESS"
+
+# Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+# the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+# winget.exe CLI when the module is unavailable.
+# Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+    try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+    if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+        $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        if ($process -eq $null) {
+            #run the upgrade
+            Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+            #rechecks the version if it installed and creates values for final output.
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if ($package) {
+                $versioninstalled = $package.InstalledVersion
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $VersionInstalled
+                }
+                Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
+                exit 0
+            }
+        } else {
+            write-host "$Name is currently running, will try again later."
+            exit 1
+        }
+    }
+}
+
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
     if ($wingetexe){
@@ -12,7 +44,7 @@ $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInst
 #create the sysget alias so winget can be ran as system
 new-alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 #tries to upgrade if the installed version is lower than the available version
 try {
 if ($lines -match '\bVersion\s+Available\b') {
@@ -26,7 +58,7 @@ if ($process -eq $null){
 #run the upgrade
 sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
 #rechecks the version if it installed and creates values for final output.
-$lines = sysget list --accept-source-agreements --Id $ID } else {write-host "$Name is currently running, will try again later."
+$lines = sysget list --exact --id $ID --accept-source-agreements } else {write-host "$Name is currently running, will try again later."
 exit 1
 }
 if ($Lines -match '\d+(\.\d+)+') {

--- a/scripts/endpoints/devices/winget/_templates/remediate_v1_legacy.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v1_legacy.ps1
@@ -4,6 +4,38 @@ $name = 'APPNAME'
 $ID = 'WINGETID'
 #Name of the running process (so you don't force close it)
 $AppProcess = "PROCESS"
+
+# Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+# the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+# winget.exe CLI when the module is unavailable.
+# Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+    try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+    if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+        $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        if ($process -eq $null) {
+            #run the upgrade
+            Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+            #rechecks the version if it installed and creates values for final output.
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if ($package) {
+                $versioninstalled = $package.InstalledVersion
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $VersionInstalled
+                }
+                Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
+                exit 0
+            }
+        } else {
+            write-host "$Name is currently running, will try again later."
+            exit 1
+        }
+    }
+}
+
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
     if ($wingetexe){
@@ -12,7 +44,7 @@ $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInst
 #create the sysget alias so winget can be ran as system
 new-alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
-$lines = sysget list --accept-source-agreements --Id $ID
+$lines = sysget list --exact --id $ID --accept-source-agreements
 #tries to upgrade if the installed version is lower than the available version
 try {
 if ($lines -match '\bVersion\s+Available\b') {
@@ -26,7 +58,7 @@ if ($process -eq $null){
 #run the upgrade
 sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
 #rechecks the version if it installed and creates values for final output.
-$lines = sysget list --accept-source-agreements --Id $ID } else {write-host "$Name is currently running, will try again later."
+$lines = sysget list --exact --id $ID --accept-source-agreements } else {write-host "$Name is currently running, will try again later."
 exit 1
 }
 if ($Lines -match '\d+(\.\d+)+') {

--- a/scripts/endpoints/devices/winget/_templates/remediate_v2_force_close.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v2_force_close.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will forcefully close the app before updating.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -40,13 +43,102 @@ $VerifyWaitSeconds = 10         # Time to wait after update to verify installati
 
 #region Script - DO NOT MODIFY BELOW THIS LINE
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                # Extract process name from package ID (e.g., 'TeamViewer.TeamViewer' -> 'TeamViewer')
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and force close if needed
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Host "$name is running. Force closing application..."
+                Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds $GracePeriodSeconds
+
+                # Verify process was closed
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Warning "$name process still running after force close attempt. Retrying..."
+                    Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                    Start-Sleep -Seconds 2
+                }
+                Write-Host "$name closed successfully."
+            } else {
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Update available for $name : $verInstalled -> $verAvailable"
+
+                # Perform upgrade via the module
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Verify installation
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Host "$name updated successfully to version $versionInstalled"
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+                    exit 0
+                } else {
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Host "$name is already up to date (version $versionInstalled)"
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
     # Locate winget executable
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $SystemContext = $wingetexe[-1].Path
     New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information
-    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+    # Get package information (exact ID match)
+    $packageInfo = sysget list --exact --id $ID --accept-source-agreements 2>$null
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -102,7 +194,7 @@ try {
         Start-Sleep -Seconds $VerifyWaitSeconds
 
         # Verify installation
-        $verifyInfo = sysget list --accept-source-agreements --Id $ID
+        $verifyInfo = sysget list --exact --id $ID --accept-source-agreements
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]
             Write-Host "$name updated successfully to version $versionInstalled"

--- a/scripts/endpoints/devices/winget/_templates/remediate_v2_standard.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v2_standard.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will skip the update and retry later.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -34,13 +37,90 @@ $AppProcess = $null     # Leave as $null to auto-detect, or set manually: 'chrom
 
 #region Script - DO NOT MODIFY BELOW THIS LINE
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Verbose -Verbose "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                # Auto-detect process name if not provided
+                if (-not $AppProcess) {
+                    # Extract process name from package ID (e.g., 'Google.Chrome' -> 'chrome')
+                    $AppProcess = ($ID -split '\.')[-1]
+                }
+
+                # Check if app is running
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running. Will try again later."
+                    [pscustomobject] @{
+                        Name = $name
+                        InstalledVersion = $verInstalled
+                        AvailableVersion = $verAvailable
+                        Status = "Skipped - App Running"
+                    }
+                    exit 1
+                }
+
+                # Perform upgrade via the module
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Verify installation
+                Start-Sleep -Seconds 5
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Host "$name updated successfully to version $versionInstalled"
+                    [pscustomobject] @{
+                        Name = $name
+                        InstalledVersion = $versionInstalled
+                        Status = "Updated Successfully"
+                    }
+                    exit 0
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Host "$name is already up to date (version $versionInstalled)"
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
     # Locate winget executable
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $SystemContext = $wingetexe[-1].Path
     New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information
-    $packageInfo = sysget list --accept-source-agreements --Id $ID 2>$null
+    # Get package information (exact ID match)
+    $packageInfo = sysget list --exact --id $ID --accept-source-agreements 2>$null
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -88,7 +168,7 @@ try {
 
         # Verify installation
         Start-Sleep -Seconds 5
-        $verifyInfo = sysget list --accept-source-agreements --Id $ID
+        $verifyInfo = sysget list --exact --id $ID --accept-source-agreements
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]
             Write-Host "$name updated successfully to version $versionInstalled"

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_force_close.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_force_close.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will optionally notify the user before forcefully closing the app.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
     V3 ENHANCEMENTS:
     - Optional user notification before force closing
@@ -12,6 +15,7 @@
     - Better error handling and logging
     - Configurable grace periods
     - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -23,8 +27,8 @@
     3. (Optional) Enable logging for troubleshooting
 
 .EXAMPLE
-    # For TeamViewer with user notification:
-    $ID = 'TeamViewer.TeamViewer'
+    # For your application with user notification:
+    $ID = 'WINGETID'
     $NotifyUserBeforeClose = $true
     $UserNotificationSeconds = 30
 #>
@@ -148,14 +152,14 @@ function Invoke-WingetWithRetry {
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
-            
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -166,21 +170,32 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
 
-            if ($stdout -and -not ($stdout -match "error|failed|exception")) {
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
                 return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
         if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -194,7 +209,143 @@ function Invoke-WingetWithRetry {
 try {
     Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and handle accordingly
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+                # Send user notification if enabled
+                if ($NotifyUserBeforeClose) {
+                    Write-Log "Sending user notification before closing $name..." -Level Info
+                    Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+                    Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+                    Start-Sleep -Seconds $UserNotificationSeconds
+                }
+
+                # Force close the application
+                Write-Host "$name is running. Force closing application..."
+                $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+                if (-not $closedSuccessfully) {
+                    Write-Log "Failed to close $name process. Aborting update." -Level Error
+                    Write-Error "Failed to close $name process. Cannot proceed with update."
+                    exit 1
+                }
+
+                Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+                Start-Sleep -Seconds $GracePeriodSeconds
+            } else {
+                Write-Log "$name is not currently running." -Level Info
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
 
     if ($wingetexe.Count -gt 1) {
@@ -206,8 +357,8 @@ try {
     New-Alias -Name sysget -Value "$SystemContext" -Force
     Write-Log "Found winget: $SystemContext" -Level Info
 
-    # Get package information
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -298,7 +449,7 @@ try {
 
         # Verify installation
         Write-Log "Verifying installation..." -Level Info
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_maintenance_window.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_maintenance_window.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it ONLY during
     configured maintenance windows. Outside maintenance windows, the script exits without action.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
     V3 ENHANCEMENTS:
     - Configurable maintenance window (day of week + time range)
@@ -12,6 +15,7 @@
     - Retry logic with exponential backoff
     - Better error handling and logging
     - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
     REQUIRED: Configure winget ID and maintenance window schedule.
@@ -23,8 +27,8 @@
     3. Choose whether to force close app during maintenance window
 
 .EXAMPLE
-    # For SQL Server Management Studio - only update on weekends between 2-6 AM:
-    $ID = 'Microsoft.SQLServerManagementStudio'
+    # For your application - only update on weekends between 2-6 AM:
+    $ID = 'WINGETID'
     $MaintenanceWindowDays = @('Saturday', 'Sunday')
     $MaintenanceWindowStartHour = 2
     $MaintenanceWindowEndHour = 6
@@ -120,14 +124,14 @@ function Invoke-WingetWithRetry {
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
-            
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -138,21 +142,32 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
 
-            if ($stdout -and -not ($stdout -match "error|failed|exception")) {
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
                 return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
         if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -175,7 +190,142 @@ try {
 
     Write-Host "Inside maintenance window. Proceeding with update check..."
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Handle running processes
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    if ($ForceCloseInMaintenanceWindow) {
+                        Write-Log "$name is running. Force closing during maintenance window..." -Level Info
+                        Write-Host "$name is running. Force closing application during maintenance window..."
+
+                        Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                        Start-Sleep -Seconds $GracePeriodSeconds
+
+                        # Verify process was closed
+                        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                        if ($process) {
+                            Write-Log "$name process still running after force close attempt. Retrying..." -Level Warning
+                            Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                            Start-Sleep -Seconds 2
+                        }
+
+                        Write-Log "$name closed successfully." -Level Info
+                    } else {
+                        Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
+                        Write-Host "$name is currently running. Skipping update."
+                        exit 1
+                    }
+                } else {
+                    Write-Log "$name is not currently running." -Level Info
+                }
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Updated During Maintenance Window"
+                        MaintenanceWindow = "$($MaintenanceWindowDays -join ', ') $MaintenanceWindowStartHour-$MaintenanceWindowEndHour"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
 
     if ($wingetexe.Count -gt 1) {
@@ -187,8 +337,8 @@ try {
     New-Alias -Name sysget -Value "$SystemContext" -Force
     Write-Log "Found winget: $SystemContext" -Level Info
 
-    # Get package information
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -277,7 +427,7 @@ try {
 
         # Verify installation
         Write-Log "Verifying installation..." -Level Info
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_standard.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_standard.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will skip the update and retry later.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
     V3 ENHANCEMENTS:
     - Retry logic with exponential backoff
@@ -12,6 +15,7 @@
     - Better error handling and status reporting
     - Configurable wait times
     - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -22,8 +26,8 @@
     3. (Optional) Define pre/post update hooks for custom actions
 
 .EXAMPLE
-    # For Google Chrome with logging enabled:
-    $ID = 'Google.Chrome'
+    # For your application with logging enabled:
+    $ID = 'WINGETID'
     $EnableLogging = $true
 #>
 
@@ -85,14 +89,14 @@ function Invoke-WingetWithRetry {
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
     while ($attempt -le $MaxAttempts) {
         try {
             Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
-            
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -103,15 +107,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            
-            if ($stdout -and -not ($stdout -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
                 return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -119,7 +132,7 @@ function Invoke-WingetWithRetry {
         if ($attempt -lt $MaxAttempts) {
             Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -132,6 +145,129 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     Write-Log "=== Starting winget remediation for package: $ID ===" -Level Info
+
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Check if app is running
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Log "$name is currently running. Skipping update - will retry later." -Level Warning
+                    Write-Host "$name is currently running. Will try again later."
+                    [pscustomobject] @{
+                        Name = $name
+                        InstalledVersion = $verInstalled
+                        AvailableVersion = $verAvailable
+                        Status = "Skipped - App Running"
+                    }
+                    exit 1
+                }
+
+                Write-Log "$name is not running. Proceeding with update..." -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                        Write-Log "Pre-update hook completed successfully" -Level Info
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                        Write-Log "Post-update hook completed successfully" -Level Info
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
 
     # Locate winget executable
     Write-Log "Locating winget executable..." -Level Info
@@ -146,9 +282,9 @@ try {
     New-Alias -Name sysget -Value "$SystemContext" -Force
     Write-Log "Found winget: $SystemContext" -Level Info
 
-    # Get package information
+    # Get package information (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -227,7 +363,7 @@ try {
 
         # Verify installation
         Write-Log "Verifying installation..." -Level Info
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]

--- a/scripts/endpoints/devices/winget/browsers/Firefox/detect.ps1
+++ b/scripts/endpoints/devices/winget/browsers/Firefox/detect.ps1
@@ -31,10 +31,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -46,7 +59,27 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/browsers/Firefox/remediate.ps1
+++ b/scripts/endpoints/devices/winget/browsers/Firefox/remediate.ps1
@@ -20,35 +20,81 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Mozilla Firefox" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -66,7 +112,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/browsers/GoogleChrome/detect.ps1
+++ b/scripts/endpoints/devices/winget/browsers/GoogleChrome/detect.ps1
@@ -31,10 +31,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -46,9 +59,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/browsers/GoogleChrome/remediate.ps1
+++ b/scripts/endpoints/devices/winget/browsers/GoogleChrome/remediate.ps1
@@ -20,35 +20,81 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Google Chrome" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -66,7 +112,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
@@ -3,7 +3,10 @@
     Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    This template checks if an app update is available via winget with enhanced features:
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
     - Retry logic with exponential backoff
     - Better error handling and logging
     - Network connectivity validation
@@ -20,13 +23,14 @@
     - Optional logging to file or event log
     - Network connectivity checks before querying winget
     - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .CONFIGURATION
     1. Set the $ID variable to your winget package ID
     2. (Optional) Customize retry, logging, and other advanced settings
 
 .EXAMPLE
-    # For Discord:
+    # For your application:
     $ID = 'Discord.Discord'
 
     # Enable logging:
@@ -36,7 +40,7 @@
 
 #region Configuration
 # ===== REQUIRED: Set your winget package ID =====
-$ID = 'Discord.Discord'
+$ID = 'Discord.Discord'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
 
 # ===== OPTIONAL: Basic Settings =====
 $name = $null     # Leave as $null to auto-detect from winget, or set manually
@@ -96,16 +100,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
 
-            # Execute winget command
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -116,18 +120,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            # Check if result is valid (not empty and not an error)
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -159,6 +169,65 @@ try {
         Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
     Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
@@ -171,11 +240,11 @@ try {
         Write-Log "Found winget: $SystemContext" -Level Info
     }
 
-    
+    New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information with retry logic
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {

--- a/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will optionally notify the user before forcefully closing the app.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
     V3 ENHANCEMENTS:
     - Optional user notification before force closing
@@ -12,6 +15,7 @@
     - Better error handling and logging
     - Configurable grace periods
     - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -23,15 +27,15 @@
     3. (Optional) Enable logging for troubleshooting
 
 .EXAMPLE
-    # For Discord with user notification:
+    # For your application with user notification:
     $ID = 'Discord.Discord'
     $NotifyUserBeforeClose = $true
-    $UserNotificationSeconds = 60
+    $UserNotificationSeconds = 30
 #>
 
 #region Configuration
 # ===== REQUIRED: Set your winget package ID =====
-$ID = 'Discord.Discord'
+$ID = 'Discord.Discord'  # Example: 'TeamViewer.TeamViewer', 'OBSProject.OBSStudio'
 
 # ===== OPTIONAL: Basic Settings =====
 $name = $null                   # Leave as $null to auto-detect from winget
@@ -115,8 +119,6 @@ function Stop-ApplicationProcess {
     )
 
     $attempt = 1
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
 
@@ -148,12 +150,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -164,23 +170,32 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
         if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -194,7 +209,144 @@ function Invoke-WingetWithRetry {
 try {
     Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and handle accordingly
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+                # Send user notification if enabled
+                if ($NotifyUserBeforeClose) {
+                    Write-Log "Sending user notification before closing $name..." -Level Info
+                    Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+                    Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+                    Start-Sleep -Seconds $UserNotificationSeconds
+                }
+
+                # Force close the application
+                Write-Host "$name is running. Force closing application..."
+                $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+                if (-not $closedSuccessfully) {
+                    Write-Log "Failed to close $name process. Aborting update." -Level Error
+                    Write-Error "Failed to close $name process. Cannot proceed with update."
+                    exit 1
+                }
+
+                Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+                Start-Sleep -Seconds $GracePeriodSeconds
+            } else {
+                Write-Log "$name is not currently running." -Level Info
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
@@ -202,11 +354,11 @@ try {
         $SystemContext = $wingetexe.Path
     }
 
-    
+    New-Alias -Name sysget -Value "$SystemContext" -Force
     Write-Log "Found winget: $SystemContext" -Level Info
 
-    # Get package information
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -297,7 +449,7 @@ try {
 
         # Verify installation
         Write-Log "Verifying installation..." -Level Info
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]

--- a/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
@@ -3,7 +3,10 @@
     Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    This template checks if an app update is available via winget with enhanced features:
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
     - Retry logic with exponential backoff
     - Better error handling and logging
     - Network connectivity validation
@@ -20,13 +23,14 @@
     - Optional logging to file or event log
     - Network connectivity checks before querying winget
     - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .CONFIGURATION
     1. Set the $ID variable to your winget package ID
     2. (Optional) Customize retry, logging, and other advanced settings
 
 .EXAMPLE
-    # For Slack:
+    # For your application:
     $ID = 'SlackTechnologies.Slack'
 
     # Enable logging:
@@ -36,7 +40,7 @@
 
 #region Configuration
 # ===== REQUIRED: Set your winget package ID =====
-$ID = 'SlackTechnologies.Slack'
+$ID = 'SlackTechnologies.Slack'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
 
 # ===== OPTIONAL: Basic Settings =====
 $name = $null     # Leave as $null to auto-detect from winget, or set manually
@@ -96,16 +100,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
 
-            # Execute winget command
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -116,18 +120,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            # Check if result is valid (not empty and not an error)
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -159,6 +169,65 @@ try {
         Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
     # Locate winget executable
     Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
@@ -171,11 +240,11 @@ try {
         Write-Log "Found winget: $SystemContext" -Level Info
     }
 
-    
+    New-Alias -Name sysget -Value "$SystemContext" -Force
 
-    # Get package information with retry logic
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {

--- a/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
@@ -5,6 +5,9 @@
 .DESCRIPTION
     This template checks if an app update is available and installs it.
     If the app is running, it will optionally notify the user before forcefully closing the app.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
 
     V3 ENHANCEMENTS:
     - Optional user notification before force closing
@@ -12,6 +15,7 @@
     - Better error handling and logging
     - Configurable grace periods
     - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
     REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
@@ -23,7 +27,7 @@
     3. (Optional) Enable logging for troubleshooting
 
 .EXAMPLE
-    # For Slack with user notification:
+    # For your application with user notification:
     $ID = 'SlackTechnologies.Slack'
     $NotifyUserBeforeClose = $true
     $UserNotificationSeconds = 30
@@ -31,7 +35,7 @@
 
 #region Configuration
 # ===== REQUIRED: Set your winget package ID =====
-$ID = 'SlackTechnologies.Slack'
+$ID = 'SlackTechnologies.Slack'  # Example: 'TeamViewer.TeamViewer', 'OBSProject.OBSStudio'
 
 # ===== OPTIONAL: Basic Settings =====
 $name = $null                   # Leave as $null to auto-detect from winget
@@ -146,15 +150,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
-    $attempt = 1
-    $delay = $RetryDelaySeconds
-
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
 
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -165,23 +170,32 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
         if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -195,8 +209,156 @@ function Invoke-WingetWithRetry {
 try {
     Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
 
-    # Get package information
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and handle accordingly
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+                # Send user notification if enabled
+                if ($NotifyUserBeforeClose) {
+                    Write-Log "Sending user notification before closing $name..." -Level Info
+                    Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+                    Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+                    Start-Sleep -Seconds $UserNotificationSeconds
+                }
+
+                # Force close the application
+                Write-Host "$name is running. Force closing application..."
+                $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+                if (-not $closedSuccessfully) {
+                    Write-Log "Failed to close $name process. Aborting update." -Level Error
+                    Write-Error "Failed to close $name process. Cannot proceed with update."
+                    exit 1
+                }
+
+                Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+                Start-Sleep -Seconds $GracePeriodSeconds
+            } else {
+                Write-Log "$name is not currently running." -Level Info
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
+    if ($wingetexe.Count -gt 1) {
+        $SystemContext = $wingetexe[-1].Path
+    } else {
+        $SystemContext = $wingetexe.Path
+    }
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+    Write-Log "Found winget: $SystemContext" -Level Info
+
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
     # Auto-detect name if not provided
     if (-not $name) {
@@ -287,7 +449,7 @@ try {
 
         # Verify installation
         Write-Log "Verifying installation..." -Level Info
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]

--- a/scripts/endpoints/devices/winget/development/AzureCLI/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/AzureCLI/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/AzureCLI/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/AzureCLI/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Azure CLI" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/Git/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/Git/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/Git/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/Git/remediate.ps1
@@ -21,37 +21,84 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "Closing $name processes..."
+                    Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                    Start-Sleep -Seconds $GracePeriodSeconds
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Git" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -71,7 +118,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "Git updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/OhMyPosh/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/OhMyPosh/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/OhMyPosh/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/OhMyPosh/remediate.ps1
@@ -1,16 +1,16 @@
 <#
 .SYNOPSIS
-    Standard update script for APPNAME (V3).
+    Standard update script for Oh My Posh (V3).
 .DESCRIPTION
     Checks if app is running and skips update if so (will retry later).
 .NOTES
-    Package ID: WINGETID
-    Process: PROCESS
+    Package ID: JanDeDobbeleer.OhMyPosh
+    Process: oh-my-posh
 #>
 
 #region Configuration
-$ID = 'WINGETID'
-$AppProcess = 'PROCESS'
+$ID = 'JanDeDobbeleer.OhMyPosh'
+$AppProcess = 'oh-my-posh'
 $MaxRetries = 3
 $VerifyWaitSeconds = 5
 #endregion
@@ -20,38 +20,84 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-    $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "APPNAME" }
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+    $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Oh My Posh" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/PowerShell7/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/PowerShell7/detect.ps1
@@ -18,37 +18,70 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $stderr = $p.StandardError.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = "PowerShell 7"
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/PowerShell7/remediate_maintenance_window.ps1
+++ b/scripts/endpoints/devices/winget/development/PowerShell7/remediate_maintenance_window.ps1
@@ -1,45 +1,93 @@
 <#
 .SYNOPSIS
-    Maintenance window update for PowerShell 7 (V3).
+    Maintenance window winget update script that only runs during specified hours (V3).
 
 .DESCRIPTION
-    Updates PowerShell 7 ONLY during weekend maintenance windows.
-    Recommended for production environments to avoid disrupting scheduled scripts.
+    This template checks if an app update is available and installs it ONLY during
+    configured maintenance windows. Outside maintenance windows, the script exits without action.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
+
+    V3 ENHANCEMENTS:
+    - Configurable maintenance window (day of week + time range)
+    - Option to force close app during maintenance window
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
-    Package ID: Microsoft.PowerShell
-    Maintenance Window: Saturdays & Sundays, 2 AM - 6 AM
-    Force closes PowerShell sessions during maintenance window
+    REQUIRED: Configure winget ID and maintenance window schedule.
+    BEST FOR: Critical apps that should only update during off-hours (e.g., databases, production tools).
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. Configure maintenance window settings (days, start/end times)
+    3. Choose whether to force close app during maintenance window
+
+.EXAMPLE
+    # For your application - only update on weekends between 2-6 AM:
+    $ID = 'Microsoft.PowerShell'
+    $MaintenanceWindowDays = @('Saturday', 'Sunday')
+    $MaintenanceWindowStartHour = 2
+    $MaintenanceWindowEndHour = 6
+    $ForceCloseInMaintenanceWindow = $true
 #>
 
 #region Configuration
-$ID = 'Microsoft.PowerShell'
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'Microsoft.PowerShell'  # Example: 'Microsoft.SQLServerManagementStudio', 'OBSProject.OBSStudio'
+
+# ===== REQUIRED: Maintenance Window Configuration =====
+# Days when updates are allowed (Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)
+$MaintenanceWindowDays = @('Saturday', 'Sunday')  # Update only on weekends
+
+# Time range when updates are allowed (24-hour format)
+$MaintenanceWindowStartHour = 2   # 2 AM
+$MaintenanceWindowEndHour = 6     # 6 AM
+
+# ===== OPTIONAL: Basic Settings =====
 $name = 'PowerShell 7'
 $AppProcess = 'pwsh'
+$ForceCloseInMaintenanceWindow = $true     # Force close app if running during maintenance window
 
-# Maintenance Window: Weekends 2-6 AM
-$MaintenanceWindowDays = @('Saturday', 'Sunday')
-$MaintenanceWindowStartHour = 2
-$MaintenanceWindowEndHour = 6
-$ForceCloseInMaintenanceWindow = $true
-
-$MaxRetries = 3
-$GracePeriodSeconds = 5
-$VerifyWaitSeconds = 10
-$EnableLogging = $true
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                            # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2                     # Initial delay between retries
+$GracePeriodSeconds = 5                    # Time to wait after closing app (if force close enabled)
+$VerifyWaitSeconds = 10                    # Time to wait after update to verify installation
+$EnableLogging = $true                     # Set to $true to enable file logging
 $LogPath = "C:\ProgramData\IntuneScripts\Logs\PowerShell7_Maintenance.log"
+
+# ===== OPTIONAL: Hooks for Custom Actions =====
+$PreUpdateScriptBlock = $null              # Script block to run before update
+$PostUpdateScriptBlock = $null             # Script block to run after update
 #endregion
 
 #region Functions
 function Write-Log {
-    param([string]$Message, [string]$Level = 'Info')
+    param(
+        [string]$Message,
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Level = 'Info'
+    )
+
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
-    switch ($Level) { 'Error' { Write-Error $Message } 'Warning' { Write-Warning $Message } default { Write-Host $Message } }
+
+    switch ($Level) {
+        'Error'   { Write-Error $Message }
+        'Warning' { Write-Warning $Message }
+        'Info'    { Write-Host $Message }
+    }
+
     if ($EnableLogging) {
         try {
-            $logDir = Split-Path $LogPath -Parent
-            if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }
+            $logDir = Split-Path -Path $LogPath -Parent
+            if (-not (Test-Path $logDir)) {
+                New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+            }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
         } catch { }
     }
@@ -49,29 +97,41 @@ function Test-MaintenanceWindow {
     $now = Get-Date
     $currentDay = $now.DayOfWeek.ToString()
     $currentHour = $now.Hour
-    Write-Log "Current: $($now.ToString('yyyy-MM-dd HH:mm')) | Day: $currentDay | Hour: $currentHour"
 
+    Write-Log "Current time: $($now.ToString('yyyy-MM-dd HH:mm:ss')) | Day: $currentDay | Hour: $currentHour" -Level Info
+
+    # Check if current day is in maintenance window
     if ($MaintenanceWindowDays -notcontains $currentDay) {
-        Write-Log "Day ($currentDay) not in maintenance window: $($MaintenanceWindowDays -join ', ')"
+        Write-Log "Current day ($currentDay) is not in maintenance window. Allowed days: $($MaintenanceWindowDays -join ', ')" -Level Info
         return $false
     }
 
+    # Check if current hour is in maintenance window
     if ($currentHour -lt $MaintenanceWindowStartHour -or $currentHour -ge $MaintenanceWindowEndHour) {
-        Write-Log "Hour ($currentHour) outside window: $MaintenanceWindowStartHour-$MaintenanceWindowEndHour"
+        Write-Log "Current hour ($currentHour) is outside maintenance window ($MaintenanceWindowStartHour-$MaintenanceWindowEndHour)" -Level Info
         return $false
     }
 
-    Write-Log "IN MAINTENANCE WINDOW: $currentDay $currentHour`:00" -Level Warning
+    Write-Log "Currently IN maintenance window: $currentDay $currentHour`:00" -Level Info
     return $true
 }
 
 function Invoke-WingetWithRetry {
-    param([string]$Arguments)
+    param(
+        [string]$Arguments,
+        [int]$MaxAttempts = $MaxRetries
+    )
+
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
+    while ($attempt -le $MaxAttempts) {
         try {
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -82,77 +142,335 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
+            }
+
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
+            Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
-        Start-Sleep -Seconds 2
-        $a++
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2  # Exponential backoff
+        }
+
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+
+    throw "Winget command failed after $MaxAttempts attempts"
 }
 #endregion
 
 #region Script
 try {
-    Write-Log "=== PowerShell 7 Maintenance Window Update ===" -Level Warning
+    Write-Log "=== Starting winget maintenance window remediation for package: $ID ===" -Level Info
 
+    # Check if we're in maintenance window
     if (-not (Test-MaintenanceWindow)) {
-        Write-Host "Outside maintenance window. Updates run: $($MaintenanceWindowDays -join ', ') $MaintenanceWindowStartHour`:00-$MaintenanceWindowEndHour`:00"
-        Write-Log "Exiting - outside maintenance window"
+        Write-Log "Outside maintenance window. Update will not be performed." -Level Info
+        Write-Host "Outside maintenance window. Updates only run during: $($MaintenanceWindowDays -join ', ') between $MaintenanceWindowStartHour`:00-$MaintenanceWindowEndHour`:00"
+        exit 0  # Don't trigger remediation outside maintenance window
+    }
+
+    Write-Host "Inside maintenance window. Proceeding with update check..."
+
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Handle running processes
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    if ($ForceCloseInMaintenanceWindow) {
+                        Write-Log "$name is running. Force closing during maintenance window..." -Level Info
+                        Write-Host "$name is running. Force closing application during maintenance window..."
+
+                        Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                        Start-Sleep -Seconds $GracePeriodSeconds
+
+                        # Verify process was closed
+                        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                        if ($process) {
+                            Write-Log "$name process still running after force close attempt. Retrying..." -Level Warning
+                            Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                            Start-Sleep -Seconds 2
+                        }
+
+                        Write-Log "$name closed successfully." -Level Info
+                    } else {
+                        Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
+                        Write-Host "$name is currently running. Skipping update."
+                        exit 1
+                    }
+                } else {
+                    Write-Log "$name is not currently running." -Level Info
+                }
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Updated During Maintenance Window"
+                        MaintenanceWindow = "$($MaintenanceWindowDays -join ', ') $MaintenanceWindowStartHour-$MaintenanceWindowEndHour"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
+    if ($wingetexe.Count -gt 1) {
+        $SystemContext = $wingetexe[-1].Path
+    } else {
+        $SystemContext = $wingetexe.Path
+    }
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+    Write-Log "Found winget: $SystemContext" -Level Info
+
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Log "$name is not installed on this device." -Level Info
+        Write-Host "$name is not installed on this device."
         exit 0
     }
 
-    Write-Host "Inside maintenance window. Proceeding with update..."
-
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    New-Alias -Name sysget -Value $(if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }) -Force
-
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-
-    if ($packageInfo -match "No installed package found") {
-        Write-Host "$name not installed."; exit 0
-    }
-
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
-        Write-Log "Update available: $($v[0]) -> $($v[1])" -Level Warning
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
-        # Force close PowerShell 7 sessions during maintenance
+        # Auto-detect process name if not provided
+        if (-not $AppProcess) {
+            $AppProcess = ($ID -split '\.')[-1]
+        }
+
+        # Handle running processes
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         if ($process) {
-            Write-Log "Closing PowerShell 7 sessions (PID: $($process.Id -join ', '))" -Level Warning
-            Write-Host "Force closing PowerShell 7 sessions..."
-            Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds $GracePeriodSeconds
+            if ($ForceCloseInMaintenanceWindow) {
+                Write-Log "$name is running. Force closing during maintenance window..." -Level Info
+                Write-Host "$name is running. Force closing application during maintenance window..."
+
+                Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds $GracePeriodSeconds
+
+                # Verify process was closed
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Log "$name process still running after force close attempt. Retrying..." -Level Warning
+                    Stop-Process -Name "$AppProcess" -Force -ErrorAction SilentlyContinue
+                    Start-Sleep -Seconds 2
+                }
+
+                Write-Log "$name closed successfully." -Level Info
+            } else {
+                Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
+                Write-Host "$name is currently running. Skipping update."
+                exit 1
+            }
+        } else {
+            Write-Log "$name is not currently running." -Level Info
         }
 
-        Write-Host "Installing PowerShell 7 update ($($v[0]) -> $($v[1]))..."
-        Write-Log "Starting update installation..."
+        # Execute pre-update hook if defined
+        if ($PreUpdateScriptBlock) {
+            Write-Log "Executing pre-update hook..." -Level Info
+            try {
+                & $PreUpdateScriptBlock
+            } catch {
+                Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
+        }
 
-        Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
+        # Perform upgrade
+        Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+        Write-Host "Installing $name update..."
+
+        $upgradeResult = Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements"
+
+        # Wait for installation to complete
+        Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-        if ($verify -match '\d+(\.\d+)+') {
-            $installedVer = (-split $verify[-1])[-2]
-            Write-Host "PowerShell 7 updated successfully to version $installedVer"
-            Write-Log "Update completed: $installedVer" -Level Warning
-            exit 0
+        # Execute post-update hook if defined
+        if ($PostUpdateScriptBlock) {
+            Write-Log "Executing post-update hook..." -Level Info
+            try {
+                & $PostUpdateScriptBlock
+            } catch {
+                Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
         }
 
-        Write-Error "Verification failed"
-        Write-Log "Verification failed" -Level Error
-        exit 1
+        # Verify installation
+        Write-Log "Verifying installation..." -Level Info
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+        if ($verifyInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $verifyInfo[-1])[-2]
+            Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+            Write-Host "$name updated successfully to version $versionInstalled"
+
+            [pscustomobject] @{
+                Name = $name
+                PreviousVersion = $verInstalled
+                InstalledVersion = $versionInstalled
+                Status = "Updated During Maintenance Window"
+                MaintenanceWindow = "$($MaintenanceWindowDays -join ', ') $MaintenanceWindowStartHour-$MaintenanceWindowEndHour"
+            }
+
+            exit 0
+        } else {
+            Write-Log "Failed to verify $name installation after update" -Level Error
+            Write-Error "Failed to verify $name installation after update."
+            exit 1
+        }
+    } else {
+        # No update available
+        if ($packageInfo -match '\d+(\.\d+)+') {
+            $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+            Write-Host "$name is already up to date (version $versionInstalled)"
+
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Up to Date"
+            }
+
+            exit 0
+        }
     }
 
-    Write-Host "$name is up to date."
-    exit 0
 } catch {
-    Write-Error "Update failed: $_"
-    Write-Log "ERROR: $_" -Level Error
+    $errMsg = $_.Exception.Message
+    Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
+    Write-Error "Failed to update $name : $errMsg"
     exit 1
+} finally {
+    Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/SSMS/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/SSMS/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/SSMS/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/SSMS/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "SQL Server Management Studio" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/VisualStudioCode/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioCode/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/VisualStudioCode/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioCode/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Visual Studio Code" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2019/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2019/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2019/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2019/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Visual Studio Professional 2019" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2022/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2022/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2022/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2022/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Visual Studio Professional 2022" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/media/OBS/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/OBS/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/media/OBS/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/OBS/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "OBS Studio" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/media/VLCMediaPlayer/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/VLCMediaPlayer/detect.ps1
@@ -20,39 +20,71 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
     if ($CheckNetworkConnectivity -and -not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $SystemContext = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
     $name = if ($nameMatch) { $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name is not installed."; exit 0 }

--- a/scripts/endpoints/devices/winget/media/VLCMediaPlayer/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/VLCMediaPlayer/remediate.ps1
@@ -19,52 +19,111 @@ $VerifyWaitSeconds = 5
 #endregion
 
 #region Functions
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+function Invoke-WingetWithRetry {
+    param([string]$Arguments)
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
+        try {
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
+        Start-Sleep -Seconds 2
+        $attempt++
+    }
+    throw "Failed to execute winget after $MaxRetries attempts"
+}
 #endregion
 
 #region Script
 try {
-    $SystemContext = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+    $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "VLC Media Player" }
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    $name = if ($nameMatch) { $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $ID }
-
-    if ($packageInfo -match "No installed package found") { Write-Host "$name is not installed."; exit 0 }
+    if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3,-2]
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         # Check if VLC is playing - don't interrupt user
-        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         if ($process) {
             Write-Host "$name is currently running. Will try again later."
             exit 1
         }
 
-        Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
-        $upgradeResult = Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements"
+        Write-Host "Installing $name update ($($v[0]) -> $($v[1]))..."
+        Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-        if ($verifyInfo -match '\d+(\.\d+)+') {
-            $versionInstalled = (-split $verifyInfo[-1])[-2]
-            Write-Host "$name updated successfully to version $versionInstalled"
-            exit 0
-        } else {
-            Write-Error "Failed to verify installation."; exit 1
-        }
-    } else {
-        if ($packageInfo -match '\d+(\.\d+)+') {
-            $versionInstalled = (-split $packageInfo[-1])[-2]
-            Write-Host "$name is up to date (version $versionInstalled)"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+        if ($verify -match '\d+(\.\d+)+') {
+            $ver = (-split $verify[-1])[-2]
+            Write-Host "$name updated to version $ver"
             exit 0
         }
+        Write-Error "Verification failed"; exit 1
     }
-} catch {
-    Write-Error "Update failed: $($_.Exception.Message)"; exit 1
-}
+    Write-Host "$name is up to date."; exit 0
+} catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/Zoom/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/Zoom/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/media/Zoom/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/Zoom/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Zoomies" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
@@ -1,26 +1,56 @@
 <#
 .SYNOPSIS
-    Winget update detection script for Adobe Acrobat Reader 32-bit (V3).
+    Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    Enhanced detection script with retry logic and better error handling.
-    Auto-detects application name from winget.
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Network connectivity validation
+    - Detailed status reporting
+
+    Returns exit code 1 if update is available (triggers remediation).
+    Returns exit code 0 if app is up to date or not installed (no action needed).
 
 .NOTES
-    Package ID: Adobe.Acrobat.Reader.32-bit
-    Application: Adobe Acrobat Reader (32-bit)
-    Template Version: V3
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name.
+
+    V3 ENHANCEMENTS:
+    - Configurable retry logic (default: 3 attempts with exponential backoff)
+    - Optional logging to file or event log
+    - Network connectivity checks before querying winget
+    - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize retry, logging, and other advanced settings
+
+.EXAMPLE
+    # For your application:
+    $ID = 'Adobe.Acrobat.Reader.32-bit'
+
+    # Enable logging:
+    $EnableLogging = $true
+    $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection.log"
 #>
 
 #region Configuration
-$ID = 'Adobe.Acrobat.Reader.32-bit'
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'Adobe.Acrobat.Reader.32-bit'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
 
-# Optional: Advanced Settings
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
-$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"
-$CheckNetworkConnectivity = $true
+# ===== OPTIONAL: Basic Settings =====
+$name = $null     # Leave as $null to auto-detect from winget, or set manually
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                    # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2             # Initial delay between retries (doubles each retry)
+$EnableLogging = $false            # Set to $true to enable file logging
+$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"  # Log file path
+$CheckNetworkConnectivity = $true  # Verify internet connectivity before querying winget
 #endregion
 
 #region Functions
@@ -34,12 +64,14 @@ function Write-Log {
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
 
+    # Always write to console
     switch ($Level) {
         'Error'   { Write-Error $Message }
         'Warning' { Write-Warning $Message }
         'Info'    { Write-Host $Message }
     }
 
+    # Optionally write to file
     if ($EnableLogging) {
         try {
             $logDir = Split-Path -Path $LogPath -Parent
@@ -47,7 +79,9 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        } catch {
+            # Fail silently if logging doesn't work
+        }
     }
 }
 
@@ -66,14 +100,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -84,17 +120,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -102,7 +145,7 @@ function Invoke-WingetWithRetry {
         if ($attempt -lt $MaxAttempts) {
             Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -116,15 +159,77 @@ function Invoke-WingetWithRetry {
 try {
     Write-Log "=== Starting winget detection for package: $ID ===" -Level Info
 
+    # Check network connectivity if enabled
     if ($CheckNetworkConnectivity) {
         Write-Log "Checking network connectivity..." -Level Info
         if (-not (Test-NetworkConnectivity)) {
             Write-Log "No network connectivity detected. Cannot check for updates." -Level Warning
-            exit 0
+            exit 0  # Don't trigger remediation if offline
         }
         Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
 
     if ($wingetexe.Count -gt 1) {
@@ -135,26 +240,32 @@ try {
         Write-Log "Found winget: $SystemContext" -Level Info
     }
 
-    
+    New-Alias -Name sysget -Value "$SystemContext" -Force
 
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    if ($nameMatch) {
-        $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        Write-Log "Auto-detected application name: $name" -Level Info
-    } else {
-        $name = $ID
-        Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+            Write-Log "Auto-detected application name: $name" -Level Info
+        } else {
+            $name = $ID
+            Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
+        }
     }
 
+    # Check if package is installed
     if ($packageInfo -match "No installed package found matching input criteria") {
         Write-Log "$name is not installed on this device." -Level Info
         Write-Host "$name is not installed on this device."
         exit 0
     }
 
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
@@ -167,8 +278,9 @@ try {
             Status = "UpdateAvailable"
         }
 
-        exit 1
+        exit 1  # Trigger remediation
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
             Write-Log "$name is up to date (version $versionInstalled)" -Level Info
@@ -180,7 +292,7 @@ try {
                 Status = "UpToDate"
             }
 
-            exit 0
+            exit 0  # No action needed
         } else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
@@ -191,8 +303,8 @@ try {
 } catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
-    Write-Error "Failed to check for updates: $errMsg"
-    exit 0
+    Write-Error "Failed to check $name for updates: $errMsg"
+    exit 0  # Don't trigger remediation on error
 } finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Adobe Acrobat Reader 32-bit" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Adobe Acrobat Reader 64-bit" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
@@ -1,42 +1,115 @@
 <#
 .SYNOPSIS
-    Winget update detection script for Microsoft Teams (V3).
+    Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    Enhanced detection script with retry logic and better error handling.
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Network connectivity validation
+    - Detailed status reporting
+
+    Returns exit code 1 if update is available (triggers remediation).
+    Returns exit code 0 if app is up to date or not installed (no action needed).
 
 .NOTES
-    Package ID: Microsoft.Teams
-    Application: Microsoft Teams
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name.
+
+    V3 ENHANCEMENTS:
+    - Configurable retry logic (default: 3 attempts with exponential backoff)
+    - Optional logging to file or event log
+    - Network connectivity checks before querying winget
+    - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize retry, logging, and other advanced settings
+
+.EXAMPLE
+    # For your application:
+    $ID = 'Microsoft.Teams'
+
+    # Enable logging:
+    $EnableLogging = $true
+    $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection.log"
 #>
 
 #region Configuration
-$ID = 'Microsoft.Teams'
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
-$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"
-$CheckNetworkConnectivity = $true
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'Microsoft.Teams'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
+
+# ===== OPTIONAL: Basic Settings =====
+$name = $null     # Leave as $null to auto-detect from winget, or set manually
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                    # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2             # Initial delay between retries (doubles each retry)
+$EnableLogging = $false            # Set to $true to enable file logging
+$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"  # Log file path
+$CheckNetworkConnectivity = $true  # Verify internet connectivity before querying winget
 #endregion
 
 #region Functions
 function Write-Log {
-    param([string]$Message, [ValidateSet('Info', 'Warning', 'Error')][string]$Level = 'Info')
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"; $logMessage = "[$timestamp] [$Level] $Message"
-    switch ($Level) { 'Error' { Write-Error $Message } 'Warning' { Write-Warning $Message } 'Info' { Write-Host $Message } }
-    if ($EnableLogging) { try { $logDir = Split-Path -Path $LogPath -Parent; if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }; Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue } catch { } }
+    param(
+        [string]$Message,
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Level = 'Info'
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logMessage = "[$timestamp] [$Level] $Message"
+
+    # Always write to console
+    switch ($Level) {
+        'Error'   { Write-Error $Message }
+        'Warning' { Write-Warning $Message }
+        'Info'    { Write-Host $Message }
+    }
+
+    # Optionally write to file
+    if ($EnableLogging) {
+        try {
+            $logDir = Split-Path -Path $LogPath -Parent
+            if (-not (Test-Path $logDir)) {
+                New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+            }
+            Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
+        } catch {
+            # Fail silently if logging doesn't work
+        }
+    }
 }
 
-function Test-NetworkConnectivity { try { return (Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue) } catch { return $false } }
+function Test-NetworkConnectivity {
+    try {
+        $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
+        return $testConnection
+    } catch {
+        return $false
+    }
+}
 
 function Invoke-WingetWithRetry {
-    param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
-    $attempt = 1; $delay = $RetryDelaySeconds
+    param(
+        [string]$Arguments,
+        [int]$MaxAttempts = $MaxRetries
+    )
+
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing: sysget $Arguments (Attempt $attempt/$MaxAttempts)" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -47,53 +120,192 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            $result = $stdout
 
-            if ($result -and -not ($result -match "error|failed|exception")) { Write-Log "Command succeeded" -Level Info; return $result }
-            Write-Log "Invalid result on attempt $attempt" -Level Warning
-        } catch { Write-Log "Failed: $($_.Exception.Message)" -Level Warning }
-        if ($attempt -lt $MaxAttempts) { Start-Sleep -Seconds $delay; $delay = $delay * 2 }
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
+            $p.WaitForExit()
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
+            }
+
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+        } catch {
+            Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2  # Exponential backoff
+        }
+
         $attempt++
     }
+
     throw "Winget command failed after $MaxAttempts attempts"
 }
 #endregion
 
 #region Script
 try {
-    Write-Log "=== Starting detection for $ID ===" -Level Info
-    if ($CheckNetworkConnectivity -and -not (Test-NetworkConnectivity)) { Write-Log "No network connectivity" -Level Warning; exit 0 }
+    Write-Log "=== Starting winget detection for package: $ID ===" -Level Info
 
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $SystemContext = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    
-
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    $name = if ($nameMatch) { $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $ID }
-
-    if ($packageInfo -match "No installed package found matching input criteria") {
-        Write-Host "$name is not installed on this device."; exit 0
+    # Check network connectivity if enabled
+    if ($CheckNetworkConnectivity) {
+        Write-Log "Checking network connectivity..." -Level Info
+        if (-not (Test-NetworkConnectivity)) {
+            Write-Log "No network connectivity detected. Cannot check for updates." -Level Warning
+            exit 0  # Don't trigger remediation if offline
+        }
+        Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
+    if ($wingetexe.Count -gt 1) {
+        $SystemContext = $wingetexe[-1].Path
+        Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
+    } else {
+        $SystemContext = $wingetexe.Path
+        Write-Log "Found winget: $SystemContext" -Level Info
+    }
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+
+    # Get package information with retry logic (exact ID match)
+    Write-Log "Querying package information for: $ID" -Level Info
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+            Write-Log "Auto-detected application name: $name" -Level Info
+        } else {
+            $name = $ID
+            Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Log "$name is not installed on this device." -Level Info
+        Write-Host "$name is not installed on this device."
+        exit 0
+    }
+
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
-        [pscustomobject] @{ Name = $name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable; Status = "UpdateAvailable" }
-        exit 1
+
+        [pscustomobject] @{
+            Name = $name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+            Status = "UpdateAvailable"
+        }
+
+        exit 1  # Trigger remediation
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Log "$name is up to date (version $versionInstalled)" -Level Info
             Write-Host "$name is already up to date (version $versionInstalled)"
-            [pscustomobject] @{ Name = $name; InstalledVersion = $versionInstalled; Status = "UpToDate" }
+
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "UpToDate"
+            }
+
+            exit 0  # No action needed
+        } else {
+            Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
+            Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
+
 } catch {
-    Write-Log "ERROR: $($_.Exception.Message)" -Level Error; exit 0
+    $errMsg = $_.Exception.Message
+    Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
+    Write-Error "Failed to check $name for updates: $errMsg"
+    exit 0  # Don't trigger remediation on error
 } finally {
-    Write-Log "=== Detection completed ===" -Level Info
+    Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
@@ -1,47 +1,103 @@
 <#
 .SYNOPSIS
-    Enhanced update script for Microsoft Teams with user notification (V3).
+    Enhanced force close winget update script with user notification and retry logic (V3).
 
 .DESCRIPTION
-    Notifies users 60 seconds before force-closing Teams for updates.
-    This gives users time to save conversations and finish calls.
+    This template checks if an app update is available and installs it.
+    If the app is running, it will optionally notify the user before forcefully closing the app.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
+
+    V3 ENHANCEMENTS:
+    - Optional user notification before force closing
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Configurable grace periods
+    - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
-    Package ID: Microsoft.Teams
-    Application: Microsoft Teams
-    User notification enabled with 60-second warning
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
+    WARNING: This will force close the application, potentially causing data loss!
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Enable user notifications and customize timing
+    3. (Optional) Enable logging for troubleshooting
+
+.EXAMPLE
+    # For your application with user notification:
+    $ID = 'Microsoft.Teams'
+    $NotifyUserBeforeClose = $true
+    $UserNotificationSeconds = 30
 #>
 
 #region Configuration
-$ID = 'Microsoft.Teams'
-$AppProcess = 'ms-teams'
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'Microsoft.Teams'  # Example: 'TeamViewer.TeamViewer', 'OBSProject.OBSStudio'
 
-# User Notification Settings - Give users time to save work
-$NotifyUserBeforeClose = $true
-$UserNotificationSeconds = 60
-$GracePeriodSeconds = 5
-$VerifyWaitSeconds = 10
-$MaxProcessCloseAttempts = 3
+# ===== OPTIONAL: Basic Settings =====
+$name = $null                   # Leave as $null to auto-detect from winget
+$AppProcess = 'ms-teams'        # Teams process
 
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
+# ===== OPTIONAL: Force Close Settings =====
+$NotifyUserBeforeClose = $true      # Show notification to user before closing app
+$UserNotificationSeconds = 60       # How long to show notification before closing (if enabled)
+$GracePeriodSeconds = 5             # Time to wait after closing app before updating
+$VerifyWaitSeconds = 10             # Time to wait after update to verify installation
+$MaxProcessCloseAttempts = 3        # Number of attempts to close the process
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                     # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2              # Initial delay between retries
+$EnableLogging = $false             # Set to $true to enable file logging
 $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetRemediation_$ID.log"
+
+# ===== OPTIONAL: Hooks for Custom Actions =====
+$PreUpdateScriptBlock = $null       # Script block to run before update
+$PostUpdateScriptBlock = $null      # Script block to run after update
 #endregion
 
 #region Functions
 function Write-Log {
-    param([string]$Message, [ValidateSet('Info', 'Warning', 'Error')][string]$Level = 'Info')
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"; $logMessage = "[$timestamp] [$Level] $Message"
-    switch ($Level) { 'Error' { Write-Error $Message } 'Warning' { Write-Warning $Message } 'Info' { Write-Host $Message } }
-    if ($EnableLogging) { try { $logDir = Split-Path -Path $LogPath -Parent; if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }; Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue } catch { } }
+    param(
+        [string]$Message,
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Level = 'Info'
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logMessage = "[$timestamp] [$Level] $Message"
+
+    switch ($Level) {
+        'Error'   { Write-Error $Message }
+        'Warning' { Write-Warning $Message }
+        'Info'    { Write-Host $Message }
+    }
+
+    if ($EnableLogging) {
+        try {
+            $logDir = Split-Path -Path $LogPath -Parent
+            if (-not (Test-Path $logDir)) {
+                New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+            }
+            Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
+        } catch { }
+    }
 }
 
 function Show-UserNotification {
-    param([string]$AppName, [int]$Seconds)
+    param(
+        [string]$AppName,
+        [int]$Seconds
+    )
+
     try {
         $notificationTitle = "Application Update Required"
-        $notificationMessage = "$AppName will be closed in $Seconds seconds for an important update. Please save your work and finish any calls."
+        $notificationMessage = "$AppName will be closed in $Seconds seconds for an important update. Please save your work."
+
+        # Use msg.exe to show notification (works in SYSTEM context)
         $users = query user 2>$null | Select-Object -Skip 1
         foreach ($user in $users) {
             if ($user -match '^\s*(\S+)') {
@@ -49,33 +105,61 @@ function Show-UserNotification {
                 msg.exe $username /TIME:$Seconds "$notificationTitle`n`n$notificationMessage" 2>$null
             }
         }
+
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch { Write-Log "Failed to send notification: $($_.Exception.Message)" -Level Warning }
+    } catch {
+        Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
+    }
 }
 
 function Stop-ApplicationProcess {
-    param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
+    param(
+        [string]$ProcessName,
+        [int]$MaxAttempts = $MaxProcessCloseAttempts
+    )
+
     $attempt = 1
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
-        if (-not $process) { return $true }
-        Write-Log "Stopping $ProcessName (attempt $attempt/$MaxAttempts)..." -Level Info
+
+        if (-not $process) {
+            Write-Log "$ProcessName is not running (attempt $attempt)" -Level Info
+            return $true
+        }
+
+        Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
         Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
         Start-Sleep -Seconds 2
+
         $attempt++
     }
-    return (-not (Get-Process -Name $ProcessName -ErrorAction SilentlyContinue))
+
+    # Final check
+    $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
+    if ($process) {
+        Write-Log "Failed to stop $ProcessName after $MaxAttempts attempts" -Level Error
+        return $false
+    }
+
+    return $true
 }
 
 function Invoke-WingetWithRetry {
-    param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
-    $attempt = 1; $delay = $RetryDelaySeconds
+    param(
+        [string]$Arguments,
+        [int]$MaxAttempts = $MaxRetries
+    )
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
 
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
     while ($attempt -le $MaxAttempts) {
         try {
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -86,72 +170,328 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            $result = $stdout
 
-            if ($result -and -not ($result -match "error|failed|exception")) { return $result }
-        } catch { Write-Log "Failed: $($_.Exception.Message)" -Level Warning }
-        if ($attempt -lt $MaxAttempts) { Start-Sleep -Seconds $delay; $delay = $delay * 2 }
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
+            $p.WaitForExit()
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
+            }
+
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+        } catch {
+            Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2  # Exponential backoff
+        }
+
         $attempt++
     }
+
     throw "Winget command failed after $MaxAttempts attempts"
 }
 #endregion
 
 #region Script
 try {
-    Write-Log "=== Starting Microsoft Teams update ===" -Level Info
+    Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    $name = if ($nameMatch) { $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $ID }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
 
-    if ($packageInfo -match "No installed package found matching input criteria") {
-        Write-Host "$name is not installed."; exit 0
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and handle accordingly
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+                # Send user notification if enabled
+                if ($NotifyUserBeforeClose) {
+                    Write-Log "Sending user notification before closing $name..." -Level Info
+                    Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+                    Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+                    Start-Sleep -Seconds $UserNotificationSeconds
+                }
+
+                # Force close the application
+                Write-Host "$name is running. Force closing application..."
+                $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+                if (-not $closedSuccessfully) {
+                    Write-Log "Failed to close $name process. Aborting update." -Level Error
+                    Write-Error "Failed to close $name process. Cannot proceed with update."
+                    exit 1
+                }
+
+                Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+                Start-Sleep -Seconds $GracePeriodSeconds
+            } else {
+                Write-Log "$name is not currently running." -Level Info
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
     }
 
-    # Check if Teams is running and notify user
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
+    if ($wingetexe.Count -gt 1) {
+        $SystemContext = $wingetexe[-1].Path
+    } else {
+        $SystemContext = $wingetexe.Path
+    }
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+    Write-Log "Found winget: $SystemContext" -Level Info
+
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
+    if ($packageInfo -match "No installed package found matching input criteria") {
+        Write-Log "$name is not installed on this device." -Level Info
+        Write-Host "$name is not installed on this device."
+        exit 0
+    }
+
+    # Auto-detect process name if not provided
+    if (-not $AppProcess) {
+        $AppProcess = ($ID -split '\.')[-1]
+    }
+
+    # Check if app is running and handle accordingly
     $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
     if ($process) {
-        Write-Log "$name is running. Sending user notification..." -Level Info
-        Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
-        Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
-        Start-Sleep -Seconds $UserNotificationSeconds
+        Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
 
-        Write-Host "Force closing $name..."
-        if (-not (Stop-ApplicationProcess -ProcessName $AppProcess)) {
-            Write-Error "Failed to close $name. Cannot proceed with update."; exit 1
+        # Send user notification if enabled
+        if ($NotifyUserBeforeClose) {
+            Write-Log "Sending user notification before closing $name..." -Level Info
+            Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+            Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+            Start-Sleep -Seconds $UserNotificationSeconds
         }
+
+        # Force close the application
+        Write-Host "$name is running. Force closing application..."
+        $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+        if (-not $closedSuccessfully) {
+            Write-Log "Failed to close $name process. Aborting update." -Level Error
+            Write-Error "Failed to close $name process. Cannot proceed with update."
+            exit 1
+        }
+
+        Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
+    } else {
+        Write-Log "$name is not currently running." -Level Info
+        Write-Host "$name is not currently running."
     }
 
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
-        Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+        Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+        # Execute pre-update hook if defined
+        if ($PreUpdateScriptBlock) {
+            Write-Log "Executing pre-update hook..." -Level Info
+            try {
+                & $PreUpdateScriptBlock
+            } catch {
+                Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
+        }
+
+        # Perform upgrade
+        Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+        Write-Host "Installing $name update..."
 
         $upgradeResult = Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements"
+
+        # Wait for installation to complete
+        Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        # Execute post-update hook if defined
+        if ($PostUpdateScriptBlock) {
+            Write-Log "Executing post-update hook..." -Level Info
+            try {
+                & $PostUpdateScriptBlock
+            } catch {
+                Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
+        }
+
+        # Verify installation
+        Write-Log "Verifying installation..." -Level Info
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]
+            Write-Log "$name updated successfully to version $versionInstalled" -Level Info
             Write-Host "$name updated successfully to version $versionInstalled"
-            [pscustomobject] @{ Name = $name; PreviousVersion = $verInstalled; InstalledVersion = $versionInstalled; Status = "Updated Successfully" }
+
+            [pscustomobject] @{
+                Name = $name
+                PreviousVersion = $verInstalled
+                InstalledVersion = $versionInstalled
+                Status = "Force Updated Successfully"
+            }
+
             exit 0
         } else {
-            Write-Error "Failed to verify installation."; exit 1
+            Write-Log "Failed to verify $name installation after update" -Level Error
+            Write-Error "Failed to verify $name installation after update."
+            exit 1
         }
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
             Write-Host "$name is already up to date (version $versionInstalled)"
+
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Up to Date"
+            }
+
             exit 0
         }
     }
+
 } catch {
-    Write-Error "Failed to update: $($_.Exception.Message)"; exit 1
+    $errMsg = $_.Exception.Message
+    Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
+    Write-Error "Failed to update $name : $errMsg"
+    exit 1
 } finally {
-    Write-Log "=== Remediation completed ===" -Level Info
+    Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "NotePad++" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/productivity/RemoteDesktop/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/RemoteDesktop/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/productivity/RemoteDesktop/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/RemoteDesktop/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft Remote Desktop" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "TeamViewer Full" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate_Force_Close.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate_Force_Close.ps1
@@ -20,38 +20,84 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     New-Alias -Name sysget -Value $(if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }) -Force
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "TeamViewer Full" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -69,7 +115,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "TeamViewer Host" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/remote-access/WinSCP/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/WinSCP/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/remote-access/WinSCP/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/WinSCP/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "WinSCP" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "C++ 2008 Redist" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2010.x86" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2012.x64" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2013.x64" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2013.x86" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2015+.x86" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Microsoft.VCRedist.2015+.x64" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Edge WebView2" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/security/1Password/detect.ps1
+++ b/scripts/endpoints/devices/winget/security/1Password/detect.ps1
@@ -1,54 +1,115 @@
 <#
 .SYNOPSIS
-    Enhanced winget update detection script for Intune Proactive Remediations (V3) - 1Password.
+    Enhanced winget update detection script for Intune Proactive Remediations (V3).
+
+.DESCRIPTION
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Network connectivity validation
+    - Detailed status reporting
+
+    Returns exit code 1 if update is available (triggers remediation).
+    Returns exit code 0 if app is up to date or not installed (no action needed).
+
+.NOTES
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name.
+
+    V3 ENHANCEMENTS:
+    - Configurable retry logic (default: 3 attempts with exponential backoff)
+    - Optional logging to file or event log
+    - Network connectivity checks before querying winget
+    - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize retry, logging, and other advanced settings
+
+.EXAMPLE
+    # For your application:
+    $ID = 'AgileBits.1Password'
+
+    # Enable logging:
+    $EnableLogging = $true
+    $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection.log"
 #>
 
 #region Configuration
-$ID = 'AgileBits.1Password'
-$name = $null
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
-$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"
-$CheckNetworkConnectivity = $true
+# ===== REQUIRED: Set your winget package ID =====
+$ID = 'AgileBits.1Password'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
+
+# ===== OPTIONAL: Basic Settings =====
+$name = $null     # Leave as $null to auto-detect from winget, or set manually
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                    # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2             # Initial delay between retries (doubles each retry)
+$EnableLogging = $false            # Set to $true to enable file logging
+$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"  # Log file path
+$CheckNetworkConnectivity = $true  # Verify internet connectivity before querying winget
 #endregion
 
 #region Functions
 function Write-Log {
-    param([string]$Message, [ValidateSet('Info', 'Warning', 'Error')][string]$Level = 'Info')
+    param(
+        [string]$Message,
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Level = 'Info'
+    )
+
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
+
+    # Always write to console
     switch ($Level) {
         'Error'   { Write-Error $Message }
         'Warning' { Write-Warning $Message }
         'Info'    { Write-Host $Message }
     }
+
+    # Optionally write to file
     if ($EnableLogging) {
         try {
             $logDir = Split-Path -Path $LogPath -Parent
-            if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }
+            if (-not (Test-Path $logDir)) {
+                New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+            }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        } catch {
+            # Fail silently if logging doesn't work
+        }
     }
 }
 
 function Test-NetworkConnectivity {
     try {
-        return (Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue)
+        $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
+        return $testConnection
     } catch {
         return $false
     }
 }
 
 function Invoke-WingetWithRetry {
-    param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
-    $attempt = 1
-    $delay = $RetryDelaySeconds
+    param(
+        [string]$Arguments,
+        [int]$MaxAttempts = $MaxRetries
+    )
+
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -59,25 +120,37 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            $result = $stdout
 
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
-                return $result
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
+            $p.WaitForExit()
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
+
         if ($attempt -lt $MaxAttempts) {
             Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
+
         $attempt++
     }
+
     throw "Winget command failed after $MaxAttempts attempts"
 }
 #endregion
@@ -85,24 +158,95 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     Write-Log "=== Starting winget detection for package: $ID ===" -Level Info
+
+    # Check network connectivity if enabled
     if ($CheckNetworkConnectivity) {
         Write-Log "Checking network connectivity..." -Level Info
         if (-not (Test-NetworkConnectivity)) {
             Write-Log "No network connectivity detected. Cannot check for updates." -Level Warning
-            exit 0
+            exit 0  # Don't trigger remediation if offline
         }
         Write-Log "Network connectivity confirmed" -Level Info
     }
+
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
     Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
+        Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
     } else {
         $SystemContext = $wingetexe.Path
+        Write-Log "Found winget: $SystemContext" -Level Info
     }
-    
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+    # Auto-detect name if not provided
     if (-not $name) {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
@@ -110,34 +254,57 @@ try {
             Write-Log "Auto-detected application name: $name" -Level Info
         } else {
             $name = $ID
+            Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
     }
+
+    # Check if package is installed
     if ($packageInfo -match "No installed package found matching input criteria") {
         Write-Log "$name is not installed on this device." -Level Info
         Write-Host "$name is not installed on this device."
         exit 0
     }
+
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
-        [pscustomobject] @{Name = $name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable; Status = "UpdateAvailable"}
-        exit 1
+
+        [pscustomobject] @{
+            Name = $name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+            Status = "UpdateAvailable"
+        }
+
+        exit 1  # Trigger remediation
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
             Write-Log "$name is up to date (version $versionInstalled)" -Level Info
             Write-Host "$name is already up to date (version $versionInstalled)"
-            [pscustomobject] @{Name = $name; InstalledVersion = $versionInstalled; Status = "UpToDate"}
-            exit 0
+
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "UpToDate"
+            }
+
+            exit 0  # No action needed
         } else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
+            Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
+
 } catch {
-    Write-Log "ERROR: Failed to check $name for updates: $($_.Exception.Message)" -Level Error
-    exit 0
+    $errMsg = $_.Exception.Message
+    Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
+    Write-Error "Failed to check $name for updates: $errMsg"
+    exit 0  # Don't trigger remediation on error
 } finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
@@ -1,25 +1,56 @@
 <#
 .SYNOPSIS
-    Winget update detection script for 7-Zip (V3).
+    Enhanced winget update detection script for Intune Proactive Remediations (V3).
 
 .DESCRIPTION
-    Enhanced detection script with retry logic and better error handling.
-    Auto-detects application name from winget.
+    This template checks if an app update is available with enhanced features:
+    - Prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+      supported in the SYSTEM context that Intune Proactive Remediations run in)
+    - Falls back to the winget.exe CLI only when the module is unavailable
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Network connectivity validation
+    - Detailed status reporting
+
+    Returns exit code 1 if update is available (triggers remediation).
+    Returns exit code 0 if app is up to date or not installed (no action needed).
 
 .NOTES
-    Package ID: 7zip.7zip
-    Application: 7-Zip
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name.
+
+    V3 ENHANCEMENTS:
+    - Configurable retry logic (default: 3 attempts with exponential backoff)
+    - Optional logging to file or event log
+    - Network connectivity checks before querying winget
+    - More detailed error messages and status reporting
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Customize retry, logging, and other advanced settings
+
+.EXAMPLE
+    # For your application:
+    $ID = '7zip.7zip'
+
+    # Enable logging:
+    $EnableLogging = $true
+    $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection.log"
 #>
 
 #region Configuration
-$ID = '7zip.7zip'
+# ===== REQUIRED: Set your winget package ID =====
+$ID = '7zip.7zip'  # Example: 'Google.Chrome', 'Microsoft.Teams', 'Slack.Slack'
 
-# Optional: Advanced Settings
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
-$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"
-$CheckNetworkConnectivity = $true
+# ===== OPTIONAL: Basic Settings =====
+$name = $null     # Leave as $null to auto-detect from winget, or set manually
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                    # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2             # Initial delay between retries (doubles each retry)
+$EnableLogging = $false            # Set to $true to enable file logging
+$LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetDetection_$ID.log"  # Log file path
+$CheckNetworkConnectivity = $true  # Verify internet connectivity before querying winget
 #endregion
 
 #region Functions
@@ -33,12 +64,14 @@ function Write-Log {
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
 
+    # Always write to console
     switch ($Level) {
         'Error'   { Write-Error $Message }
         'Warning' { Write-Warning $Message }
         'Info'    { Write-Host $Message }
     }
 
+    # Optionally write to file
     if ($EnableLogging) {
         try {
             $logDir = Split-Path -Path $LogPath -Parent
@@ -46,7 +79,9 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        } catch {
+            # Fail silently if logging doesn't work
+        }
     }
 }
 
@@ -65,14 +100,16 @@ function Invoke-WingetWithRetry {
         [int]$MaxAttempts = $MaxRetries
     )
 
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
+
     $attempt = 1
     $delay = $RetryDelaySeconds
 
-    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
-    $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): sysget $Arguments" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -83,17 +120,24 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
             $p.WaitForExit()
-            $result = $stdout
 
-
-            if ($result -and -not ($result -match "error|failed|exception")) {
-                Write-Log "Winget command succeeded on attempt $attempt" -Level Info
-                return $result
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
             }
 
-            Write-Log "Winget command returned invalid result on attempt $attempt" -Level Warning
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
@@ -101,7 +145,7 @@ function Invoke-WingetWithRetry {
         if ($attempt -lt $MaxAttempts) {
             Write-Log "Waiting $delay seconds before retry..." -Level Info
             Start-Sleep -Seconds $delay
-            $delay = $delay * 2
+            $delay = $delay * 2  # Exponential backoff
         }
 
         $attempt++
@@ -115,15 +159,77 @@ function Invoke-WingetWithRetry {
 try {
     Write-Log "=== Starting winget detection for package: $ID ===" -Level Info
 
+    # Check network connectivity if enabled
     if ($CheckNetworkConnectivity) {
         Write-Log "Checking network connectivity..." -Level Info
         if (-not (Test-NetworkConnectivity)) {
             Write-Log "No network connectivity detected. Cannot check for updates." -Level Warning
-            exit 0
+            exit 0  # Don't trigger remediation if offline
         }
         Write-Log "Network connectivity confirmed" -Level Info
     }
 
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
+
+            # Get package information (exact ID match)
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+                Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $verInstalled
+                    AvailableVersion = $verAvailable
+                    Status = "UpdateAvailable"
+                }
+
+                exit 1  # Trigger remediation
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "UpToDate"
+                }
+
+                exit 0  # No action needed
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
 
     if ($wingetexe.Count -gt 1) {
@@ -134,26 +240,32 @@ try {
         Write-Log "Found winget: $SystemContext" -Level Info
     }
 
-    
+    New-Alias -Name sysget -Value "$SystemContext" -Force
 
+    # Get package information with retry logic (exact ID match)
     Write-Log "Querying package information for: $ID" -Level Info
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
 
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    if ($nameMatch) {
-        $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        Write-Log "Auto-detected application name: $name" -Level Info
-    } else {
-        $name = $ID
-        Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+            Write-Log "Auto-detected application name: $name" -Level Info
+        } else {
+            $name = $ID
+            Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
+        }
     }
 
+    # Check if package is installed
     if ($packageInfo -match "No installed package found matching input criteria") {
         Write-Log "$name is not installed on this device." -Level Info
         Write-Host "$name is not installed on this device."
         exit 0
     }
 
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
@@ -166,8 +278,9 @@ try {
             Status = "UpdateAvailable"
         }
 
-        exit 1
+        exit 1  # Trigger remediation
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
             Write-Log "$name is up to date (version $versionInstalled)" -Level Info
@@ -179,7 +292,7 @@ try {
                 Status = "UpToDate"
             }
 
-            exit 0
+            exit 0  # No action needed
         } else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
@@ -190,8 +303,8 @@ try {
 } catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
-    Write-Error "Failed to check for updates: $errMsg"
-    exit 0
+    Write-Error "Failed to check $name for updates: $errMsg"
+    exit 0  # Don't trigger remediation on error
 } finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
@@ -1,86 +1,165 @@
 <#
 .SYNOPSIS
-    Force close winget update script for 7-Zip (V3).
+    Enhanced force close winget update script with user notification and retry logic (V3).
 
 .DESCRIPTION
-    7-Zip can be safely force-closed during updates as it's a utility tool.
-    This script uses the V3 enhanced force close template.
+    This template checks if an app update is available and installs it.
+    If the app is running, it will optionally notify the user before forcefully closing the app.
+    It prefers the Microsoft.WinGet.Client PowerShell module (the winget CLI is NOT
+    supported in the SYSTEM context that Intune Proactive Remediations run in) and
+    falls back to the winget.exe CLI only when the module is unavailable.
+
+    V3 ENHANCEMENTS:
+    - Optional user notification before force closing
+    - Retry logic with exponential backoff
+    - Better error handling and logging
+    - Configurable grace periods
+    - Pre/post update hooks
+    - Microsoft.WinGet.Client module preferred over the winget.exe CLI (SYSTEM context safe)
 
 .NOTES
-    Package ID: 7zip.7zip
-    Application: 7-Zip
-    Process: 7zFM (File Manager), 7zG (GUI)
+    REQUIRED: Only the winget ID is required. The script will auto-detect app name and process.
+    WARNING: This will force close the application, potentially causing data loss!
+
+.CONFIGURATION
+    1. Set the $ID variable to your winget package ID
+    2. (Optional) Enable user notifications and customize timing
+    3. (Optional) Enable logging for troubleshooting
+
+.EXAMPLE
+    # For your application with user notification:
+    $ID = '7zip.7zip'
+    $NotifyUserBeforeClose = $true
+    $UserNotificationSeconds = 30
 #>
 
 #region Configuration
-$ID = '7zip.7zip'
-$AppProcess = '7zFM'  # 7-Zip File Manager process
+# ===== REQUIRED: Set your winget package ID =====
+$ID = '7zip.7zip'  # Example: 'TeamViewer.TeamViewer', 'OBSProject.OBSStudio'
 
-# Force Close Settings
-$NotifyUserBeforeClose = $false
-$GracePeriodSeconds = 2
-$VerifyWaitSeconds = 5
-$MaxProcessCloseAttempts = 3
+# ===== OPTIONAL: Basic Settings =====
+$name = $null                   # Leave as $null to auto-detect from winget
+$AppProcess = '7zFM'            # 7-Zip File Manager process
 
-# Advanced Settings
-$MaxRetries = 3
-$RetryDelaySeconds = 2
-$EnableLogging = $false
+# ===== OPTIONAL: Force Close Settings =====
+$NotifyUserBeforeClose = $false     # Show notification to user before closing app
+$UserNotificationSeconds = 60       # How long to show notification before closing (if enabled)
+$GracePeriodSeconds = 2             # Time to wait after closing app before updating
+$VerifyWaitSeconds = 5              # Time to wait after update to verify installation
+$MaxProcessCloseAttempts = 3        # Number of attempts to close the process
+
+# ===== OPTIONAL: Advanced Settings =====
+$MaxRetries = 3                     # Number of retry attempts for winget operations
+$RetryDelaySeconds = 2              # Initial delay between retries
+$EnableLogging = $false             # Set to $true to enable file logging
 $LogPath = "C:\ProgramData\IntuneScripts\Logs\WingetRemediation_$ID.log"
+
+# ===== OPTIONAL: Hooks for Custom Actions =====
+$PreUpdateScriptBlock = $null       # Script block to run before update
+$PostUpdateScriptBlock = $null      # Script block to run after update
 #endregion
 
 #region Functions
 function Write-Log {
-    param([string]$Message, [ValidateSet('Info', 'Warning', 'Error')][string]$Level = 'Info')
+    param(
+        [string]$Message,
+        [ValidateSet('Info', 'Warning', 'Error')]
+        [string]$Level = 'Info'
+    )
+
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
     $logMessage = "[$timestamp] [$Level] $Message"
+
     switch ($Level) {
         'Error'   { Write-Error $Message }
         'Warning' { Write-Warning $Message }
         'Info'    { Write-Host $Message }
     }
+
     if ($EnableLogging) {
         try {
             $logDir = Split-Path -Path $LogPath -Parent
-            if (-not (Test-Path $logDir)) { New-Item -Path $logDir -ItemType Directory -Force | Out-Null }
+            if (-not (Test-Path $logDir)) {
+                New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+            }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
         } catch { }
     }
 }
 
+function Show-UserNotification {
+    param(
+        [string]$AppName,
+        [int]$Seconds
+    )
+
+    try {
+        $notificationTitle = "Application Update Required"
+        $notificationMessage = "$AppName will be closed in $Seconds seconds for an important update. Please save your work."
+
+        # Use msg.exe to show notification (works in SYSTEM context)
+        $users = query user 2>$null | Select-Object -Skip 1
+        foreach ($user in $users) {
+            if ($user -match '^\s*(\S+)') {
+                $username = $Matches[1]
+                msg.exe $username /TIME:$Seconds "$notificationTitle`n`n$notificationMessage" 2>$null
+            }
+        }
+
+        Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
+    } catch {
+        Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
+    }
+}
+
 function Stop-ApplicationProcess {
-    param([string]$ProcessName, [int]$MaxAttempts = $MaxProcessCloseAttempts)
+    param(
+        [string]$ProcessName,
+        [int]$MaxAttempts = $MaxProcessCloseAttempts
+    )
+
     $attempt = 1
     while ($attempt -le $MaxAttempts) {
         $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
+
         if (-not $process) {
-            Write-Log "$ProcessName is not running" -Level Info
+            Write-Log "$ProcessName is not running (attempt $attempt)" -Level Info
             return $true
         }
-        Write-Log "Stopping $ProcessName (attempt $attempt/$MaxAttempts)..." -Level Info
+
+        Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
         Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
         Start-Sleep -Seconds 2
+
         $attempt++
     }
+
+    # Final check
     $process = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue
     if ($process) {
         Write-Log "Failed to stop $ProcessName after $MaxAttempts attempts" -Level Error
         return $false
     }
+
     return $true
 }
 
 function Invoke-WingetWithRetry {
-    param([string]$Arguments, [int]$MaxAttempts = $MaxRetries)
-    $attempt = 1
-    $delay = $RetryDelaySeconds
+    param(
+        [string]$Arguments,
+        [int]$MaxAttempts = $MaxRetries
+    )
 
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
 
+    $attempt = 1
+    $delay = $RetryDelaySeconds
+
     while ($attempt -le $MaxAttempts) {
         try {
-            Write-Log "Executing: sysget $Arguments (Attempt $attempt/$MaxAttempts)" -Level Info
+            Write-Log "Executing winget command (Attempt $attempt/$MaxAttempts): $wingetPath $Arguments" -Level Info
+
             $psi = New-Object System.Diagnostics.ProcessStartInfo
             $psi.FileName = $wingetPath
             $psi.Arguments = $Arguments
@@ -91,81 +170,328 @@ function Invoke-WingetWithRetry {
             $p = New-Object System.Diagnostics.Process
             $p.StartInfo = $psi
             $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            $result = $stdout
 
-            if ($result -and -not ($result -match "error|failed|exception")) { return $result }
-            Write-Log "Invalid result on attempt $attempt" -Level Warning
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $p.StandardOutput.ReadToEnd()
+            $stderr = $p.StandardError.ReadToEnd()
+            $p.WaitForExit()
+
+            # Base success on the process exit code, not on a grep of stdout.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($p.ExitCode -eq 0 -or $p.ExitCode -eq 0x8A150014 -or $p.ExitCode -eq 0x8A150109) {
+                Write-Log "Winget command succeeded on attempt $attempt (exit code 0x$($p.ExitCode.ToString('X8')))" -Level Info
+                if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
+                return $stdout
+            }
+
+            Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
+            if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
         } catch {
-            Write-Log "Failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
+            Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
-        if ($attempt -lt $MaxAttempts) { Start-Sleep -Seconds $delay; $delay = $delay * 2 }
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-Log "Waiting $delay seconds before retry..." -Level Info
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2  # Exponential backoff
+        }
+
         $attempt++
     }
+
     throw "Winget command failed after $MaxAttempts attempts"
 }
 #endregion
 
 #region Script
 try {
-    Write-Log "=== Starting 7-Zip update ===" -Level Info
+    Write-Log "=== Starting winget force close remediation for package: $ID ===" -Level Info
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            Write-Log "Using Microsoft.WinGet.Client module" -Level Info
 
-    $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
-    if ($nameMatch) { $name = $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $name = $ID }
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
 
+            # Auto-detect name if not provided
+            if (-not $name) {
+                $name = if ($package.Name) { $package.Name } else { $ID }
+            }
+
+            # Check if package is installed
+            if (-not $package) {
+                Write-Log "$name is not installed on this device." -Level Info
+                Write-Host "$name is not installed on this device."
+                exit 0
+            }
+
+            # Auto-detect process name if not provided
+            if (-not $AppProcess) {
+                $AppProcess = ($ID -split '\.')[-1]
+            }
+
+            # Check if app is running and handle accordingly
+            $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+            if ($process) {
+                Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+                # Send user notification if enabled
+                if ($NotifyUserBeforeClose) {
+                    Write-Log "Sending user notification before closing $name..." -Level Info
+                    Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+                    Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+                    Start-Sleep -Seconds $UserNotificationSeconds
+                }
+
+                # Force close the application
+                Write-Host "$name is running. Force closing application..."
+                $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+                if (-not $closedSuccessfully) {
+                    Write-Log "Failed to close $name process. Aborting update." -Level Error
+                    Write-Error "Failed to close $name process. Cannot proceed with update."
+                    exit 1
+                }
+
+                Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+                Start-Sleep -Seconds $GracePeriodSeconds
+            } else {
+                Write-Log "$name is not currently running." -Level Info
+                Write-Host "$name is not currently running."
+            }
+
+            # Check if update is available
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+                # Execute pre-update hook if defined
+                if ($PreUpdateScriptBlock) {
+                    Write-Log "Executing pre-update hook..." -Level Info
+                    try {
+                        & $PreUpdateScriptBlock
+                    } catch {
+                        Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Perform upgrade via the module
+                Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
+                Write-Host "Installing $name update..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+
+                # Wait for installation to complete
+                Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
+                Start-Sleep -Seconds $VerifyWaitSeconds
+
+                # Execute post-update hook if defined
+                if ($PostUpdateScriptBlock) {
+                    Write-Log "Executing post-update hook..." -Level Info
+                    try {
+                        & $PostUpdateScriptBlock
+                    } catch {
+                        Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+                    }
+                }
+
+                # Verify installation
+                Write-Log "Verifying installation..." -Level Info
+                $verifyPackage = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+
+                if ($verifyPackage) {
+                    $versionInstalled = $verifyPackage.InstalledVersion
+                    Write-Log "$name updated successfully to version $versionInstalled" -Level Info
+                    Write-Host "$name updated successfully to version $versionInstalled"
+
+                    [pscustomobject] @{
+                        Name = $name
+                        PreviousVersion = $verInstalled
+                        InstalledVersion = $versionInstalled
+                        Status = "Force Updated Successfully"
+                    }
+
+                    exit 0
+                } else {
+                    Write-Log "Failed to verify $name installation after update" -Level Error
+                    Write-Error "Failed to verify $name installation after update."
+                    exit 1
+                }
+            } else {
+                # No update available
+                $versionInstalled = $package.InstalledVersion
+                Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
+                Write-Host "$name is already up to date (version $versionInstalled)"
+
+                [pscustomobject] @{
+                    Name = $name
+                    InstalledVersion = $versionInstalled
+                    Status = "Up to Date"
+                }
+
+                exit 0
+            }
+        }
+    }
+
+    # Fallback: winget.exe CLI (only reached when the Microsoft.WinGet.Client module is unavailable)
+    Write-Log "Microsoft.WinGet.Client module unavailable, falling back to winget.exe CLI" -Level Warning
+
+    # Locate winget executable
+    Write-Log "Locating winget executable..." -Level Info
+    $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
+
+    if ($wingetexe.Count -gt 1) {
+        $SystemContext = $wingetexe[-1].Path
+    } else {
+        $SystemContext = $wingetexe.Path
+    }
+
+    New-Alias -Name sysget -Value "$SystemContext" -Force
+    Write-Log "Found winget: $SystemContext" -Level Info
+
+    # Get package information (exact ID match)
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
+    # Auto-detect name if not provided
+    if (-not $name) {
+        $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
+        if ($nameMatch) {
+            $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
+        } else {
+            $name = $ID
+        }
+    }
+
+    # Check if package is installed
     if ($packageInfo -match "No installed package found matching input criteria") {
-        Write-Log "$name is not installed." -Level Info
+        Write-Log "$name is not installed on this device." -Level Info
         Write-Host "$name is not installed on this device."
         exit 0
     }
 
-    # Close 7-Zip if running
-    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
-    if ($process) {
-        Write-Host "$name is running. Force closing application..."
-        $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
-        if (-not $closedSuccessfully) {
-            Write-Error "Failed to close $name. Cannot proceed with update."
-            exit 1
-        }
-        Start-Sleep -Seconds $GracePeriodSeconds
+    # Auto-detect process name if not provided
+    if (-not $AppProcess) {
+        $AppProcess = ($ID -split '\.')[-1]
     }
 
+    # Check if app is running and handle accordingly
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    if ($process) {
+        Write-Log "$name is currently running (PID: $($process.Id -join ', '))" -Level Info
+
+        # Send user notification if enabled
+        if ($NotifyUserBeforeClose) {
+            Write-Log "Sending user notification before closing $name..." -Level Info
+            Show-UserNotification -AppName $name -Seconds $UserNotificationSeconds
+            Write-Host "$name will be closed in $UserNotificationSeconds seconds. Notifying users..."
+            Start-Sleep -Seconds $UserNotificationSeconds
+        }
+
+        # Force close the application
+        Write-Host "$name is running. Force closing application..."
+        $closedSuccessfully = Stop-ApplicationProcess -ProcessName $AppProcess
+
+        if (-not $closedSuccessfully) {
+            Write-Log "Failed to close $name process. Aborting update." -Level Error
+            Write-Error "Failed to close $name process. Cannot proceed with update."
+            exit 1
+        }
+
+        Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
+        Start-Sleep -Seconds $GracePeriodSeconds
+    } else {
+        Write-Log "$name is not currently running." -Level Info
+        Write-Host "$name is not currently running."
+    }
+
+    # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
         $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
-        Write-Log "Update available: $verInstalled -> $verAvailable" -Level Info
+        Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
+
+        # Execute pre-update hook if defined
+        if ($PreUpdateScriptBlock) {
+            Write-Log "Executing pre-update hook..." -Level Info
+            try {
+                & $PreUpdateScriptBlock
+            } catch {
+                Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
+        }
+
+        # Perform upgrade
+        Write-Log "Installing $name update ($verInstalled -> $verAvailable)..." -Level Info
         Write-Host "Installing $name update..."
 
         $upgradeResult = Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements"
+
+        # Wait for installation to complete
+        Write-Log "Waiting $VerifyWaitSeconds seconds for installation to complete..." -Level Info
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        # Execute post-update hook if defined
+        if ($PostUpdateScriptBlock) {
+            Write-Log "Executing post-update hook..." -Level Info
+            try {
+                & $PostUpdateScriptBlock
+            } catch {
+                Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
+            }
+        }
+
+        # Verify installation
+        Write-Log "Verifying installation..." -Level Info
+        $verifyInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
+
         if ($verifyInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $verifyInfo[-1])[-2]
-            Write-Log "$name updated successfully to $versionInstalled" -Level Info
+            Write-Log "$name updated successfully to version $versionInstalled" -Level Info
             Write-Host "$name updated successfully to version $versionInstalled"
-            [pscustomobject] @{ Name = $name; PreviousVersion = $verInstalled; InstalledVersion = $versionInstalled; Status = "Updated Successfully" }
+
+            [pscustomobject] @{
+                Name = $name
+                PreviousVersion = $verInstalled
+                InstalledVersion = $versionInstalled
+                Status = "Force Updated Successfully"
+            }
+
             exit 0
         } else {
-            Write-Error "Failed to verify installation."
+            Write-Log "Failed to verify $name installation after update" -Level Error
+            Write-Error "Failed to verify $name installation after update."
             exit 1
         }
     } else {
+        # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
+            Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
             Write-Host "$name is already up to date (version $versionInstalled)"
-            [pscustomobject] @{ Name = $name; InstalledVersion = $versionInstalled; Status = "Up to Date" }
+
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $versionInstalled
+                Status = "Up to Date"
+            }
+
             exit 0
         }
     }
+
 } catch {
-    Write-Log "ERROR: $($_.Exception.Message)" -Level Error
-    Write-Error "Failed to update $name : $($_.Exception.Message)"
+    $errMsg = $_.Exception.Message
+    Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
+    Write-Error "Failed to update $name : $errMsg"
     exit 1
 } finally {
-    Write-Log "=== Remediation completed ===" -Level Info
+    Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/detect.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/remediate.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Lenovo Dock Manager" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/detect.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/detect.ps1
@@ -30,10 +30,23 @@ function Invoke-WingetWithRetry {
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo = $processInfo
             $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
             $stdout = $process.StandardOutput.ReadToEnd()
             $stderr = $process.StandardError.ReadToEnd()
             $process.WaitForExit()
-            if ($stdout) { return $stdout }
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
         } catch { }
         Start-Sleep -Seconds 2
         $attempt++
@@ -45,9 +58,29 @@ function Invoke-WingetWithRetry {
 #region Script
 try {
     if (-not (Test-NetworkConnectivity)) { exit 0 }
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            if ($package.IsUpdateAvailable) {
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Application update available for $($package.Name). Current: $verInstalled, Available: $verAvailable"
+                [pscustomobject] @{ Name = $package.Name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
+                exit 1
+            }
+            Write-Host "$($package.Name) is already up to date (version $($package.InstalledVersion))."
+            exit 0
+        }
+    }
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/remediate.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/remediate.ps1
@@ -20,37 +20,83 @@ function Invoke-WingetWithRetry {
     param([string]$Arguments)
     $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction Stop
     $wingetPath = if ($wingetexe.Count -gt 1) { $wingetexe[-1].Path } else { $wingetexe.Path }
-    $a = 1
-    while ($a -le 3) {
+    $attempt = 1
+    while ($attempt -le $MaxRetries) {
         try {
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = $wingetPath
-            $psi.Arguments = $Arguments
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            $psi.CreateNoWindow = $true
-            $p = New-Object System.Diagnostics.Process
-            $p.StartInfo = $psi
-            $p.Start() | Out-Null
-            $stdout = $p.StandardOutput.ReadToEnd()
-            $p.WaitForExit()
-            if ($stdout) { return $stdout }
-        } catch {
-            Write-Verbose "Winget command failed on attempt $a: $($_.Exception.Message)" -Verbose:$false
-        }
+            $processInfo = New-Object System.Diagnostics.ProcessStartInfo
+            $processInfo.FileName = $wingetPath
+            $processInfo.Arguments = $Arguments
+            $processInfo.RedirectStandardOutput = $true
+            $processInfo.RedirectStandardError = $true
+            $processInfo.UseShellExecute = $false
+            $processInfo.CreateNoWindow = $true
+            $process = New-Object System.Diagnostics.Process
+            $process.StartInfo = $processInfo
+            $process.Start() | Out-Null
+
+            # Drain BOTH output streams before waiting so a full stderr pipe cannot deadlock the child.
+            $stdout = $process.StandardOutput.ReadToEnd()
+            $stderr = $process.StandardError.ReadToEnd()
+            $process.WaitForExit()
+
+            # Base success on the process exit code, not on stdout content.
+            # Success: 0 (S_OK), 0x8A150014 (no packages found - "not installed" for list),
+            # 0x8A150109 (install succeeded, reboot required).
+            # Reference: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
+            if ($process.ExitCode -eq 0 -or $process.ExitCode -eq 0x8A150014 -or $process.ExitCode -eq 0x8A150109) {
+                if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+                return $stdout
+            }
+
+            Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
+            if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
+        } catch { }
         Start-Sleep -Seconds 2
-        $a++
+        $attempt++
     }
-    throw "Failed after 3 attempts"
+    throw "Failed to execute winget after $MaxRetries attempts"
 }
 #endregion
 
 #region Script
 try {
+    # Prefer the Microsoft.WinGet.Client PowerShell module - the winget CLI is NOT supported in
+    # the SYSTEM context (Intune Proactive Remediations run as SYSTEM). Only fall back to the
+    # winget.exe CLI when the module is unavailable.
+    # Reference: https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
+        try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
+        if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+            $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+            if (-not $package) { Write-Host "$ID is not installed on this device."; exit 0 }
+            $name = if ($package.Name) { $package.Name } else { $ID }
+            if ($package.IsUpdateAvailable) {
+                $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+                if ($process) {
+                    Write-Host "$name is currently running, will try again later."
+                    exit 1
+                }
+                $verInstalled = $package.InstalledVersion
+                $verAvailable = $package.AvailableVersions | Select-Object -Last 1
+                Write-Host "Installing $name update ($verInstalled -> $verAvailable)..."
+                Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
+                Start-Sleep -Seconds $VerifyWaitSeconds
+                $verify = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
+                if ($verify) {
+                    Write-Host "$name updated successfully to version $($verify.InstalledVersion)"
+                    [pscustomobject] @{ Name = $name; InstalledVersion = $verify.InstalledVersion; Status = "Updated Successfully" }
+                    exit 0
+                }
+                Write-Error "Failed to verify $name installation after update."
+                exit 1
+            }
+            Write-Host "$name is already up to date."
+            exit 0
+        }
+    }
     
 
-    $packageInfo = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+    $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { "Lenovo System Update" }
 
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
@@ -68,7 +114,7 @@ try {
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
         Start-Sleep -Seconds $VerifyWaitSeconds
 
-        $verify = Invoke-WingetWithRetry -Arguments "list --accept-source-agreements --Id $ID"
+        $verify = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
         if ($verify -match '\d+(\.\d+)+') {
             $ver = (-split $verify[-1])[-2]
             Write-Host "$name updated to version $ver"


### PR DESCRIPTION
Closes #139
Closes #191
Closes #192

Fixes from the 2026-08-08 Microsoft Learn alignment review (MSLEARN-REVIEW.md).

## Summary by Sourcery

Prefer the Microsoft.WinGet.Client PowerShell module over the winget.exe CLI across winget detection and remediation templates and app-specific scripts, while tightening success checks and matching behavior to be exit-code and exact-ID based.

Bug Fixes:
- Ensure winget invocations in detection and remediation scripts treat process exit codes (including documented non-zero success codes) as the source of truth instead of grepping stdout, avoiding false failures and hangs.
- Fix winget list/upgrade commands to use exact ID matching to prevent inadvertent updates when multiple packages share similar identifiers.
- Resolve potential deadlocks when calling winget by draining both stdout and stderr before waiting for process exit in all helper functions.

Enhancements:
- Adopt a module-first strategy that prefers the Microsoft.WinGet.Client PowerShell module for all Intune Proactive Remediations, falling back to winget.exe only when the module or its commands are unavailable.
- Update all winget detection and remediation templates and app-specific scripts (browsers, productivity, runtimes, vendor tools, remote access, media) to use Get-WinGetPackage/Update-WinGetPackage where available for safer, more robust operations.
- Standardize retry, logging, and verification patterns across scripts, including clearer status reporting and consistent use of exact list queries for post-update verification.