### PR TITLE
fix: repair 6 scripts with pre-existing parse errors (unblocks real CI syntax gate)

### DIFF
--- a/scripts/collaboration/microsoft365/azure-ad/Set-UserLanguageSettings.ps1
+++ b/scripts/collaboration/microsoft365/azure-ad/Set-UserLanguageSettings.ps1
@@ -593,3 +593,4 @@ elseif ($nonCompliantCount -gt 0 -and -not $Apply) {
 else {
     exit 0
 }
+}

--- a/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/remediate.ps1
@@ -40,7 +40,7 @@ try {
                 Write-Host "    ✓ Successfully started $svcName"
             } catch {
                 $remediationActions += "Failed to start service: $svcName - $_"
-                Write-Host "    ✗ Failed to start $svcName: $_"
+                Write-Host "    ✗ Failed to start ${svcName}: $_"
             }
         }
     }

--- a/scripts/endpoints/intune/maintenance/Add-LenovoFriendlyModelNames.ps1
+++ b/scripts/endpoints/intune/maintenance/Add-LenovoFriendlyModelNames.ps1
@@ -407,7 +407,7 @@ function Build-NotesLine {
         return $FamilyName
     }
 
-    # Use $() to avoid PowerShell treating "$var:" as scoped variable
+    # Use $() to avoid PowerShell treating "${var}:" as scoped variable
     return "$($NotesPrefix): $FamilyName"
 }
 
@@ -688,7 +688,7 @@ try {
                         -ErrorAction Stop
 
                     $stats.ExtUpdated++
-                    Write-Log "Updated $ExtensionAttributeName for $($device.deviceName) using $methodUsed: $familyName" "Verbose"
+                    Write-Log "Updated $ExtensionAttributeName for $($device.deviceName) using ${methodUsed}: $familyName" "Verbose"
                 }
             }
             elseif ($UpdateExtensionAttributes) {

--- a/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
@@ -187,8 +187,8 @@ if ($IncludeSecurityAnalysis) {
         @{Name = "SQL Injection"; Pattern = "(\%27)|(')|(--)|(\%23)|(#)|(union)|(select)|(insert)|(drop)|(update)|(delete)|(exec)"}
         @{Name = "XSS Attempts"; Pattern = "(<script|javascript:|onerror=|onload=)"}
         @{Name = "Path Traversal"; Pattern = "(\.\./|\.\.\\|%2e%2e)"}
-        @{Name = "Command Injection"; Pattern = "(\||;|`|\\$\(|\${)"}
-    }
+        @{Name = 'Command Injection'; Pattern = '(\||;|`|\\$\(|\${)'}
+    )
 
     $analysis.SecurityThreats = @()
     foreach ($pattern in $suspiciousPatterns) {

--- a/scripts/infrastructure/windows/active-directory/Get-ADUserAudit.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ADUserAudit.ps1
@@ -253,7 +253,7 @@ try {
                 }
             }
             catch {
-                Write-Warning "Could not process group $groupName: $_"
+                Write-Warning "Could not process group ${groupName}: $_"
             }
         }
 

--- a/scripts/security/monitoring/Get-SystemHealthCheck.ps1
+++ b/scripts/security/monitoring/Get-SystemHealthCheck.ps1
@@ -208,7 +208,7 @@ try {
             $serviceColor = if ($service.Status -eq 'Running') {'Green'} else {'Red'}
             Write-Host "  $($service.DisplayName): $($service.Status)" -ForegroundColor $serviceColor
         } else {
-            Write-Host "  $serviceName: Not Found" -ForegroundColor Yellow
+            Write-Host "  ${serviceName}: Not Found" -ForegroundColor Yellow
         }
     }
 } catch {


### PR DESCRIPTION
Fixes pre-existing parse errors in 6 scripts that the old PSParser-based CI gate never caught (the fixed gate in #229 scans all of scripts/).

These files parse-fail under [System.Management.Automation.Language.Parser]::ParseFile and would break at load time.

Required before the validate-powershell.yml syntax-gate fix (#229) can pass CI.

## Summary by Sourcery

Fix PowerShell parse errors in multiple scripts to allow the updated syntax gate to run across the scripts directory.

Bug Fixes:
- Correct variable interpolation in log and host messages to avoid misparsed scoped variable syntax.
- Fix hashtable and block termination syntax in IIS log analyzer security patterns.
- Add missing closing brace in Azure AD user language settings script to restore valid script structure.