### PR TITLE
fix: enforce PSSA style/help/ShouldProcess in endpoints/devices

### DIFF
--- a/scripts/endpoints/devices/adobe-rum/detect.ps1
+++ b/scripts/endpoints/devices/adobe-rum/detect.ps1
@@ -1,4 +1,22 @@
 <#
+.SYNOPSIS
+    Detect Adobe Creative Cloud app updates via Remote Update Manager
+
+.DESCRIPTION
+    Runs the Adobe Remote Update Manager (RUM) in detection mode to determine whether any Adobe Creative Cloud apps require an update. Exits 1 when updates are required (so the paired remediation runs) and 0 when the system is up to date or RUM is not present. Must run in the SYSTEM context.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
+<#
 ===============================
 |  Detect-AdobeCCUpdates.ps1  |
 ===============================
@@ -117,7 +135,7 @@ $productNames = @{
 #endregion
 
 #region Main process
-if (!(Test-Path $LogPath)) {mkdir $LogPath -Force | Out-Null}
+if (!(Test-Path $LogPath)) { mkdir $LogPath -Force | Out-Null }
 
 Start-Transcript -Path $LogFile -Force
 
@@ -158,38 +176,45 @@ try {
         $resultsstring = (($results -join ", " ) -replace "`r`n", ", ").Trim()
 
         # Search the output for the string
-        $ARUMStatus = $ARUMOutput | ForEach-Object {"$_" | Select-String -Pattern $updatesrequired}
+        $ARUMStatus = $ARUMOutput | ForEach-Object { "$_" | Select-String -Pattern $updatesrequired }
         if ($ARUMStatus.Matches.Success -eq "True") {
             # proceed to remediation script
-            If ($InstalledVersion -ge $LatestVersion){
+            if ($InstalledVersion -ge $LatestVersion) {
                 Write-Output "$($results.count) updates are required for the following Adobe Creative Cloud Apps: $($resultsstring)"
                 exit 1 # Return a non-zero exit code to trigger the remediation
-            } else {
+            }
+            else {
                 Write-Output "$($results.count) updates are required for the following Adobe Creative Cloud Apps: $($resultsstring) N.B. Adobe RUM is not the latest version ($($LatestVersion)), the version on this machine ($($InstalledVersion)) should be updated"
                 exit 1 # Return a non-zero exit code to trigger the remediation
             }
-        } else {
+        }
+        else {
             # nothing further to do
-            If ($InstalledVersion -ge $LatestVersion){
+            if ($InstalledVersion -ge $LatestVersion) {
                 Write-Output "No updates are required for Adobe Creative Cloud Apps"
                 exit 0  # Return a zero exit code to indicate success
-            } else {
+            }
+            else {
                 Write-Output "No updates are required for Adobe Creative Cloud Apps. N.B. Adobe RUM is not the latest version ($($LatestVersion)), the version on this machine ($($InstalledVersion)) should be updated"
                 exit 0  # Return a zero exit code to indicate success
             }
         }
-    } else {
+    }
+    else {
         Write-Output "Adobe RUM not found N.B. Check if RUM should exist on this device"
         exit 0
     }
-} catch {
+}
+catch {
     $errorMsg = $_.Exception.Message
-} finally {
+}
+finally {
     if ($errorMsg) {
         Write-Output "Something went wrong: $errorMsg"
         Stop-Transcript | Out-Null
-        Throw $errorMsg
-} else {
+        throw $errorMsg
+    }
+    else {
         Stop-Transcript | Out-Null
     }
 }

--- a/scripts/endpoints/devices/adobe-rum/remediate.ps1
+++ b/scripts/endpoints/devices/adobe-rum/remediate.ps1
@@ -1,4 +1,22 @@
 <#
+.SYNOPSIS
+    Remediate Adobe Creative Cloud app updates via Remote Update Manager
+
+.DESCRIPTION
+    Runs the Adobe Remote Update Manager (RUM) to install all applicable Adobe Creative Cloud app updates, logs the results, and exits 0 on success. Must run in the SYSTEM context.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
+<#
 ==================================
 |  Remediate-AdobeCCUpdates.ps1  |
 ==================================
@@ -113,7 +131,7 @@ $productNames = @{
 #endregion
 
 #region Main process
-if (!(Test-Path $LogPath)) {mkdir $LogPath -Force | Out-Null}
+if (!(Test-Path $LogPath)) { mkdir $LogPath -Force | Out-Null }
 
 Start-Transcript -Path $LogFile -Force
 
@@ -121,20 +139,20 @@ try {
     # Run Adobe Remote Update Manager and capture its output
     $ARUMOutput = (& "$ARUMPath") 2>&1 | Out-String
 	
-	# Use regex to find the app codes, version numbers, and platforms in the text string
+    # Use regex to find the app codes, version numbers, and platforms in the text string
     $discoveries = [regex]::Matches($ARUMOutput, $regexpattern)
 	
-	# Create an array to store the results
-	$results = @()
+    # Create an array to store the results
+    $results = @()
 	
-	# Loop through the regex matches and add a row to the results array for each app
-	foreach ($discovered in $discoveries) {
-		$SapCode = $discovered.Groups[1].Value
-		$versionNumber = $discovered.Groups[2].Value
-		#$platform = $discovered.Groups[3].Value
-		$productName = $productNames[$SapCode]
+    # Loop through the regex matches and add a row to the results array for each app
+    foreach ($discovered in $discoveries) {
+        $SapCode = $discovered.Groups[1].Value
+        $versionNumber = $discovered.Groups[2].Value
+        #$platform = $discovered.Groups[3].Value
+        $productName = $productNames[$SapCode]
 
-		<#
+        <#
 		# Add a row to the results array
 		$results += [pscustomobject]@{
 			"Product Name" = $productName
@@ -143,29 +161,33 @@ try {
 			"Platform Architecture" = $platform
 		}
 		#>
-		$results += "$($productName) ($($SapCode)) (v$($versionNumber))"
-	}
+        $results += "$($productName) ($($SapCode)) (v$($versionNumber))"
+    }
     
-	# Convert $results array to a string and join each line with a comma (so content can be output in PR results)
+    # Convert $results array to a string and join each line with a comma (so content can be output in PR results)
     $resultsstring = (($results -join ", " ) -replace "`r`n", ", ").Trim()
 	
-	# Search the output for the string
-	$ARUMStatus = $ARUMOutput | ForEach-Object {"$_" | Select-String -Pattern $updatesinstalled}
-	if ($ARUMStatus.Matches.Success -eq "True") {
-		# proceed to remediation script
-		Write-Output "$($results.count) updates were successfully installed for the following Adobe Creative Cloud Apps: $($resultsstring)"
-	} else {
-		# nothing further to do
-		Write-Output "No updates are required for Adobe Creative Cloud Apps"
-	}
-} catch {
+    # Search the output for the string
+    $ARUMStatus = $ARUMOutput | ForEach-Object { "$_" | Select-String -Pattern $updatesinstalled }
+    if ($ARUMStatus.Matches.Success -eq "True") {
+        # proceed to remediation script
+        Write-Output "$($results.count) updates were successfully installed for the following Adobe Creative Cloud Apps: $($resultsstring)"
+    }
+    else {
+        # nothing further to do
+        Write-Output "No updates are required for Adobe Creative Cloud Apps"
+    }
+}
+catch {
     $errorMsg = $_.Exception.Message
-} finally {
+}
+finally {
     if ($errorMsg) {
         Write-Output "Something went wrong: $errorMsg"
         Stop-Transcript | Out-Null
-        Throw $errorMsg
-} else {
+        throw $errorMsg
+    }
+    else {
         Stop-Transcript | Out-Null
     }
 }

--- a/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect the NoAutoUpdate Windows Update policy (DisableWindowsUpdateAccess pair)
+
+.DESCRIPTION
+    The DisableWindowsUpdateAccess policy is unsupported on Windows 10+ / Server 2016+; this pair instead manages the supported WUaaS policy NoAutoUpdate. Exits 1 when NoAutoUpdate is present under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU and 0 otherwise.
+
+.EXAMPLE
+    ./Detect.ps1
+
+.NOTES
+    File Name  : Detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect: the policy "Remove access to use all Windows Update features"
 # (DisableWindowsUpdateAccess) is NOT supported on Windows 10 and later or
 # Windows Server 2016 and later. This pair instead detects the supported
@@ -6,6 +24,7 @@
 # See https://learn.microsoft.com/en-us/windows/deployment/update/waas-wu-settings
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains 'NoAutoUpdate') {
     exit 1
-} else {
+}
+else {
     exit 0
 } 

--- a/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DisableWindowsUpdateAccess/Remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the NoAutoUpdate Windows Update policy (DisableWindowsUpdateAccess pair)
+
+.DESCRIPTION
+    Removes the NoAutoUpdate value from HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU (the supported WUaaS control managed by this pair; DisableWindowsUpdateAccess itself is unsupported on Windows 10+ / Server 2016+).
+
+.EXAMPLE
+    ./Remediate.ps1
+
+.NOTES
+    File Name  : Remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate: remove the NoAutoUpdate policy (see Detect.ps1 for the policy
 # rationale - DisableWindowsUpdateAccess is unsupported on Windows 10+ /
 # Server 2016+, so this pair manages the supported WUaaS policy NoAutoUpdate

--- a/scripts/endpoints/devices/autopatch/V1/DoNotConnectToWindowsUpdateInternetLocations/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DoNotConnectToWindowsUpdateInternetLocations/Detect.ps1
@@ -1,5 +1,24 @@
+<#
+.SYNOPSIS
+    Detect the DoNotConnectToWindowsUpdateInternetLocations Windows Update policy
+
+.DESCRIPTION
+    Exits 1 when the DoNotConnectToWindowsUpdateInternetLocations value is present under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate and 0 otherwise, so the paired remediation can remove it.
+
+.EXAMPLE
+    ./Detect.ps1
+
+.NOTES
+    File Name  : Detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'DoNotConnectToWindowsUpdateInternetLocations') {
     exit 1
-} else {
+}
+else {
     exit 0
 } 

--- a/scripts/endpoints/devices/autopatch/V1/DoNotConnectToWindowsUpdateInternetLocations/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/DoNotConnectToWindowsUpdateInternetLocations/Remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the DoNotConnectToWindowsUpdateInternetLocations Windows Update policy
+
+.DESCRIPTION
+    Removes the DoNotConnectToWindowsUpdateInternetLocations value from HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate so the device can connect to Windows Update internet locations.
+
+.EXAMPLE
+    ./Remediate.ps1
+
+.NOTES
+    File Name  : Remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'DoNotConnectToWindowsUpdateInternetLocations') {
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "DoNotConnectToWindowsUpdateInternetLocations"
 }

--- a/scripts/endpoints/devices/autopatch/V1/NoAutoUpdate/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/NoAutoUpdate/Detect.ps1
@@ -1,5 +1,24 @@
+<#
+.SYNOPSIS
+    Detect the NoAutoUpdate Windows Update policy
+
+.DESCRIPTION
+    Exits 1 when the NoAutoUpdate value is present under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU and 0 otherwise, so the paired remediation can remove it.
+
+.EXAMPLE
+    ./Detect.ps1
+
+.NOTES
+    File Name  : Detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU).PSObject.Properties.Name -contains 'NoAutoUpdate') {
     exit 1
-} else {
+}
+else {
     exit 0
 } 

--- a/scripts/endpoints/devices/autopatch/V1/NoAutoUpdate/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/NoAutoUpdate/Remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the NoAutoUpdate Windows Update policy
+
+.DESCRIPTION
+    Removes the NoAutoUpdate value from HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU so automatic Windows Update behaviour is restored.
+
+.EXAMPLE
+    ./Remediate.ps1
+
+.NOTES
+    File Name  : Remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU).PSObject.Properties.Name -contains 'NoAutoUpdate') {
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "NoAutoUpdate"
 }

--- a/scripts/endpoints/devices/autopatch/V1/UseWUServer/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/UseWUServer/Detect.ps1
@@ -1,5 +1,24 @@
+<#
+.SYNOPSIS
+    Detect the UseWUServer Windows Update policy
+
+.DESCRIPTION
+    Exits 1 when the UseWUServer value is present under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU (indicating WSUS is configured) and 0 otherwise, so the paired remediation can remove it.
+
+.EXAMPLE
+    ./Detect.ps1
+
+.NOTES
+    File Name  : Detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU).PSObject.Properties.Name -contains 'UseWUServer') {
     exit 1
-} else {
+}
+else {
     exit 0
 } 

--- a/scripts/endpoints/devices/autopatch/V1/UseWUServer/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/UseWUServer/Remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the UseWUServer Windows Update policy
+
+.DESCRIPTION
+    Removes the UseWUServer value from HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU so the device stops using the WSUS server.
+
+.EXAMPLE
+    ./Remediate.ps1
+
+.NOTES
+    File Name  : Remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU).PSObject.Properties.Name -contains 'UseWUServer') {
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Name "UseWUServer"
 }

--- a/scripts/endpoints/devices/autopatch/V1/WUServer/Detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/WUServer/Detect.ps1
@@ -1,5 +1,24 @@
+<#
+.SYNOPSIS
+    Detect the WUServer Windows Update policy
+
+.DESCRIPTION
+    Exits 1 when the WUServer value is present under HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate (indicating a WSUS server is configured) and 0 otherwise, so the paired remediation can remove it.
+
+.EXAMPLE
+    ./Detect.ps1
+
+.NOTES
+    File Name  : Detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'WUServer') {
     exit 1
-} else {
+}
+else {
     exit 0
 } 

--- a/scripts/endpoints/devices/autopatch/V1/WUServer/Remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V1/WUServer/Remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the WUServer Windows Update policy
+
+.DESCRIPTION
+    Removes the WUServer value from HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate so the device stops using the configured WSUS server.
+
+.EXAMPLE
+    ./Remediate.ps1
+
+.NOTES
+    File Name  : Remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 if ((Get-ItemProperty HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate).PSObject.Properties.Name -contains 'WUServer') {
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" -Name "WUServer"
 }

--- a/scripts/endpoints/devices/autopatch/V2/AP_Detection.ps1
+++ b/scripts/endpoints/devices/autopatch/V2/AP_Detection.ps1
@@ -1,13 +1,30 @@
+<#
+.SYNOPSIS
+    Detect Windows Update policy drift (Autopatch V2)
+
+.DESCRIPTION
+    Checks the registry for the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations and NoAutoUpdate (the supported WUaaS controls; DisableWindowsUpdateAccess is unsupported on Windows 10+ / Server 2016+). Exits 1 when drift is found so the paired remediation can remove the values. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./AP_Detection.ps1
+
+.NOTES
+    File Name  : AP_Detection.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchDetection.log"
-new-item $TranscriptPath -ItemType Directory -Force
+New-Item $TranscriptPath -ItemType Directory -Force
 
 # stopping orphaned transcripts
-try
-{
-    stop-transcript|out-null
+try {
+    Stop-Transcript | Out-Null
 }
-  catch [System.InvalidOperationException]
+catch [System.InvalidOperationException]
 {}
 
 Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
@@ -19,30 +36,26 @@ Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
 # NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
 # is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
 # NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
-$regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
-$regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\"}
+$regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" }
+$regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 
 
-foreach ($setting in $regkeys)
-{
-    write-host "checking $($setting.name)"
-    if((Get-Item $setting.path -ErrorAction Ignore).Property  -contains $setting.name)
-    {
-        write-host "$($setting.name) is not correct"
+foreach ($setting in $regkeys) {
+    Write-Host "checking $($setting.name)"
+    if ((Get-Item $setting.path -ErrorAction Ignore).Property -contains $setting.name) {
+        Write-Host "$($setting.name) is not correct"
         $RemediationNeeded = $true
     }
 }
 
 
-if ($RemediationNeeded -eq $true)
-{
-    write-host "registry settings are incorrect"
+if ($RemediationNeeded -eq $true) {
+    Write-Host "registry settings are incorrect"
     Stop-Transcript
     exit 1
 }
-else 
-{
-    write-host "registry settings are correct"
+else {
+    Write-Host "registry settings are correct"
     Stop-Transcript
     exit 0
 }

--- a/scripts/endpoints/devices/autopatch/V2/AP_Remediation.ps1
+++ b/scripts/endpoints/devices/autopatch/V2/AP_Remediation.ps1
@@ -1,13 +1,30 @@
+<#
+.SYNOPSIS
+    Remediate Windows Update policy drift (Autopatch V2)
+
+.DESCRIPTION
+    Removes the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations and NoAutoUpdate from the registry so devices return to the default Windows Update behaviour. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./AP_Remediation.ps1
+
+.NOTES
+    File Name  : AP_Remediation.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchRemediation.log"
-new-item $TranscriptPath -ItemType Directory -Force
+New-Item $TranscriptPath -ItemType Directory -Force
 
 # stopping orphaned transcripts
-try
-{
-    stop-transcript|out-null
+try {
+    Stop-Transcript | Out-Null
 }
-  catch [System.InvalidOperationException]
+catch [System.InvalidOperationException]
 {}
 
 Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
@@ -19,20 +36,17 @@ Start-Transcript -Path $TranscriptPath\$TranscriptName -Append
 # NOTE: "DisableWindowsUpdateAccess" ("Remove access to use all Windows Update features")
 # is not supported on Windows 10+ / Server 2016+; the supported WUaaS control is
 # NoAutoUpdate under ...\WindowsUpdate\AU (see waas-wu-settings).
-$regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\"}
-$regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\"}
+$regkeys += [PsObject]@{ Name = "DoNotConnectToWindowsUpdateInternetLocations"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\" }
+$regkeys += [PsObject]@{ Name = "NoAutoUpdate"; path = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU\" }
 
-foreach ($setting in $regkeys)
-{
-    write-host "checking $($setting.name)"
-    if((Get-Item $setting.path -ErrorAction Ignore).Property -contains $setting.name)
-    {
-        write-host "remediating $($setting.name)"
+foreach ($setting in $regkeys) {
+    Write-Host "checking $($setting.name)"
+    if ((Get-Item $setting.path -ErrorAction Ignore).Property -contains $setting.name) {
+        Write-Host "remediating $($setting.name)"
         Remove-ItemProperty -Path $setting.path -Name $($setting.name)
     }
-    else
-    {
-        write-host "$($setting.name) was not found"
+    else {
+        Write-Host "$($setting.name) was not found"
     }
 }
 Stop-Transcript

--- a/scripts/endpoints/devices/autopatch/V3/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V3/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect Windows Update policy drift (Autopatch V3)
+
+.DESCRIPTION
+    Checks the registry for the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations and NoAutoUpdate (the supported WUaaS controls; DisableWindowsUpdateAccess is unsupported on Windows 10+ / Server 2016+). Exits 1 when drift is found so the paired remediation can remove the values.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchDetection.log"
 New-Item -Path $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -29,6 +47,7 @@ Stop-Transcript
 
 if ($RemediationNeeded) {
     exit 1  # Remediation needed
-} else {
+}
+else {
     exit 0  # All clear
 }

--- a/scripts/endpoints/devices/autopatch/V3/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V3/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remediate Windows Update policy drift (Autopatch V3)
+
+.DESCRIPTION
+    Removes the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations and NoAutoUpdate from the registry so devices return to the default Windows Update behaviour. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchRemediation.log"
 New-Item -Path $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -20,7 +38,8 @@ foreach ($setting in $regkeys) {
     if ((Get-Item $setting.Path -ErrorAction Ignore).Property -contains $setting.Name) {
         Write-Host "Removing $($setting.Name)"
         Remove-ItemProperty -Path $setting.Path -Name $setting.Name -Force
-    } else {
+    }
+    else {
         Write-Host "$($setting.Name) not found"
     }
 }

--- a/scripts/endpoints/devices/autopatch/V4/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V4/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect Windows Update policy drift (Autopatch V4)
+
+.DESCRIPTION
+    Checks the registry for the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations, NoAutoUpdate, WUServer and UseWUServer (the supported WUaaS controls; DisableWindowsUpdateAccess is unsupported on Windows 10+ / Server 2016+). Exits 1 when drift is found so the paired remediation can remove the values. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchDetection.log"
 New-Item -Path $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -25,7 +43,8 @@ foreach ($setting in $regkeys) {
     if ((Get-ItemProperty -Path $setting.Path -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains $setting.Name) {
         Write-Host "Found: $($setting.Name)"
         $RemediationNeeded = $true
-    } else {
+    }
+    else {
         Write-Host "Not present: $($setting.Name)"
     }
 }

--- a/scripts/endpoints/devices/autopatch/V4/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V4/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remediate Windows Update policy drift (Autopatch V4)
+
+.DESCRIPTION
+    Removes the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations, NoAutoUpdate, WUServer and UseWUServer from the registry so devices return to the default Windows Update behaviour. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchRemediation.log"
 New-Item -Path $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -19,10 +37,12 @@ foreach ($setting in $regkeys) {
         if ((Get-ItemProperty -Path $setting.Path -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains $setting.Name) {
             Remove-ItemProperty -Path $setting.Path -Name $setting.Name -Force
             Write-Host "🧹 Removed: $($setting.Name)"
-        } else {
+        }
+        else {
             Write-Host "Already clean: $($setting.Name)"
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Could not remove $($setting.Name): $_"
     }
 }

--- a/scripts/endpoints/devices/autopatch/V5/detect.ps1
+++ b/scripts/endpoints/devices/autopatch/V5/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect Windows Update policy drift (Autopatch V5)
+
+.DESCRIPTION
+    Checks the registry for the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations, NoAutoUpdate, WUServer and UseWUServer (the supported WUaaS controls; DisableWindowsUpdateAccess is unsupported on Windows 10+ / Server 2016+). Exits 1 when drift is found so the paired remediation can remove the values. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchDetection.log"
 New-Item $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -32,6 +50,7 @@ Stop-Transcript
 
 if ($RemediationNeeded) {
     exit 1
-} else {
+}
+else {
     exit 0
 }

--- a/scripts/endpoints/devices/autopatch/V5/remediate.ps1
+++ b/scripts/endpoints/devices/autopatch/V5/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remediate Windows Update policy drift (Autopatch V5)
+
+.DESCRIPTION
+    Removes the Windows Update policies DoNotConnectToWindowsUpdateInternetLocations, NoAutoUpdate, WUServer and UseWUServer from the registry so devices return to the default Windows Update behaviour. Logs via Start-Transcript.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 $TranscriptPath = "C:\ProgramData\Microsoft\IntuneManagementExtension\Logs"
 $TranscriptName = "AutoPatchRemediation.log"
 New-Item $TranscriptPath -ItemType Directory -Force | Out-Null
@@ -23,7 +41,8 @@ foreach ($setting in $regkeys) {
     if ((Get-Item $setting.Path -ErrorAction Ignore).Property -contains $setting.Name) {
         Write-Host "Removing $($setting.Name)"
         Remove-ItemProperty -Path $setting.Path -Name $setting.Name -ErrorAction SilentlyContinue
-    } else {
+    }
+    else {
         Write-Host "$($setting.Name) not found"
     }
 }

--- a/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
+++ b/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
@@ -27,10 +27,10 @@ function Test-DeviceJoinStatus {
         }
 
         # Check the result for "AzureAdJoined : YES" - if it exists, the device is Azure AD joined
-        $AzureAdJoined = if($result -match "AzureAdJoined : YES"){"Yes"} else {"No"}
+        $AzureAdJoined = if ($result -match "AzureAdJoined : YES") { "Yes" } else { "No" }
 
         # Similarly, check the result for "DomainJoined : YES" - if it exists, the device is Domain joined
-        $DomainJoined = if($result -match "DomainJoined : YES"){"Yes"} else {"No"}
+        $DomainJoined = if ($result -match "DomainJoined : YES") { "Yes" } else { "No" }
 
         # Retrieve the hostname of the device
         $hostname = $env:COMPUTERNAME
@@ -77,7 +77,7 @@ function Test-AzureADBitLockerBackup {
     #>
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [int]
         $nDays = 1
     )
@@ -90,13 +90,13 @@ function Test-AzureADBitLockerBackup {
         $systemDrive = $env:SystemDrive
 
         # Get the BitLocker Management event log events with ID 845 and Level 4 (Information) from the past nDays
-        $events = Get-WinEvent -FilterHashTable @{LogName="Microsoft-Windows-BitLocker/BitLocker Management"; ID=845; Level=4; StartTime=$pastDate} -ErrorAction Stop
+        $events = Get-WinEvent -FilterHashTable @{LogName = "Microsoft-Windows-BitLocker/BitLocker Management"; ID = 845; Level = 4; StartTime = $pastDate } -ErrorAction Stop
 
         # If events exist, check if any of them are for the system drive
         if ($events) {
             foreach ($event in $events) {
                 $eventData = [xml]$event.ToXml()
-                $volume = $eventData.Event.EventData.Data | Where-Object {$_.Name -eq 'VolumeMountPoint'} | Select-Object -ExpandProperty '#text'
+                $volume = $eventData.Event.EventData.Data | Where-Object { $_.Name -eq 'VolumeMountPoint' } | Select-Object -ExpandProperty '#text'
                 if ($volume -eq $systemDrive) {
                     Write-Host "BitLocker key backup to Azure AD for the system drive ($systemDrive) was successful in the past $nDays day(s)." -ForegroundColor Green
                     return 0
@@ -105,7 +105,8 @@ function Test-AzureADBitLockerBackup {
 
             Write-Host "No events found in the past $nDays day(s) indicating successful BitLocker key backup to Azure AD for the system drive ($systemDrive)." -ForegroundColor Yellow
             return 1
-        } else {
+        }
+        else {
             Write-Host "No events found in the past $nDays day(s) indicating successful BitLocker key backup to Azure AD." -ForegroundColor Yellow
             return 1
         }
@@ -131,7 +132,7 @@ function Test-OSBitLockerStatus {
     #>
 
     # Identify the system drive
-    $systemDrive = [Environment]::GetFolderPath("System").Substring(0,2)
+    $systemDrive = [Environment]::GetFolderPath("System").Substring(0, 2)
 
     # Get the BitLocker volume status for the system drive
     $BitLockerVolume = Get-BitLockerVolume -MountPoint $systemDrive
@@ -205,11 +206,11 @@ function Get-BitLockerVolumeInfo {
     param (
     )
 
-    Begin {
+    begin {
         Write-Host "Starting BitLocker volume information retrieval process." -ForegroundColor Cyan
     }
 
-    Process {
+    process {
         try {
             # Get BitLocker volumes
             $BitLockerVolumes = Get-BitLockerVolume -ErrorAction Stop
@@ -237,7 +238,7 @@ function Get-BitLockerVolumeInfo {
         }
     }
 
-    End {
+    end {
         Write-Host "BitLocker volume information retrieval process completed." -ForegroundColor Cyan
         return $volumeInfoString
     }
@@ -282,7 +283,7 @@ Write-Host "`n`n"
 # Then it exits the script with a success status code (0).
 if ($bitlockerBackupStatus -eq 0) {
     Write-Host "OK $([datetime]::Now) : $txtStatus"
-    Exit 0
+    exit 0
 }
 
 # If the BitLocker key backup to Azure AD has failed ($bitlockerBackupStatus equals 1),
@@ -290,7 +291,7 @@ if ($bitlockerBackupStatus -eq 0) {
 # Then it exits the script with an error status code (1). This will call the Remediation script.
 elseif ($bitlockerBackupStatus -eq 1) {
     Write-Host "FAIL $([datetime]::Now) : $txtStatus"
-    Exit 1
+    exit 1
 }
 
 # If the value of $bitlockerBackupStatus is anything other than 0 or 1,
@@ -299,7 +300,7 @@ elseif ($bitlockerBackupStatus -eq 1) {
 #   but something is wrong, something that can't be fix with Remediation script.
 else {
     Write-Host "WARNING $([datetime]::Now) : $txtStatus"
-    Exit 0
+    exit 0
 }
 
 #endregion Main

--- a/scripts/endpoints/devices/bitlocker/Fix_BitLockerKeyBackup.ps1
+++ b/scripts/endpoints/devices/bitlocker/Fix_BitLockerKeyBackup.ps1
@@ -14,12 +14,12 @@ function Backup-BitLockerKeyToAAD {
     param (
     )
 
-    Begin {
+    begin {
         Write-Host "Starting BitLocker Key Backup process to Azure AD." -ForegroundColor Cyan
         $script:BackupFailed = $false
     }
 
-    Process {
+    process {
         try {
             # Get BitLocker volumes
             $BitLockerVolumes = Get-BitLockerVolume -ErrorAction Stop
@@ -58,7 +58,7 @@ function Backup-BitLockerKeyToAAD {
         }
     }
 
-    End {
+    end {
         Write-Host "`n`n"
         Write-Host "BitLocker Key Backup process to Azure AD completed." -ForegroundColor Cyan
         Write-Host $driveInfoString

--- a/scripts/endpoints/devices/drivers/BlockAMDDriver.ps1
+++ b/scripts/endpoints/devices/drivers/BlockAMDDriver.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Block the AMD Radeon driver via DeviceInstallation policy
+
+.DESCRIPTION
+    Applies the DeviceInstallation policy that blocks the AMD Radeon hardware ID (PCIVEN_1002&DEV_1681) by merging it into the DenyDeviceIDs multi-string value under HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Restrictions and setting the DenyDeviceIDsRetroactive flag so already-installed devices are blocked too.
+
+.EXAMPLE
+    ./BlockAMDDriver.ps1
+
+.NOTES
+    File Name  : BlockAMDDriver.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Block the AMD Radeon driver (DeviceInstallation policy)
 #
 # Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
@@ -32,4 +50,4 @@ if ($denyList -notcontains $RegValue) {
 Set-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -Value 1 -Type DWord -Force
 
 Write-Output "AMD Radeon driver block policy applied."
-Exit 0
+exit 0

--- a/scripts/endpoints/devices/drivers/UnblockAMDDriver.ps1
+++ b/scripts/endpoints/devices/drivers/UnblockAMDDriver.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove the AMD Radeon driver block
+
+.DESCRIPTION
+    Removes the AMD Radeon hardware ID (PCIVEN_1002&DEV_1681) from the DeviceInstallation DenyDeviceIDs policy and clears the DenyDeviceIDsRetroactive flag so previously blocked AMD Radeon drivers are no longer denied.
+
+.EXAMPLE
+    ./UnblockAMDDriver.ps1
+
+.NOTES
+    File Name  : UnblockAMDDriver.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Unblock the AMD Radeon driver (DeviceInstallation policy)
 #
 # Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
@@ -20,18 +38,21 @@ if (Test-Path $RegPath) {
     if ($remaining.Count -gt 0) {
         Set-ItemProperty -Path $RegPath -Name $RegValueName -Value $remaining -Type MultiString -Force
         Write-Output "Removed AMD device block: $RegValue"
-    } elseif ($denyList.Count -gt 0) {
+    }
+    elseif ($denyList.Count -gt 0) {
         # The list only contained the AMD ID - remove the value entirely
         Remove-ItemProperty -Path $RegPath -Name $RegValueName -ErrorAction SilentlyContinue
         Write-Output "Removed AMD device block: $RegValue"
-    } else {
+    }
+    else {
         Write-Output "AMD device block was not present."
     }
 
     # Clear the retroactive flag so previously blocked devices are no longer denied
     Remove-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -ErrorAction SilentlyContinue
-} else {
+}
+else {
     Write-Output "Registry path does not exist. No action needed."
 }
 
-Exit 0
+exit 0

--- a/scripts/endpoints/devices/drivers/detect.ps1
+++ b/scripts/endpoints/devices/drivers/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect if the AMD Radeon driver block is applied
+
+.DESCRIPTION
+    Checks whether the DeviceInstallation DenyDeviceIDs policy contains the AMD Radeon hardware ID (PCIVEN_1002&DEV_1681). Skips non-target Lenovo 21L8S0VP00 devices and exits 0; exits 1 when the driver block is missing on a target device.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect if the AMD Radeon driver block (DeviceInstallation policy) is applied
 #
 # Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
@@ -10,7 +28,7 @@ $DeviceModel = (Get-CimInstance -ClassName Win32_ComputerSystem).Model
 
 if ($DeviceModel -ne "21L8S0VP00") {
     Write-Output "Device is not a Lenovo 21L8S0VP00. No action needed."
-    Exit 0
+    exit 0
 }
 
 # Documented registry location
@@ -26,8 +44,9 @@ if (Test-Path $RegPath) {
 
 if ($denyList -contains $RegValue) {
     Write-Output "Driver block is already applied."
-    Exit 0
-} else {
+    exit 0
+}
+else {
     Write-Output "Driver block is missing."
-    Exit 1
+    exit 1
 }

--- a/scripts/endpoints/devices/drivers/remediate.ps1
+++ b/scripts/endpoints/devices/drivers/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Apply the AMD Radeon driver block
+
+.DESCRIPTION
+    Applies the DeviceInstallation DenyDeviceIDs policy for the AMD Radeon hardware ID (PCIVEN_1002&DEV_1681) on target Lenovo 21L8S0VP00 devices, including the DenyDeviceIDsRetroactive flag so already-installed devices are blocked. Non-target devices exit 0 without changes.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate: apply the AMD Radeon driver block (DeviceInstallation policy)
 #
 # Documented layout (Policy CSP PreventInstallationOfMatchingDeviceIDs / ADMX
@@ -11,7 +29,7 @@ $DeviceModel = (Get-CimInstance -ClassName Win32_ComputerSystem).Model
 
 if ($DeviceModel -ne "21L8S0VP00") {
     Write-Output "Device is not a Lenovo 21L8S0VP00. No action needed."
-    Exit 0
+    exit 0
 }
 
 # Documented registry location
@@ -39,4 +57,4 @@ if ($denyList -notcontains $RegValue) {
 Set-ItemProperty -Path $RegPath -Name "DenyDeviceIDsRetroactive" -Value 1 -Type DWord -Force
 
 Write-Output "AMD Radeon driver block policy applied."
-Exit 0
+exit 0

--- a/scripts/endpoints/devices/proactive-remediations/Check-ApplicationCrashes/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-ApplicationCrashes/detect.ps1
@@ -161,7 +161,8 @@ try {
     Write-Host "`nNo significant application crashes detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking application crashes: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-ApplicationCrashes/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-ApplicationCrashes/remediate.ps1
@@ -54,7 +54,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during application crash remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-BatteryHealth/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-BatteryHealth/detect.ps1
@@ -43,7 +43,8 @@ try {
             # Handle multi-battery systems - get first battery or single battery
             $battery = if ($batteryReport.BatteryReport.Batteries.Battery -is [array]) {
                 $batteryReport.BatteryReport.Batteries.Battery[0]
-            } else {
+            }
+            else {
                 $batteryReport.BatteryReport.Batteries.Battery
             }
 
@@ -51,11 +52,13 @@ try {
             if ($battery.DesignCapacity -and $battery.FullChargeCapacity) {
                 $designCapacity = [int]$battery.DesignCapacity
                 $fullChargeCapacity = [int]$battery.FullChargeCapacity
-            } else {
+            }
+            else {
                 $designCapacity = 0
                 $fullChargeCapacity = 0
             }
-        } else {
+        }
+        else {
             $designCapacity = 0
             $fullChargeCapacity = 0
         }
@@ -99,7 +102,8 @@ try {
     Write-Host "Battery health is acceptable"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking battery health: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-BatteryHealth/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-BatteryHealth/remediate.ps1
@@ -34,7 +34,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error generating battery report: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-BootPerformance/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-BootPerformance/detect.ps1
@@ -53,7 +53,8 @@ try {
 
                 if ($bootTimeSec -gt $maxBootSeconds) {
                     $issues += "Boot time is $bootTimeSec seconds (threshold: $maxBootSeconds seconds)"
-                } elseif ($bootTimeSec -gt $warningBootSeconds) {
+                }
+                elseif ($bootTimeSec -gt $warningBootSeconds) {
                     Write-Host "  Warning: Boot time approaching threshold ($bootTimeSec / $maxBootSeconds seconds)"
                 }
             }
@@ -104,7 +105,8 @@ try {
             $issues += "Boot performance degradation events detected in last 7 days"
         }
 
-    } else {
+    }
+    else {
         $issues += "Unable to retrieve boot information"
     }
 
@@ -120,7 +122,8 @@ try {
     Write-Host "`nBoot performance is within acceptable limits"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking boot performance: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-BootPerformance/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-BootPerformance/remediate.ps1
@@ -48,7 +48,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during boot performance remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DefenderHealthStatus/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DefenderHealthStatus/detect.ps1
@@ -59,7 +59,8 @@ try {
     Write-Host "Windows Defender is healthy and up to date"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Defender status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DefenderHealthStatus/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DefenderHealthStatus/remediate.ps1
@@ -58,13 +58,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No remediation actions were necessary"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Defender remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/detect.Tests.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/detect.Tests.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Pester tests for Check-DeviceHealthScore/detect.ps1
+
+.DESCRIPTION
+    Pester test suite covering the device health score calculation of the Check-DeviceHealthScore proactive remediation detection script. Mocks Get-CimInstance, Get-WinEvent, Get-MpComputerStatus and related cmdlets to validate the category scores and that the script does not throw on null data.
+
+.EXAMPLE
+    ./detect.Tests.ps1
+
+.NOTES
+    File Name  : detect.Tests.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 BeforeAll {
     # Import the script to test
     $scriptPath = "$PSScriptRoot/detect.ps1"
@@ -214,7 +232,8 @@ Describe "Check-DeviceHealthScore.detect.ps1" {
             try {
                 & $scriptPath
                 $LASTEXITCODE | Should -Be 0
-            } catch {
+            }
+            catch {
                 # Expected exit behavior
             }
         }
@@ -233,7 +252,8 @@ Describe "Check-DeviceHealthScore.detect.ps1" {
             try {
                 & $scriptPath
                 $LASTEXITCODE | Should -Be 1
-            } catch {
+            }
+            catch {
                 # Expected exit behavior
             }
         }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/detect.ps1
@@ -64,7 +64,8 @@ try {
         if ($uptimeDays -gt 30) {
             $uptimeScore -= 10
             $healthReport.Issues += "Excessive uptime: $uptimeDays days"
-        } elseif ($uptimeDays -gt 14) {
+        }
+        elseif ($uptimeDays -gt 14) {
             $uptimeScore -= 5
             $healthReport.Issues += "High uptime: $uptimeDays days"
         }
@@ -89,7 +90,8 @@ try {
         $crashScore -= [Math]::Min($crashCount * 3, 15)
         $healthReport.Issues += "System crashes: $crashCount events"
         Write-Host "  Crashes: $crashCount | Score: $crashScore/100"
-    } else {
+    }
+    else {
         Write-Host "  Crashes: 0 | Score: $crashScore/100"
     }
     $healthReport.Categories.CrashStability = $crashScore
@@ -110,7 +112,8 @@ try {
         $appScore -= [Math]::Min([Math]::Floor($appCrashCount / 2), 10)
         $healthReport.Issues += "Application crashes: $appCrashCount events"
         Write-Host "  App Crashes: $appCrashCount | Score: $appScore/100"
-    } else {
+    }
+    else {
         Write-Host "  App Crashes: 0 | Score: $appScore/100"
     }
     $healthReport.Categories.ApplicationStability = $appScore
@@ -131,7 +134,8 @@ try {
         $serviceScore -= [Math]::Min([Math]::Floor($serviceFailCount / 3), 10)
         $healthReport.Issues += "Service failures: $serviceFailCount events"
         Write-Host "  Service Failures: $serviceFailCount | Score: $serviceScore/100"
-    } else {
+    }
+    else {
         Write-Host "  Service Failures: 0 | Score: $serviceScore/100"
     }
     $healthReport.Categories.ServiceHealth = $serviceScore
@@ -151,7 +155,8 @@ try {
         $criticalScore -= [Math]::Min($criticalCount * 2, 15)
         $healthReport.Issues += "Critical system errors: $criticalCount events"
         Write-Host "  Critical Errors: $criticalCount | Score: $criticalScore/100"
-    } else {
+    }
+    else {
         Write-Host "  Critical Errors: 0 | Score: $criticalScore/100"
     }
     $healthReport.Categories.SystemErrors = $criticalScore
@@ -204,13 +209,15 @@ try {
         if ($bootTimeSec -gt 180) {
             $bootScore -= 10
             $healthReport.Issues += "Very slow boot: $bootTimeSec seconds"
-        } elseif ($bootTimeSec -gt 120) {
+        }
+        elseif ($bootTimeSec -gt 120) {
             $bootScore -= 5
             $healthReport.Issues += "Slow boot: $bootTimeSec seconds"
         }
 
         Write-Host "  Boot Time: $bootTimeSec sec | Score: $bootScore/100"
-    } else {
+    }
+    else {
         Write-Host "  Boot Time: No data | Score: $bootScore/100"
     }
     $healthReport.Categories.BootPerformance = $bootScore
@@ -235,7 +242,8 @@ try {
                 $healthReport.Issues += "Antivirus signatures outdated: $($defender.AntivirusSignatureAge) days old"
             }
         }
-    } else {
+    }
+    else {
         # Defender module not available (likely server with third-party AV)
         Write-Host "  Defender module not available - skipping AV checks"
         Write-Host "  (Third-party antivirus or server environment detected)"
@@ -246,24 +254,24 @@ try {
 
     # Calculate final health score (weighted average)
     $finalScore = [Math]::Round((
-        ($healthReport.Categories.Uptime * 0.10) +
-        ($healthReport.Categories.CrashStability * 0.20) +
-        ($healthReport.Categories.ApplicationStability * 0.10) +
-        ($healthReport.Categories.ServiceHealth * 0.10) +
-        ($healthReport.Categories.SystemErrors * 0.15) +
-        ($healthReport.Categories.HardwareHealth * 0.20) +
-        ($healthReport.Categories.BootPerformance * 0.05) +
-        ($healthReport.Categories.SecurityPosture * 0.10)
-    ), 0)
+            ($healthReport.Categories.Uptime * 0.10) +
+            ($healthReport.Categories.CrashStability * 0.20) +
+            ($healthReport.Categories.ApplicationStability * 0.10) +
+            ($healthReport.Categories.ServiceHealth * 0.10) +
+            ($healthReport.Categories.SystemErrors * 0.15) +
+            ($healthReport.Categories.HardwareHealth * 0.20) +
+            ($healthReport.Categories.BootPerformance * 0.05) +
+            ($healthReport.Categories.SecurityPosture * 0.10)
+        ), 0)
 
     $healthReport.TotalScore = $finalScore
 
     # Determine health status
     $healthStatus = if ($finalScore -ge 90) { "EXCELLENT" }
-                    elseif ($finalScore -ge 80) { "GOOD" }
-                    elseif ($finalScore -ge 70) { "FAIR" }
-                    elseif ($finalScore -ge 50) { "POOR" }
-                    else { "CRITICAL" }
+    elseif ($finalScore -ge 80) { "GOOD" }
+    elseif ($finalScore -ge 70) { "FAIR" }
+    elseif ($finalScore -ge 50) { "POOR" }
+    else { "CRITICAL" }
 
     Write-Host ""
     Write-Host "==================================="
@@ -327,7 +335,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error calculating device health score: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DeviceHealthScore/remediate.ps1
@@ -96,7 +96,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during health improvement remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DeviceUptime/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DeviceUptime/detect.ps1
@@ -44,7 +44,8 @@ try {
         if ($uptimeDays -gt $maxUptimeDays) {
             $issues += "Device has been running for $uptimeDays days (threshold: $maxUptimeDays days)"
             $issues += "Reboot recommended to maintain system health and install updates"
-        } elseif ($uptimeDays -gt $warningUptimeDays) {
+        }
+        elseif ($uptimeDays -gt $warningUptimeDays) {
             Write-Host "  Warning: Approaching reboot threshold ($uptimeDays / $maxUptimeDays days)"
         }
 
@@ -72,7 +73,8 @@ try {
         $uptimePercent = 100  # Assume 100% uptime
         Write-Host "  Uptime Percentage: $uptimePercent% (since last boot)"
 
-    } else {
+    }
+    else {
         $issues += "Unable to retrieve system boot time"
     }
 
@@ -87,7 +89,8 @@ try {
     Write-Host "`nDevice uptime is within acceptable limits"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking device uptime: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DeviceUptime/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DeviceUptime/remediate.ps1
@@ -70,7 +70,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during uptime remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DiskHealth/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DiskHealth/detect.ps1
@@ -69,7 +69,8 @@ try {
     Write-Host "All disks are healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking disk health: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-DiskHealth/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-DiskHealth/remediate.ps1
@@ -41,7 +41,8 @@ try {
         # Run cleanmgr
         Start-Process -FilePath "cleanmgr.exe" -ArgumentList "/sagerun:1" -WindowStyle Hidden -Wait -ErrorAction SilentlyContinue
         $remediationActions += "Executed disk cleanup"
-    } catch {
+    }
+    catch {
         Write-Host "Warning: Could not complete disk cleanup: $_"
     }
 
@@ -51,7 +52,8 @@ try {
         Write-Host "Scheduling disk check for $systemDrive on next reboot..."
         chkdsk $systemDrive /F /R /X 2>&1 | Out-Null
         $remediationActions += "Scheduled disk check for next reboot"
-    } catch {
+    }
+    catch {
         Write-Host "Warning: Could not schedule disk check: $_"
     }
 
@@ -62,7 +64,8 @@ try {
         try {
             Optimize-Volume -DriveLetter $volume.DriveLetter -Verbose -ErrorAction SilentlyContinue
             $remediationActions += "Optimized volume $($volume.DriveLetter):"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not optimize volume $($volume.DriveLetter): $_"
         }
     }
@@ -75,13 +78,15 @@ try {
         Write-Host ""
         Write-Host "Note: Disk errors may require a system restart to fully repair"
         Write-Host "Hardware failures require physical disk replacement"
-    } else {
+    }
+    else {
         Write-Host "No disk maintenance actions were necessary"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during disk health remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.Tests.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.Tests.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Pester tests for Check-HardwareErrors/detect.ps1
+
+.DESCRIPTION
+    Pester test suite covering the WHEA hardware error detection logic of the Check-HardwareErrors proactive remediation detection script. Mocks Get-WinEvent, Get-CimInstance and related cmdlets to validate that WHEA errors are detected and reported without contacting the hardware.
+
+.EXAMPLE
+    ./detect.Tests.ps1
+
+.NOTES
+    File Name  : detect.Tests.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 BeforeAll {
     # Import the script to test
     $scriptPath = "$PSScriptRoot/detect.ps1"

--- a/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/detect.ps1
@@ -210,7 +210,8 @@ try {
     Write-Host "`nNo hardware errors detected - hardware health is good"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking hardware errors: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-HardwareErrors/remediate.ps1
@@ -76,7 +76,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during hardware error remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/detect.ps1
@@ -87,7 +87,8 @@ try {
     Write-Host "Local administrator accounts are properly configured"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking local administrator accounts: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-LocalAdminAccounts/remediate.ps1
@@ -22,7 +22,8 @@ try {
         try {
             Disable-LocalUser -Name "Administrator" -ErrorAction Stop
             $remediationActions += "Disabled built-in Administrator account"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not disable Administrator account: $_"
         }
     }
@@ -36,7 +37,8 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "  - No automatic remediation performed"
     }
 
@@ -46,7 +48,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during local administrator remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-MemoryDiagnostics/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-MemoryDiagnostics/detect.ps1
@@ -72,7 +72,8 @@ try {
     Write-Host "No memory errors detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking memory diagnostics: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-MemoryDiagnostics/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-MemoryDiagnostics/remediate.ps1
@@ -17,7 +17,7 @@ try {
     $remediationActions = @()
 
     # Schedule memory diagnostic for next reboot
-    $schedResult = bcdedit /set {default} bootstatuspolicy ignoreallfailures
+    $schedResult = bcdedit /set { default } bootstatuspolicy ignoreallfailures
     $memDiagResult = MdSched.exe /v
 
     if ($LASTEXITCODE -eq 0) {
@@ -42,7 +42,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error scheduling memory diagnostic: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-MicrosoftStoreAppsHealth/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-MicrosoftStoreAppsHealth/detect.ps1
@@ -32,7 +32,8 @@ try {
 
     if (-not $storeApp) {
         $issues += "Microsoft Store app is not installed"
-    } elseif ($storeApp.Status -ne "Ok") {
+    }
+    elseif ($storeApp.Status -ne "Ok") {
         $issues += "Microsoft Store app is in error state: $($storeApp.Status)"
     }
 
@@ -61,7 +62,8 @@ try {
     Write-Host "Microsoft Store apps are healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Store apps health: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-MicrosoftStoreAppsHealth/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-MicrosoftStoreAppsHealth/remediate.ps1
@@ -25,7 +25,8 @@ try {
             # Re-register the package
             Add-AppxPackage -DisableDevelopmentMode -Register "$($package.InstallLocation)\AppXManifest.xml" -ErrorAction SilentlyContinue
             $remediationActions += "Re-registered $($package.Name)"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not re-register $($package.Name): $_"
         }
     }
@@ -46,13 +47,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No Store apps required remediation"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Store apps remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/detect.ps1
@@ -104,7 +104,8 @@ function Test-WingetAvailable {
         $wingetPath = Get-Command winget -ErrorAction Stop
         Write-Log "Winget found at: $($wingetPath.Source)"
         return $true
-    } catch {
+    }
+    catch {
         # FIX: Include exception details in log
         Write-Log "Winget not found or not accessible: $($_.Exception.Message)" "ERROR"
         return $false
@@ -118,7 +119,8 @@ function Test-NetworkConnectivity {
             Write-Log "Network connectivity verified"
             return $true
         }
-    } catch {
+    }
+    catch {
         Write-Log "Network connectivity check failed: $_" "WARN"
     }
     return $false
@@ -193,7 +195,8 @@ function Get-OutdatedApps {
                     AvailableVersion = $availableVersion
                     IsPriority = ($appId -in $PriorityApps)
                 }
-            } elseif ($line -match '[a-zA-Z]' -and $line -notmatch '^\s*$' -and $dataLineCount -gt 0) {
+            }
+            elseif ($line -match '[a-zA-Z]' -and $line -notmatch '^\s*$' -and $dataLineCount -gt 0) {
                 # Log lines that look like data but failed to parse
                 Write-Log "Failed to parse potential data line: $line" "WARN"
                 $failedParseCount++
@@ -209,7 +212,8 @@ function Get-OutdatedApps {
             if ($failureRate -gt 75) {
                 Write-Log "CRITICAL: Parse failure rate exceeds 75% - winget output format may have changed. This may indicate security updates are not being detected properly." "ERROR"
                 return @()  # Return empty array to trigger remediation failure
-            } elseif ($failureRate -gt 50) {
+            }
+            elseif ($failureRate -gt 50) {
                 Write-Log "High parse failure rate suggests winget output format may have changed. Consider investigating." "ERROR"
             }
         }
@@ -217,7 +221,8 @@ function Get-OutdatedApps {
         Write-Log "Found $($outdatedApps.Count) total outdated applications"
         return $outdatedApps
 
-    } catch {
+    }
+    catch {
         Write-Log "Error detecting updates: $_" "ERROR"
         if ($RetryCount -lt ($MaxRetries - 1)) {
             Start-Sleep -Seconds ([Math]::Pow(2, $RetryCount))
@@ -256,7 +261,8 @@ try {
     # Filter for priority apps if configured
     if ($PriorityAppsOnly) {
         $criticalUpdates = $outdatedApps | Where-Object { $_.IsPriority -eq $true }
-    } else {
+    }
+    else {
         # Include priority and standard apps
         $appsToCheck = $PriorityApps + $StandardApps
         $criticalUpdates = $outdatedApps | Where-Object { $_.Id -in $appsToCheck }
@@ -288,7 +294,8 @@ try {
 
     exit 1
 
-} catch {
+}
+catch {
     Write-Log "Unexpected error during detection: $_" "ERROR"
     Write-Log "Stack trace: $($_.ScriptStackTrace)" "ERROR"
     exit 1

--- a/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/remediate.ps1
@@ -181,6 +181,7 @@ function Test-AppRunning {
 }
 
 function Stop-AppProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$AppId, [int]$MaxAttempts = 3)
 
     $processName = Get-AppProcessName -AppId $AppId
@@ -199,8 +200,10 @@ function Stop-AppProcess {
         Write-Log "Attempting to close $processName (attempt $i/$MaxAttempts)"
 
         try {
-            $processes | ForEach-Object {
-                $_.CloseMainWindow() | Out-Null
+            if ($PSCmdlet.ShouldProcess($processName, 'Close application process')) {
+                $processes | ForEach-Object {
+                    $_.CloseMainWindow() | Out-Null
+                }
             }
 
             Start-Sleep -Seconds 3
@@ -214,7 +217,9 @@ function Stop-AppProcess {
             # Force kill if last attempt
             if ($i -eq $MaxAttempts) {
                 Write-Log "Force killing $processName" "WARN"
-                Stop-Process -Name $processName -Force -ErrorAction SilentlyContinue
+                if ($PSCmdlet.ShouldProcess($processName, 'Force kill application process')) {
+                    Stop-Process -Name $processName -Force -ErrorAction SilentlyContinue
+                }
                 Start-Sleep -Seconds 2
 
                 # FIX: Verify process was actually terminated
@@ -227,7 +232,8 @@ function Stop-AppProcess {
                 return $true
             }
 
-        } catch {
+        }
+        catch {
             Write-Log "Error closing process: $_" "ERROR"
         }
 
@@ -240,6 +246,7 @@ function Stop-AppProcess {
 # ========================= UPDATE FUNCTIONS ========================= #
 
 function Update-Application {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$AppId,
         [string]$AppName,
@@ -267,7 +274,8 @@ function Update-Application {
                         Message = "Application is running and could not be closed"
                     }
                 }
-            } else {
+            }
+            else {
                 Write-Log "$AppName is currently running, skipping update" "WARN"
                 return [PSCustomObject]@{
                     AppId = $AppId
@@ -295,6 +303,14 @@ function Update-Application {
         Write-Log "Executing: winget upgrade --id $AppId --source winget --silent --accept-source-agreements --accept-package-agreements"
 
         $timeoutSeconds = $TimeoutPerAppMinutes * 60
+        if (-not $PSCmdlet.ShouldProcess($AppId, 'Run winget upgrade')) {
+            return [PSCustomObject]@{
+                AppId = $AppId
+                AppName = $AppName
+                Success = $false
+                Message = "Update skipped (WhatIf)"
+            }
+        }
         $job = Start-Job -ScriptBlock {
             param($id)
             & winget upgrade --id $id --source winget --silent --accept-source-agreements --accept-package-agreements 2>&1
@@ -312,7 +328,7 @@ function Update-Application {
             # FIX: Differentiate between actually updated, already up-to-date, and failed
             $wasUpdated = $outputString -match 'Successfully installed'
             $alreadyUpToDate = $outputString -match 'No applicable update found' -or
-                               $outputString -match 'No available upgrade found'
+            $outputString -match 'No available upgrade found'
 
             if ($wasUpdated) {
                 Write-Log "Successfully updated $AppName" "SUCCESS"
@@ -322,7 +338,8 @@ function Update-Application {
                     Success = $true
                     Message = "Update installed successfully"
                 }
-            } elseif ($alreadyUpToDate) {
+            }
+            elseif ($alreadyUpToDate) {
                 Write-Log "$AppName is already up-to-date (no update needed)" "INFO"
                 return [PSCustomObject]@{
                     AppId = $AppId
@@ -330,7 +347,8 @@ function Update-Application {
                     Success = $true
                     Message = "Already up-to-date"
                 }
-            } else {
+            }
+            else {
                 $errorMessage = $output -join "`n"
                 Write-Log "Update failed for $AppName : $errorMessage" "ERROR"
 
@@ -348,12 +366,14 @@ function Update-Application {
                     Message = "Update failed after $MaxRetries attempts"
                 }
             }
-        } else {
+        }
+        else {
             # Timeout occurred - FIX: Add error handling for job cleanup
             try {
                 Stop-Job -Job $job -ErrorAction SilentlyContinue
                 Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
-            } catch {
+            }
+            catch {
                 Write-Log "Error cleaning up timed out job: $_" "WARN"
             }
 
@@ -366,7 +386,8 @@ function Update-Application {
             }
         }
 
-    } catch {
+    }
+    catch {
         Write-Log "Error updating $AppName : $_" "ERROR"
 
         if ($RetryCount -lt ($MaxRetries - 1)) {
@@ -408,7 +429,8 @@ function Get-OutdatedApps {
         }
 
         return $outdatedApps
-    } catch {
+    }
+    catch {
         Write-Log "Error detecting outdated apps: $_" "ERROR"
         return @()
     }
@@ -433,7 +455,8 @@ try {
     # Filter apps to update
     if ($PriorityAppsOnly) {
         $appsToUpdate = $outdatedApps | Where-Object { $_.IsPriority -eq $true }
-    } else {
+    }
+    else {
         $appsToCheck = $PriorityApps + $StandardApps
         $appsToUpdate = $outdatedApps | Where-Object { $_.Id -in $appsToCheck }
     }
@@ -458,9 +481,11 @@ try {
 
         if ($result.Success) {
             $successCount++
-        } elseif ($result.Message -match "running") {
+        }
+        elseif ($result.Message -match "running") {
             $skippedCount++
-        } else {
+        }
+        else {
             $failCount++
         }
 
@@ -486,12 +511,14 @@ try {
     if ($successCount -gt 0) {
         Write-Log "Remediation completed successfully (some apps may require restart)"
         exit 0
-    } else {
+    }
+    else {
         Write-Log "No applications were successfully updated" "WARN"
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Log "Unexpected error during remediation: $_" "ERROR"
     Write-Log "Stack trace: $($_.ScriptStackTrace)" "ERROR"
     exit 1

--- a/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/remediate_priority_only.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-OutdatedCriticalApps/remediate_priority_only.ps1
@@ -117,6 +117,7 @@ function Get-AppProcessName {
 }
 
 function Stop-AppProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$AppId)
 
     $processName = Get-AppProcessName -AppId $AppId
@@ -134,14 +135,16 @@ function Stop-AppProcess {
     Write-Log "Force closing $processName..."
 
     try {
-        $processes | ForEach-Object {
-            $_.CloseMainWindow() | Out-Null
+        if ($PSCmdlet.ShouldProcess($processName, 'Close application process')) {
+            $processes | ForEach-Object {
+                $_.CloseMainWindow() | Out-Null
+            }
         }
 
         Start-Sleep -Seconds 2
 
         $remainingProcesses = Get-Process -Name $processName -ErrorAction SilentlyContinue
-        if ($remainingProcesses) {
+        if ($remainingProcesses -and $PSCmdlet.ShouldProcess($processName, 'Force kill application process')) {
             Stop-Process -Name $processName -Force -ErrorAction SilentlyContinue
             Start-Sleep -Seconds 1
 
@@ -156,7 +159,8 @@ function Stop-AppProcess {
         Write-Log "Successfully closed $processName"
         return $true
 
-    } catch {
+    }
+    catch {
         Write-Log "Error closing process: $_" "ERROR"
         return $false
     }
@@ -165,6 +169,7 @@ function Stop-AppProcess {
 # ========================= UPDATE FUNCTION ========================= #
 
 function Update-PriorityApp {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$AppId, [string]$AppName, [int]$RetryCount = 0)
 
     Write-Log "[PRIORITY] Updating: $AppName ($AppId)"
@@ -186,6 +191,9 @@ function Update-PriorityApp {
     try {
         Write-Log "Executing: winget upgrade --id $AppId --silent"
 
+        if (-not $PSCmdlet.ShouldProcess($AppId, 'Run winget upgrade')) {
+            return $false
+        }
         $job = Start-Job -ScriptBlock {
             param($id)
             & winget upgrade --id $id --silent --accept-source-agreements --accept-package-agreements 2>&1
@@ -203,15 +211,17 @@ function Update-PriorityApp {
             # FIX: Differentiate between actually updated vs already up-to-date
             $wasUpdated = $outputString -match 'Successfully installed'
             $alreadyUpToDate = $outputString -match 'No applicable update found' -or
-                               $outputString -match 'No available upgrade found'
+            $outputString -match 'No available upgrade found'
 
             if ($wasUpdated) {
                 Write-Log "Successfully updated $AppName" "SUCCESS"
                 return $true
-            } elseif ($alreadyUpToDate) {
+            }
+            elseif ($alreadyUpToDate) {
                 Write-Log "$AppName is already up-to-date (no update needed)" "INFO"
                 return $true
-            } else {
+            }
+            else {
                 Write-Log "Update failed for $AppName" "ERROR"
 
                 if ($RetryCount -lt ($MaxRetries - 1)) {
@@ -222,14 +232,16 @@ function Update-PriorityApp {
 
                 return $false
             }
-        } else {
+        }
+        else {
             Stop-Job -Job $job
             Remove-Job -Job $job -Force
             Write-Log "Update timed out for $AppName" "ERROR"
             return $false
         }
 
-    } catch {
+    }
+    catch {
         Write-Log "Error updating $AppName : $_" "ERROR"
 
         if ($RetryCount -lt ($MaxRetries - 1)) {
@@ -289,7 +301,8 @@ try {
 
         if ($success) {
             $successCount++
-        } else {
+        }
+        else {
             $failCount++
         }
 
@@ -304,12 +317,14 @@ try {
     if ($successCount -gt 0) {
         Write-Log "Priority security updates completed successfully"
         exit 0
-    } else {
+    }
+    else {
         Write-Log "No priority applications were updated" "WARN"
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Log "Unexpected error: $_" "ERROR"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/detect.ps1
@@ -45,7 +45,8 @@ try {
         if ($compSys.AutomaticManagedPagefile -eq $false) {
             $issues += "Page file is disabled (not recommended)"
         }
-    } else {
+    }
+    else {
         # Explicitly configured (custom) page file - report as informational;
         # only flag when the initial size is below the configurable ratio.
         $totalRAM = (Get-WmiObject -Class Win32_ComputerSystem).TotalPhysicalMemory / 1GB
@@ -89,7 +90,8 @@ try {
     Write-Host "Page file is properly configured"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking page file configuration: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-PageFileConfiguration/remediate.ps1
@@ -40,7 +40,8 @@ try {
         }
         Write-Host ""
         Write-Host "IMPORTANT: A system restart is required for changes to take effect"
-    } elseif ($pageFiles -and $pageFiles.Count -gt 0) {
+    }
+    elseif ($pageFiles -and $pageFiles.Count -gt 0) {
         # Custom page file exists - don't touch it even if undersized
         Write-Host "Custom page file configuration detected:"
         foreach ($pf in $pageFiles) {
@@ -53,13 +54,15 @@ try {
         Write-Host "  - SQL Server performance"
         Write-Host "  - Complete memory dump collection"
         Write-Host "  - Application-specific requirements"
-    } else {
+    }
+    else {
         Write-Host "Page file is already properly configured (system-managed)"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during page file remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SecurityBaseline/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SecurityBaseline/detect.ps1
@@ -1,38 +1,56 @@
+<#
+.SYNOPSIS
+    Detect security baseline drift
+
+.DESCRIPTION
+    Checks core security baseline settings: Windows Firewall profiles enabled, Windows Defender real-time protection and signature age, UAC (EnableLUA), and related hardening settings. Exits 1 when drift is found so remediation can run.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect security baseline drift
 $issues = @()
 
 # Check Windows Firewall
 $firewallProfiles = Get-NetFirewallProfile
-foreach($profile in $firewallProfiles) {
-    if(-not $profile.Enabled) {
+foreach ($profile in $firewallProfiles) {
+    if (-not $profile.Enabled) {
         $issues += "Firewall $($profile.Name) profile is disabled"
     }
 }
 
 # Check Windows Defender
 $defenderStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
-if($defenderStatus) {
-    if(-not $defenderStatus.RealTimeProtectionEnabled) {
+if ($defenderStatus) {
+    if (-not $defenderStatus.RealTimeProtectionEnabled) {
         $issues += "Real-time protection disabled"
     }
-    if($defenderStatus.AntivirusSignatureAge -gt 7) {
+    if ($defenderStatus.AntivirusSignatureAge -gt 7) {
         $issues += "Antivirus signatures outdated ($($defenderStatus.AntivirusSignatureAge) days)"
     }
 }
 
 # Check UAC
 $uacKey = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -ErrorAction SilentlyContinue
-if($uacKey.EnableLUA -ne 1) {
+if ($uacKey.EnableLUA -ne 1) {
     $issues += "UAC is disabled"
 }
 
 # Check automatic updates
 $wuKey = Get-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -ErrorAction SilentlyContinue
-if($wuKey.NoAutoUpdate -eq 1) {
+if ($wuKey.NoAutoUpdate -eq 1) {
     $issues += "Automatic updates disabled"
 }
 
-if($issues.Count -gt 0) {
+if ($issues.Count -gt 0) {
     Write-Host "Security baseline issues: $($issues -join '; ')"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SecurityBaseline/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SecurityBaseline/remediate.ps1
@@ -1,10 +1,28 @@
+<#
+.SYNOPSIS
+    Remediate security baseline drift
+
+.DESCRIPTION
+    Re-applies the security baseline: enables Windows Firewall profiles, re-enables Defender real-time protection, updates Defender signatures, enables UAC and remediates the other baseline settings detected by Check-SecurityBaseline/detect.ps1.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate security baseline issues
 $remediated = @()
 
 # Enable Windows Firewall
 $firewallProfiles = Get-NetFirewallProfile
-foreach($profile in $firewallProfiles) {
-    if(-not $profile.Enabled) {
+foreach ($profile in $firewallProfiles) {
+    if (-not $profile.Enabled) {
         Set-NetFirewallProfile -Profile $profile.Name -Enabled True
         $remediated += "Enabled $($profile.Name) firewall profile"
     }
@@ -12,7 +30,7 @@ foreach($profile in $firewallProfiles) {
 
 # Enable Windows Defender Real-Time Protection
 $defenderStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
-if($defenderStatus -and -not $defenderStatus.RealTimeProtectionEnabled) {
+if ($defenderStatus -and -not $defenderStatus.RealTimeProtectionEnabled) {
     Set-MpPreference -DisableRealtimeMonitoring $false
     $remediated += "Enabled real-time protection"
 }
@@ -23,14 +41,15 @@ $remediated += "Updated antivirus signatures"
 
 # Enable UAC
 $uacKey = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -ErrorAction SilentlyContinue
-if($uacKey.EnableLUA -ne 1) {
+if ($uacKey.EnableLUA -ne 1) {
     Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "EnableLUA" -Value 1
     $remediated += "Enabled UAC"
 }
 
-if($remediated.Count -gt 0) {
+if ($remediated.Count -gt 0) {
     Write-Host "Remediated $($remediated.Count) issues: $($remediated -join '; ')"
-} else {
+}
+else {
     Write-Host "No remediation needed"
 }
 exit 0

--- a/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/detect.ps1
@@ -144,7 +144,8 @@ try {
     Write-Host "`nNo significant service failures detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking service failures: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-ServiceFailures/remediate.ps1
@@ -38,7 +38,8 @@ try {
                 Start-Service -Name $svcName -ErrorAction Stop
                 $remediationActions += "Started service: $svcName"
                 Write-Host "    ✓ Successfully started $svcName"
-            } catch {
+            }
+            catch {
                 $remediationActions += "Failed to start service: $svcName - $_"
                 Write-Host "    ✗ Failed to start ${svcName}: $_"
             }
@@ -63,7 +64,8 @@ try {
         Write-Host "  5. Check system resource availability"
         Write-Host ""
         Write-Host "Device flagged for service stability review."
-    } else {
+    }
+    else {
         Write-Host ""
         Write-Host "Remediation actions taken:"
         foreach ($action in $remediationActions) {
@@ -76,7 +78,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during service failure remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SharedFolders/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SharedFolders/detect.ps1
@@ -64,7 +64,8 @@ try {
     Write-Host "No unauthorized network shares detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking network shares: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SharedFolders/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SharedFolders/remediate.ps1
@@ -45,7 +45,8 @@ try {
             try {
                 Remove-SmbShare -Name $share.Name -Force -ErrorAction Stop
                 $remediationActions += "Removed unauthorized share: $($share.Name) ($($share.Path))"
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not remove share $($share.Name): $_"
             }
         }
@@ -56,13 +57,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No unauthorized shares found to remove"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during network share remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/detect.ps1
@@ -150,7 +150,8 @@ try {
     Write-Host "`nNo critical system errors detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking system event errors: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemEventErrors/remediate.ps1
@@ -61,7 +61,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during system event remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/detect.ps1
@@ -67,7 +67,8 @@ try {
     Write-Host "`nSystem stability is within acceptable range"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking system stability: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-SystemStabilityIndex/remediate.ps1
@@ -44,7 +44,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during stability remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/detect.ps1
@@ -66,7 +66,8 @@ try {
     Write-Host "TPM is healthy and ready (Version: $tpmVersion)"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking TPM status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-TPMStatus/remediate.ps1
@@ -28,7 +28,8 @@ try {
         try {
             Initialize-Tpm -AllowClear -AllowPhysicalPresence -ErrorAction SilentlyContinue
             $remediationActions += "Attempted TPM initialization"
-        } catch {
+        }
+        catch {
             $remediationActions += "TPM initialization failed - may require BIOS/UEFI intervention"
         }
     }
@@ -45,7 +46,8 @@ try {
                     $remediationActions += "Attempted to take TPM ownership"
                 }
             }
-        } catch {
+        }
+        catch {
             $remediationActions += "Could not take TPM ownership automatically"
         }
     }
@@ -64,13 +66,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "TPM is already in a healthy state"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during TPM remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-UnexpectedReboots/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-UnexpectedReboots/detect.ps1
@@ -136,7 +136,8 @@ try {
     Write-Host "`nNo unexpected reboots detected - system stability is good"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking unexpected reboots: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-UnexpectedReboots/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-UnexpectedReboots/remediate.ps1
@@ -36,7 +36,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during unexpected reboot remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-WindowsActivationGracePeriod/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-WindowsActivationGracePeriod/detect.ps1
@@ -64,7 +64,8 @@ try {
     Write-Host "Windows activation is valid"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking activation grace period: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Check-WindowsActivationGracePeriod/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Check-WindowsActivationGracePeriod/remediate.ps1
@@ -21,7 +21,8 @@ try {
 
     if ($LASTEXITCODE -eq 0) {
         $remediationActions += "Triggered Windows activation"
-    } else {
+    }
+    else {
         $remediationActions += "Activation initiated (may require additional time)"
     }
 
@@ -41,7 +42,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during grace period remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-BitLockerNotEscrowedKeys/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-BitLockerNotEscrowedKeys/detect.ps1
@@ -63,7 +63,8 @@ try {
     Write-Host "All BitLocker volumes have a recovery password protector"
     exit 0
 
-} catch {
+}
+catch {
     Write-Error "Failed to check BitLocker status: $($_.Exception.Message)"
     Write-Error $_.ScriptStackTrace
     exit 1

--- a/scripts/endpoints/devices/proactive-remediations/Fix-BitLockerNotEscrowedKeys/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-BitLockerNotEscrowedKeys/remediate.ps1
@@ -50,7 +50,8 @@ try {
                     Write-Host "Adding recovery password protector for $($vol.MountPoint)"
                     $newProtector = Add-BitLockerKeyProtector -MountPoint $vol.MountPoint -RecoveryPassword -ErrorAction Stop
                     $recoveryKeys = @($newProtector)
-                } catch {
+                }
+                catch {
                     $errorMsg = "Failed to add recovery key for $($vol.MountPoint): $($_.Exception.Message)"
                     Write-Host $errorMsg
                     $failed += $errorMsg
@@ -64,7 +65,8 @@ try {
                     BackupToAAD-BitLockerKeyProtector -MountPoint $vol.MountPoint -KeyProtectorId $key.KeyProtectorId -ErrorAction Stop
                     $escrowed += "$($vol.MountPoint)"
                     Write-Host "Escrowed recovery key for $($vol.MountPoint)"
-                } catch {
+                }
+                catch {
                     $errorMsg = "Failed to escrow $($vol.MountPoint): $($_.Exception.Message)"
                     Write-Host $errorMsg
                     $failed += $errorMsg
@@ -88,7 +90,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Error "Failed to remediate BitLocker keys: $($_.Exception.Message)"
     Write-Error $_.ScriptStackTrace
     exit 1

--- a/scripts/endpoints/devices/proactive-remediations/Fix-CertificateExpiry/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-CertificateExpiry/detect.ps1
@@ -47,19 +47,20 @@ try {
         if ($null -eq $Cert) { return }
         if ($Cert.NotAfter -lt (Get-Date)) {
             [void]$script:expiredCerts.Add([PSCustomObject]@{
-                Subject = $Cert.Subject
-                Thumbprint = $Cert.Thumbprint
-                Expiry = $Cert.NotAfter
-                Store = $StoreLabel
-            })
-        } elseif ($Cert.NotAfter -lt $warningDate) {
+                    Subject = $Cert.Subject
+                    Thumbprint = $Cert.Thumbprint
+                    Expiry = $Cert.NotAfter
+                    Store = $StoreLabel
+                })
+        }
+        elseif ($Cert.NotAfter -lt $warningDate) {
             [void]$script:expiringSoon.Add([PSCustomObject]@{
-                Subject = $Cert.Subject
-                Thumbprint = $Cert.Thumbprint
-                Expiry = $Cert.NotAfter
-                DaysUntilExpiry = ($Cert.NotAfter - (Get-Date)).Days
-                Store = $StoreLabel
-            })
+                    Subject = $Cert.Subject
+                    Thumbprint = $Cert.Thumbprint
+                    Expiry = $Cert.NotAfter
+                    DaysUntilExpiry = ($Cert.NotAfter - (Get-Date)).Days
+                    Store = $StoreLabel
+                })
         }
     }
 
@@ -81,7 +82,8 @@ try {
                 [Array]::Copy($Blob, $dataStart, $certBytes, 0, $length)
                 try {
                     return New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList (, $certBytes)
-                } catch {
+                }
+                catch {
                     return $null
                 }
             }
@@ -104,7 +106,8 @@ try {
                 if ($null -ne $cert) {
                     Add-CertificateResult $cert $StoreLabel
                 }
-            } catch {
+            }
+            catch {
                 # Unparseable certificate entry - skip it
             }
         }
@@ -154,7 +157,8 @@ try {
             $certificatesPath = "Registry::HKEY_USERS\$hiveKey\SOFTWARE\Microsoft\SystemCertificates\My\Certificates"
             $userName = Split-Path $profile.LocalPath -Leaf
             Test-CertStoreRegistry $certificatesPath "User $userName ($sid)\My"
-        } finally {
+        }
+        finally {
             if ($loadedByUs) {
                 & reg.exe unload "HKU\$hiveKey" 2>$null | Out-Null
                 # If the unload fails (hive in use) the hive stays mounted under
@@ -192,7 +196,8 @@ try {
     Write-Host "No expired or expiring certificates found"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking certificate expiry: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-CertificateExpiry/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-CertificateExpiry/remediate.ps1
@@ -46,7 +46,8 @@ try {
                 [Array]::Copy($Blob, $dataStart, $certBytes, 0, $length)
                 try {
                     return New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList (, $certBytes)
-                } catch {
+                }
+                catch {
                     return $null
                 }
             }
@@ -57,6 +58,7 @@ try {
     }
 
     function Remove-ExpiredFromCertStoreRegistry {
+        [CmdletBinding(SupportsShouldProcess)]
         # $CertificatesPath points at ...\SystemCertificates\My\Certificates
         param([string]$CertificatesPath, [string]$StoreLabel)
         if (-not (Test-Path $CertificatesPath)) { return }
@@ -68,10 +70,13 @@ try {
                 $cert = Get-CertificateFromBlob $blob
                 if ($null -ne $cert -and $cert.NotAfter -lt (Get-Date)) {
                     # Remove the certificate entry from the store
-                    Remove-Item -Path $certKey.PSPath -Force -ErrorAction Stop
-                    $script:remediationActions += "Removed expired certificate: $($cert.Subject) ($StoreLabel)"
+                    if ($PSCmdlet.ShouldProcess($certKey.PSPath, 'Remove expired certificate')) {
+                        Remove-Item -Path $certKey.PSPath -Force -ErrorAction Stop
+                        $script:remediationActions += "Removed expired certificate: $($cert.Subject) ($StoreLabel)"
+                    }
                 }
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not remove certificate in $StoreLabel : $_"
             }
         }
@@ -90,7 +95,8 @@ try {
                         # Remove expired certificate
                         Remove-Item -Path "$storePath\$($cert.Thumbprint)" -Force -ErrorAction Stop
                         $script:remediationActions += "Removed expired certificate: $($cert.Subject) ($storePath)"
-                    } catch {
+                    }
+                    catch {
                         Write-Host "Warning: Could not remove certificate $($cert.Subject): $_"
                     }
                 }
@@ -124,7 +130,8 @@ try {
             $certificatesPath = "Registry::HKEY_USERS\$hiveKey\SOFTWARE\Microsoft\SystemCertificates\My\Certificates"
             $userName = Split-Path $profile.LocalPath -Leaf
             Remove-ExpiredFromCertStoreRegistry $certificatesPath "User $userName ($sid)\My"
-        } finally {
+        }
+        finally {
             if ($loadedByUs) {
                 & reg.exe unload "HKU\$hiveKey" 2>$null | Out-Null
             }
@@ -140,13 +147,15 @@ try {
         foreach ($action in $script:remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No expired certificates found to remove"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during certificate remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-CredentialManager/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-CredentialManager/detect.ps1
@@ -85,7 +85,8 @@ try {
     Write-Host "Credential Manager appears healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Credential Manager: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-CredentialManager/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-CredentialManager/remediate.ps1
@@ -65,7 +65,8 @@ try {
                         if ($LASTEXITCODE -eq 0) {
                             $remediationActions += "Removed stale credential: $target"
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-Host "Warning: Could not remove credential $target : $_"
                     }
                     break
@@ -79,13 +80,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No stale credentials found to remove"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Credential Manager remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-EdgeCacheSize/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-EdgeCacheSize/detect.ps1
@@ -41,7 +41,7 @@ try {
         foreach ($cachePath in $edgeCachePaths) {
             if (Test-Path $cachePath) {
                 $cacheSize = (Get-ChildItem -Path $cachePath -Recurse -File -ErrorAction SilentlyContinue |
-                    Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                        Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
 
                 if ($cacheSize) {
                     $totalCacheSize += $cacheSize
@@ -60,7 +60,8 @@ try {
     Write-Host "Edge cache size is healthy: $totalCacheSizeMB MB"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Edge cache size: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-EdgeCacheSize/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-EdgeCacheSize/remediate.ps1
@@ -42,7 +42,7 @@ try {
             if (Test-Path $cachePath) {
                 try {
                     $cacheSize = (Get-ChildItem -Path $cachePath -Recurse -File -ErrorAction SilentlyContinue |
-                        Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                            Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
 
                     # Clear cache
                     Remove-Item -Path "$cachePath\*" -Recurse -Force -ErrorAction SilentlyContinue
@@ -50,7 +50,8 @@ try {
                     if ($cacheSize) {
                         $totalCleared += $cacheSize
                     }
-                } catch {
+                }
+                catch {
                     Write-Host "Warning: Could not clear cache at $cachePath : $_"
                 }
             }
@@ -68,13 +69,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No Edge cache to clear"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Edge cache remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-EventLogSize/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-EventLogSize/detect.ps1
@@ -47,7 +47,8 @@ try {
     Write-Host "Event log sizes are within normal limits"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking event log sizes: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-EventLogSize/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-EventLogSize/remediate.ps1
@@ -37,12 +37,14 @@ try {
                     # For critical logs, configure auto-archiving instead of clearing
                     wevtutil.exe sl "$logName" /ms:52428800  # Set max size to 50MB
                     $remediationActions += "Configured size limit for $logName ($sizeMB MB)"
-                } else {
+                }
+                else {
                     # Clear non-critical logs
                     wevtutil.exe cl "$logName"
                     $remediationActions += "Cleared $logName ($sizeMB MB)"
                 }
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not process $logName : $_"
             }
         }
@@ -53,13 +55,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No event logs required clearing"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during event log remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-NetworkAdapterPowerManagement/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-NetworkAdapterPowerManagement/detect.ps1
@@ -46,7 +46,8 @@ try {
     Write-Host "Network adapter power management is properly configured"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking network adapter power settings: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-NetworkAdapterPowerManagement/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-NetworkAdapterPowerManagement/remediate.ps1
@@ -32,7 +32,8 @@ try {
         try {
             Disable-NetAdapterPowerManagement -Name $adapter.Name -ErrorAction Stop
             $remediationActions += "Disabled power management on $($adapter.Name)"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not disable power management on $($adapter.Name): $_"
         }
     }
@@ -42,13 +43,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No network adapters required power management changes"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during network adapter remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-OneDriveKnownFolderMove/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-OneDriveKnownFolderMove/detect.ps1
@@ -57,7 +57,8 @@ try {
             if ($picturesProtected -ne 2) {
                 $issues += "Pictures folder is not protected by OneDrive KFM"
             }
-        } else {
+        }
+        else {
             $issues += "OneDrive Business account not configured"
         }
     }
@@ -66,7 +67,8 @@ try {
     $oneDriveSettingsPath = "$env:LOCALAPPDATA\Microsoft\OneDrive\settings\Business1"
     if (Test-Path $oneDriveSettingsPath) {
         # OneDrive is configured
-    } else {
+    }
+    else {
         $issues += "OneDrive sync folder not found - may not be configured"
     }
 
@@ -81,7 +83,8 @@ try {
     Write-Host "OneDrive Known Folder Move is healthy and active"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking OneDrive KFM status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-OneDriveKnownFolderMove/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-OneDriveKnownFolderMove/remediate.ps1
@@ -66,7 +66,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during OneDrive KFM remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-OutdatedDrivers/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-OutdatedDrivers/detect.ps1
@@ -43,7 +43,8 @@ try {
             }
             exit 1
         }
-    } catch {
+    }
+    catch {
         Write-Host "Note: Could not check Windows Update for drivers: $_"
     }
 
@@ -58,7 +59,8 @@ try {
     Write-Host "All drivers appear to be up to date"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking driver status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-OutdatedDrivers/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-OutdatedDrivers/remediate.ps1
@@ -49,12 +49,14 @@ try {
 
                 if ($installResult.ResultCode -eq 2) {
                     $remediationActions += "Successfully installed $($updatesToInstall.Count) driver update(s)"
-                } else {
+                }
+                else {
                     $remediationActions += "Driver installation completed with result code: $($installResult.ResultCode)"
                 }
             }
         }
-    } catch {
+    }
+    catch {
         Write-Host "Error installing driver updates: $_"
         $remediationActions += "Could not install drivers automatically - may require manual intervention"
     }
@@ -76,13 +78,15 @@ try {
         }
         Write-Host ""
         Write-Host "Note: A restart may be required to complete driver installation"
-    } else {
+    }
+    else {
         Write-Host "No driver updates were necessary"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during driver remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-PowerShellExecutionPolicy/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-PowerShellExecutionPolicy/detect.ps1
@@ -37,12 +37,13 @@ try {
     # the first scope whose policy is not 'Undefined' wins. Process scope is
     # excluded - see the NOTES section.
     $effectivePolicy = (Get-ExecutionPolicy -List |
-        Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
-        Select-Object -First 1).ExecutionPolicy
+            Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
+            Select-Object -First 1).ExecutionPolicy
 
     if ([string]::IsNullOrEmpty($effectivePolicy)) {
         $issues += "No effective execution policy could be determined"
-    } else {
+    }
+    else {
         if ($effectivePolicy -ne $desiredPolicy) {
             $issues += "Effective execution policy is '$effectivePolicy' (should be '$desiredPolicy')"
         }
@@ -69,7 +70,8 @@ try {
     Write-Host "PowerShell execution policy is properly configured: $effectivePolicy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking PowerShell execution policy: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-PowerShellExecutionPolicy/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-PowerShellExecutionPolicy/remediate.ps1
@@ -34,8 +34,8 @@ try {
 
     # Effective policy (Process scope excluded - see detect.ps1 NOTES)
     $effectivePolicy = (Get-ExecutionPolicy -List |
-        Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
-        Select-Object -First 1).ExecutionPolicy
+            Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
+            Select-Object -First 1).ExecutionPolicy
 
     if ($effectivePolicy -eq $desiredPolicy) {
         Write-Host "PowerShell execution policy is already correctly configured (effective: $effectivePolicy)"
@@ -57,7 +57,8 @@ try {
                 exit 1
             }
             $remediationActions += "Set LocalMachine execution policy to $desiredPolicy (was: $currentPolicy)"
-        } catch {
+        }
+        catch {
             Write-Host "Error setting execution policy: $_"
             exit 1
         }
@@ -68,8 +69,8 @@ try {
     # CurrentUser scope) still overrides LocalMachine, the device remains
     # non-compliant and LocalMachine changes cannot fix it - report it honestly.
     $effectiveAfter = (Get-ExecutionPolicy -List |
-        Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
-        Select-Object -First 1).ExecutionPolicy
+            Where-Object { $_.Scope -ne 'Process' -and $_.ExecutionPolicy -ne 'Undefined' } |
+            Select-Object -First 1).ExecutionPolicy
 
     if ($effectiveAfter -ne $desiredPolicy) {
         Write-Host "Remediation incomplete: effective execution policy is still '$effectiveAfter'. It is controlled by a higher-priority scope (Group Policy MachinePolicy/UserPolicy or the CurrentUser scope) that LocalMachine changes cannot override. Review Group Policy on this device."
@@ -81,13 +82,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "PowerShell execution policy was already set correctly"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during PowerShell execution policy remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-PrintSpooler/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-PrintSpooler/detect.ps1
@@ -58,7 +58,8 @@ try {
             Write-Host "Detected $($oldJobs.Count) old print jobs (> 24 hours)"
             exit 1
         }
-    } catch {
+    }
+    catch {
         # If we can't check, assume there might be an issue
         Write-Host "Could not access spool directory: $($_.Exception.Message)"
         exit 1
@@ -67,7 +68,8 @@ try {
     Write-Host "Print Spooler is functioning properly"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Print Spooler: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-PrintSpooler/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-PrintSpooler/remediate.ps1
@@ -27,7 +27,8 @@ try {
             Start-Sleep -Seconds 3
             Write-Host "Print Spooler service stopped"
         }
-    } else {
+    }
+    else {
         Write-Host "Print Spooler service not found!"
         exit 1
     }
@@ -43,17 +44,20 @@ try {
                 Remove-Item -Force -ErrorAction SilentlyContinue
 
             Write-Host "Print spool cleared successfully"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not fully clear spool directory: $($_.Exception.Message)"
             # Continue even if some files can't be deleted
         }
-    } else {
+    }
+    else {
         Write-Host "Spool directory not found: $spoolPath"
         # Create it if it doesn't exist
         try {
             New-Item -Path $spoolPath -ItemType Directory -Force | Out-Null
             Write-Host "Created spool directory"
-        } catch {
+        }
+        catch {
             Write-Host "Failed to create spool directory: $($_.Exception.Message)"
             exit 1
         }
@@ -75,12 +79,14 @@ try {
         Write-Host "Print Spooler service is now running"
         Write-Host "Print Spooler remediation completed successfully"
         exit 0
-    } else {
+    }
+    else {
         Write-Host "Failed to start Print Spooler service. Status: $($spoolerService.Status)"
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Host "Error during Print Spooler remediation: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-SMBv1Protocol/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-SMBv1Protocol/detect.ps1
@@ -54,7 +54,8 @@ try {
     Write-Host "SMBv1 is properly disabled (secure configuration)"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking SMBv1 status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-SMBv1Protocol/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-SMBv1Protocol/remediate.ps1
@@ -23,7 +23,8 @@ try {
         try {
             Disable-WindowsOptionalFeature -Online -FeatureName "SMB1Protocol" -NoRestart -ErrorAction Stop | Out-Null
             $remediationActions += "Disabled SMBv1 Windows Optional Feature"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not disable SMBv1 feature: $_"
         }
     }
@@ -34,7 +35,8 @@ try {
         try {
             Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force -ErrorAction Stop
             $remediationActions += "Disabled SMBv1 in SMB server configuration"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not disable SMBv1 in server config: $_"
         }
     }
@@ -53,13 +55,15 @@ try {
         }
         Write-Host ""
         Write-Host "Note: A system restart may be required to fully disable SMBv1"
-    } else {
+    }
+    else {
         Write-Host "SMBv1 was already disabled"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during SMBv1 remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-StaleProfiles/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-StaleProfiles/detect.ps1
@@ -40,7 +40,8 @@ $profiles = Get-CimInstance Win32_UserProfile | Where-Object {
 foreach ($profile in $profiles) {
     try {
         $lastUse = [Management.ManagementDateTimeConverter]::ToDateTime($profile.LastUseTime)
-    } catch {
+    }
+    catch {
         # Unparseable LastUseTime - skip this profile
         continue
     }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-StaleProfiles/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-StaleProfiles/remediate.ps1
@@ -42,7 +42,8 @@ foreach ($profile in $profiles) {
     try {
         $lastUse = [Management.ManagementDateTimeConverter]::ToDateTime($profile.LastUseTime)
         $age = ((Get-Date) - $lastUse).Days
-    } catch {
+    }
+    catch {
         # Unparseable LastUseTime - skip this profile
         continue
     }
@@ -58,7 +59,8 @@ foreach ($profile in $profiles) {
             # registry entry and can delete loaded profiles).
             Remove-CimInstance -InputObject $profile -ErrorAction Stop
             $removed += "$profileName ($sizeBefore GB)"
-        } catch {
+        }
+        catch {
             Write-Host "Could not remove $profileName : $($_.Exception.Message)"
         }
     }
@@ -66,7 +68,8 @@ foreach ($profile in $profiles) {
 
 if ($removed.Count -gt 0) {
     Write-Host "Removed $($removed.Count) stale profile(s): $($removed -join '; ')"
-} else {
+}
+else {
     Write-Host "No profiles removed"
 }
 exit 0

--- a/scripts/endpoints/devices/proactive-remediations/Fix-StartMenuLayout/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-StartMenuLayout/detect.ps1
@@ -30,7 +30,8 @@ try {
             try {
                 $dbFiles = Get-ChildItem -Path $tileDataPath -File -ErrorAction Stop
                 # Database exists and is accessible
-            } catch {
+            }
+            catch {
                 $issues += "Start Menu database is corrupted or inaccessible for user: $($profile.Name)"
             }
         }
@@ -42,7 +43,8 @@ try {
             # Check if cache folder has issues
             try {
                 $cacheFiles = Get-ChildItem -Path $startMenuCache -ErrorAction Stop
-            } catch {
+            }
+            catch {
                 $issues += "Start Menu cache is corrupted for user: $($profile.Name)"
             }
         }
@@ -62,7 +64,8 @@ try {
     Write-Host "Start Menu appears to be healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Start Menu health: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-StartMenuLayout/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-StartMenuLayout/remediate.ps1
@@ -41,7 +41,8 @@ try {
             try {
                 Remove-Item -Path $tileDataPath -Recurse -Force -ErrorAction Stop
                 $remediationActions += "Removed corrupted tile database for user: $($profile.Name)"
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not remove tile database for $($profile.Name): $_"
             }
         }
@@ -53,7 +54,8 @@ try {
             try {
                 Remove-Item -Path "$startMenuCache\*" -Recurse -Force -ErrorAction Stop
                 $remediationActions += "Cleared Start Menu cache for user: $($profile.Name)"
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not clear Start Menu cache for $($profile.Name): $_"
             }
         }
@@ -72,13 +74,15 @@ try {
         }
         Write-Host ""
         Write-Host "Note: Users may need to sign out and sign back in for changes to take full effect"
-    } else {
+    }
+    else {
         Write-Host "No Start Menu remediation was necessary"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Start Menu remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-SystemFileCorruption/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-SystemFileCorruption/detect.ps1
@@ -23,7 +23,8 @@ try {
 
     if ($dismResult -match "The component store is repairable") {
         $issues += "Component store corruption detected (repairable)"
-    } elseif ($dismResult -match "The component store corruption was detected") {
+    }
+    elseif ($dismResult -match "The component store corruption was detected") {
         $issues += "Component store corruption detected"
     }
 
@@ -47,7 +48,8 @@ try {
     Write-Host "No system file corruption detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking system file integrity: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-SystemFileCorruption/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-SystemFileCorruption/remediate.ps1
@@ -74,7 +74,8 @@ try {
 
     if ($LASTEXITCODE -eq 0) {
         $remediationActions += "DISM RestoreHealth completed successfully"
-    } else {
+    }
+    else {
         $remediationActions += "DISM RestoreHealth completed with warnings (exit code: $LASTEXITCODE)"
     }
 
@@ -84,9 +85,11 @@ try {
 
     if ($sfcResult -match "did not find any integrity violations") {
         $remediationActions += "SFC scan completed - no violations found"
-    } elseif ($sfcResult -match "successfully repaired") {
+    }
+    elseif ($sfcResult -match "successfully repaired") {
         $remediationActions += "SFC successfully repaired corrupted files"
-    } else {
+    }
+    else {
         $remediationActions += "SFC scan completed"
     }
 
@@ -101,7 +104,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during system file remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TaskSchedulerCorruption/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TaskSchedulerCorruption/detect.ps1
@@ -27,7 +27,8 @@ try {
     # Try to query scheduled tasks
     try {
         $tasks = Get-ScheduledTask -ErrorAction Stop | Select-Object -First 1
-    } catch {
+    }
+    catch {
         $issues += "Unable to query scheduled tasks (database may be corrupted)"
     }
 
@@ -56,7 +57,8 @@ try {
     Write-Host "Task Scheduler is healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Task Scheduler: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TaskSchedulerCorruption/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TaskSchedulerCorruption/remediate.ps1
@@ -48,7 +48,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Task Scheduler remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TeamsCache/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TeamsCache/detect.ps1
@@ -73,7 +73,7 @@ try {
                 if (Test-Path $cachePath) {
                     try {
                         $cacheSize = (Get-ChildItem -Path $cachePath -Recurse -ErrorAction SilentlyContinue |
-                            Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                                Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
 
                         if ($null -ne $cacheSize) {
                             $totalCacheSize += $cacheSize
@@ -82,7 +82,8 @@ try {
                                 $cacheIssues += "Large cache in $userName at $(Split-Path $cachePath -Leaf): $cacheSizeMB MB"
                             }
                         }
-                    } catch {
+                    }
+                    catch {
                         Write-Host "Could not calculate size for $cachePath"
                     }
                 }
@@ -99,7 +100,7 @@ try {
             # Check for old log files
             if (Test-Path "$teamsAppData\logs") {
                 $oldLogs = @(Get-ChildItem -Path "$teamsAppData\logs" -Recurse -ErrorAction SilentlyContinue |
-                    Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) })
+                        Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-30) })
 
                 if ($oldLogs.Count -gt 50) {
                     $cacheIssues += "Many old log files in ${userName}: $($oldLogs.Count) files older than 30 days"
@@ -126,12 +127,14 @@ try {
         Write-Host "Teams cache issues detected:"
         $cacheIssues | ForEach-Object { Write-Host "  - $_" }
         exit 1
-    } else {
+    }
+    else {
         Write-Host "Teams cache is healthy (Size: $totalCacheSizeMB MB)"
         exit 0
     }
 
-} catch {
+}
+catch {
     Write-Host "Error checking Teams cache: $($_.Exception.Message)"
     exit 0
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TeamsCache/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TeamsCache/remediate.ps1
@@ -34,10 +34,12 @@ try {
         if ($teamsStillRunning) {
             Write-Host "Warning: Could not stop all Teams processes"
             # Continue anyway as cache might still be clearable
-        } else {
+        }
+        else {
             Write-Host "Teams processes stopped successfully"
         }
-    } else {
+    }
+    else {
         Write-Host "Teams is not running"
     }
 
@@ -83,7 +85,7 @@ try {
                 try {
                     # Calculate size before deletion
                     $sizeBefore = (Get-ChildItem -Path $cachePath -Recurse -ErrorAction SilentlyContinue |
-                        Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                            Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
 
                     # Remove cache contents
                     Get-ChildItem -Path $cachePath -Recurse -ErrorAction SilentlyContinue |
@@ -92,7 +94,8 @@ try {
                     $clearedSize += $sizeBefore
 
                     Write-Host "Cleared $(Split-Path $cachePath -Leaf) for $userName successfully"
-                } catch {
+                }
+                catch {
                     Write-Host "Warning: Could not fully clear $cachePath for $userName : $($_.Exception.Message)"
                     $failedPaths += $cachePath
                 }
@@ -110,7 +113,8 @@ try {
                 $oldLogs | Remove-Item -Force -ErrorAction SilentlyContinue
 
                 Write-Host "Removed $logCount old log files for $userName"
-            } catch {
+            }
+            catch {
                 Write-Host "Warning: Could not clear old logs for ${userName}: $($_.Exception.Message)"
             }
         }
@@ -133,7 +137,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Teams cache remediation: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TempFiles/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TempFiles/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect excessive temp files
+
+.DESCRIPTION
+    Measures the total size of temp files older than 7 days across the SYSTEM temp folder, the Windows temp folder and every per-user temp folder (enumerated from Win32_UserProfile so users who are not logged on are covered). Exits 1 when the total exceeds 1 GB.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect excessive temp files (> 1GB)
 # In SYSTEM context $env:TEMP points at the SYSTEM profile temp folder - real
 # user temp folders must be enumerated explicitly or they are never cleaned.
@@ -19,16 +37,16 @@ foreach ($profile in $userProfiles) {
 
 $totalSize = 0
 
-foreach($path in $tempPaths) {
-    if(Test-Path $path) {
-        $size = (Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Where-Object {$_.LastWriteTime -lt (Get-Date).AddDays(-7)} | Measure-Object -Property Length -Sum).Sum
+foreach ($path in $tempPaths) {
+    if (Test-Path $path) {
+        $size = (Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-7) } | Measure-Object -Property Length -Sum).Sum
         $totalSize += $size
     }
 }
 
 $totalGB = [math]::Round($totalSize / 1GB, 2)
 
-if($totalSize -gt $threshold) {
+if ($totalSize -gt $threshold) {
     Write-Host "Excessive temp files: $totalGB GB"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TempFiles/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TempFiles/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Clean temp files older than 7 days
+
+.DESCRIPTION
+    Deletes temp files older than 7 days from the SYSTEM temp folder, the Windows temp folder and every per-user temp folder (enumerated from Win32_UserProfile). Reports the number of files and space reclaimed.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Clean temp files older than 7 days
 # In SYSTEM context $env:TEMP points at the SYSTEM profile temp folder - real
 # user temp folders must be enumerated explicitly or they are never cleaned.
@@ -18,10 +36,10 @@ foreach ($profile in $userProfiles) {
 
 $cleaned = 0
 
-foreach($path in $tempPaths) {
-    if(Test-Path $path) {
+foreach ($path in $tempPaths) {
+    if (Test-Path $path) {
         $beforeSize = (Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
-        Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Where-Object {$_.LastWriteTime -lt (Get-Date).AddDays(-7)} | Remove-Item -Force -ErrorAction SilentlyContinue
+        Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-7) } | Remove-Item -Force -ErrorAction SilentlyContinue
         $afterSize = (Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
         $cleaned += [math]::Round(($beforeSize - $afterSize) / 1GB, 2)
     }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TimeSync/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TimeSync/detect.ps1
@@ -27,7 +27,8 @@ try {
     $syncStatus = w32tm /query /status 2>&1
     if ($LASTEXITCODE -ne 0) {
         $issues += "Time sync status check failed - service may not be configured"
-    } else {
+    }
+    else {
         # Check if time source is configured
         if ($syncStatus -match "Source: Local CMOS Clock") {
             $issues += "Time source is set to Local CMOS Clock (should sync from network)"
@@ -43,7 +44,8 @@ try {
                     if ($hoursSinceSync -gt 24) {
                         $issues += "Last successful sync was over 24 hours ago"
                     }
-                } catch {
+                }
+                catch {
                     # Unable to parse date, might be an issue
                 }
             }
@@ -66,7 +68,8 @@ try {
     Write-Host "Time synchronization is healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking time sync status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-TimeSync/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-TimeSync/remediate.ps1
@@ -50,14 +50,16 @@ try {
         if ($LASTEXITCODE -eq 0) {
             $remediationActions += "Configured NT5DS time sync (domain controller, reliable)"
         }
-    } elseif ($isDomainJoined) {
+    }
+    elseif ($isDomainJoined) {
         # Domain members use NT5DS - do NOT override with manual NTP, which
         # would break the documented domain time topology
         $configResult = w32tm /config /syncfromflags:domhier /update 2>&1
         if ($LASTEXITCODE -eq 0) {
             $remediationActions += "Configured NT5DS time sync from the domain hierarchy"
         }
-    } else {
+    }
+    else {
         # Workgroup device - manual sync from time.windows.com. /reliable is
         # only meaningful on domain controllers, so it is never set here.
         $configResult = w32tm /config /manualpeerlist:"time.windows.com" /syncfromflags:manual /update 2>&1
@@ -75,7 +77,8 @@ try {
     $syncResult = w32tm /resync /force 2>&1
     if ($LASTEXITCODE -eq 0) {
         $remediationActions += "Forced time synchronization"
-    } else {
+    }
+    else {
         $remediationActions += "Attempted time sync (may take a few minutes to complete)"
     }
 
@@ -86,7 +89,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during time sync remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsLicenseActivation/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsLicenseActivation/detect.ps1
@@ -29,15 +29,19 @@ try {
     if ($activationStatus -match "License Status: Licensed") {
         Write-Host "Windows is properly activated and licensed"
         exit 0
-    } else {
+    }
+    else {
         # Check for specific activation states
         if ($activationStatus -match "License Status: Notification") {
             $issues += "Windows is in notification mode (grace period or unlicensed)"
-        } elseif ($activationStatus -match "License Status: Unlicensed") {
+        }
+        elseif ($activationStatus -match "License Status: Unlicensed") {
             $issues += "Windows is unlicensed"
-        } elseif ($activationStatus -match "License Status: Out-of-tolerance") {
+        }
+        elseif ($activationStatus -match "License Status: Out-of-tolerance") {
             $issues += "Windows is out of tolerance (requires reactivation)"
-        } else {
+        }
+        else {
             $issues += "Windows activation status is unknown or problematic"
         }
     }
@@ -64,7 +68,8 @@ try {
     Write-Host "Windows is properly activated"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Windows activation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsLicenseActivation/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsLicenseActivation/remediate.ps1
@@ -22,7 +22,8 @@ try {
 
     if ($LASTEXITCODE -eq 0) {
         $remediationActions += "Successfully triggered Windows activation"
-    } else {
+    }
+    else {
         $remediationActions += "Activation attempt completed (may require additional steps)"
     }
 
@@ -36,7 +37,8 @@ try {
             $licensingService.RefreshLicenseStatus() | Out-Null
             $remediationActions += "Refreshed license status"
         }
-    } catch {
+    }
+    catch {
         Write-Host "Note: Could not refresh license status via WMI"
     }
 
@@ -52,7 +54,8 @@ try {
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Windows activation remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsPerformanceRecorder/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsPerformanceRecorder/detect.ps1
@@ -61,7 +61,8 @@ try {
     Write-Host "No stuck WPR/ETW sessions detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking performance recorder status: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsPerformanceRecorder/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsPerformanceRecorder/remediate.ps1
@@ -23,7 +23,8 @@ try {
         try {
             logman stop $sessionName -ets | Out-Null
             $remediationActions += "Stopped WPR session: $sessionName"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not stop session $sessionName : $_"
         }
     }
@@ -40,13 +41,15 @@ try {
         foreach ($action in $remediationActions) {
             Write-Host "  - $action"
         }
-    } else {
+    }
+    else {
         Write-Host "No stuck performance recorder sessions to stop"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during performance recorder remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsSearch/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsSearch/detect.ps1
@@ -52,7 +52,8 @@ try {
             Write-Host "Search index is paused or recovering. Status code: $catalogStatus"
             exit 1
         }
-    } catch {
+    }
+    catch {
         Write-Host "Could not check search index status: $($_.Exception.Message)"
         # Don't fail on this check as it might not be accessible in all contexts
     }
@@ -64,7 +65,8 @@ try {
             Write-Host "Windows Search service test failed"
             exit 1
         }
-    } catch {
+    }
+    catch {
         Write-Host "Windows Search service is not responding properly"
         exit 1
     }
@@ -72,7 +74,8 @@ try {
     Write-Host "Windows Search is functioning properly"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Windows Search: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsSearch/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsSearch/remediate.ps1
@@ -28,7 +28,8 @@ try {
             Start-Sleep -Seconds 3
             Write-Host "Windows Search service stopped"
         }
-    } else {
+    }
+    else {
         Write-Host "Windows Search service not found!"
         exit 1
     }
@@ -44,7 +45,8 @@ try {
                 Remove-Item -Force -ErrorAction SilentlyContinue
 
             Write-Host "Search cache cleared successfully"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not fully clear search cache: $($_.Exception.Message)"
             # Continue even if cache clear fails
         }
@@ -72,19 +74,22 @@ try {
             $catalog = $searchCatalog.GetCatalog("SystemIndex")
             $catalog.Reindex()
             Write-Host "Search index rebuild initiated"
-        } catch {
+        }
+        catch {
             Write-Host "Note: Could not trigger index rebuild automatically: $($_.Exception.Message)"
             Write-Host "Index will rebuild automatically over time"
         }
 
         Write-Host "Windows Search remediation completed successfully"
         exit 0
-    } else {
+    }
+    else {
         Write-Host "Failed to start Windows Search service. Status: $($searchService.Status)"
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Host "Error during Windows Search remediation: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsStoreLicensing/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsStoreLicensing/detect.ps1
@@ -24,7 +24,8 @@ try {
         if ($storeService.Status -ne "Running") {
             $issues += "Client License Service (ClipSVC) is not running"
         }
-    } else {
+    }
+    else {
         $issues += "Client License Service (ClipSVC) is not found"
     }
 
@@ -65,7 +66,8 @@ try {
     Write-Host "Windows Store licensing appears healthy"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking Windows Store licensing: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsStoreLicensing/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsStoreLicensing/remediate.ps1
@@ -27,7 +27,8 @@ try {
         try {
             Stop-Service -Name "ClipSVC" -Force -ErrorAction Stop
             $remediationActions += "Stopped Client License Service (ClipSVC)"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not stop ClipSVC: $_"
         }
     }
@@ -38,7 +39,8 @@ try {
         try {
             Remove-Item -Path $tokensPath -Force -ErrorAction Stop
             $remediationActions += "Removed Store licensing cache: $tokensPath"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not remove licensing cache: $_"
         }
     }
@@ -49,7 +51,8 @@ try {
             Start-Service -Name "ClipSVC" -ErrorAction Stop
             Start-Sleep -Seconds 2
             $remediationActions += "Started Client License Service (ClipSVC)"
-        } catch {
+        }
+        catch {
             Write-Host "Warning: Could not start ClipSVC: $_"
         }
     }
@@ -62,7 +65,8 @@ try {
             Add-AppxPackage -DisableDevelopmentMode -Register "$($storeApp.InstallLocation)\AppXManifest.xml" -ErrorAction SilentlyContinue
             $remediationActions += "Re-registered Microsoft Store app"
         }
-    } catch {
+    }
+    catch {
         Write-Host "Note: Could not re-register Store app: $_"
     }
 
@@ -70,7 +74,8 @@ try {
     try {
         Start-Process "wsreset.exe" -WindowStyle Hidden -ErrorAction SilentlyContinue
         $remediationActions += "Reset Windows Store cache"
-    } catch {
+    }
+    catch {
         Write-Host "Note: Could not run wsreset: $_"
     }
 
@@ -81,13 +86,15 @@ try {
         }
         Write-Host ""
         Write-Host "Note: Users may need to sign out and back in for changes to take effect"
-    } else {
+    }
+    else {
         Write-Host "No Store licensing remediation was necessary"
     }
 
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error during Windows Store licensing remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateRebootPending/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateRebootPending/detect.ps1
@@ -62,7 +62,8 @@ try {
     Write-Host "No stuck reboot pending state detected"
     exit 0
 
-} catch {
+}
+catch {
     Write-Host "Error checking reboot pending state: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateRebootPending/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateRebootPending/remediate.ps1
@@ -46,12 +46,14 @@ try {
         Write-Host "Reboot pending state detected. Scheduled a restart in 15 minutes (shutdown /r /t 900)."
         Write-Host "Note: The RebootPending/RebootRequired registry keys were left intact - they are cleared by Windows during the restart. Deleting them would strand servicing operations."
         exit 0
-    } else {
+    }
+    else {
         Write-Host "Failed to schedule restart: shutdown.exe exited with code $LASTEXITCODE"
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Host "Error during reboot pending remediation: $_"
     exit 1
 }

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateStuck/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateStuck/detect.ps1
@@ -73,7 +73,8 @@ if (-not $firstSeen) {
 
 try {
     $firstSeenDate = [DateTime]::Parse($firstSeen)
-} catch {
+}
+catch {
     # Unparseable marker - reset it and re-observe
     Set-ItemProperty -Path $markerPath -Name $markerName -Value (Get-Date).ToString("o") -Force
     Write-Host "Found $pendingCount pending updates (marker reset - not yet flagged)"

--- a/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateStuck/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/Fix-WindowsUpdateStuck/remediate.ps1
@@ -30,12 +30,12 @@ Stop-Service wuauserv, cryptSvc, bits, msiserver -Force -ErrorAction SilentlyCon
 
 # Clear Windows Update cache
 $wuCache = "$env:SystemRoot\SoftwareDistribution"
-if(Test-Path $wuCache) {
+if (Test-Path $wuCache) {
     Rename-Item $wuCache "$wuCache.old" -Force -ErrorAction SilentlyContinue
 }
 
 $catroot = "$env:SystemRoot\System32\catroot2"
-if(Test-Path $catroot) {
+if (Test-Path $catroot) {
     Rename-Item $catroot "$catroot.old" -Force -ErrorAction SilentlyContinue
 }
 

--- a/scripts/endpoints/devices/proactive-remediations/keyboard-layout/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/keyboard-layout/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect if a UK keyboard layout is the primary input method
+
+.DESCRIPTION
+    Checks the user's language list and exits 1 (non-compliant) when the primary keyboard layout is not UK English (00000809) or UK Extended (00000452), or when the primary language tag is not en-GB. Exits 0 when compliant.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect if a UK keyboard layout is the primary input method
 # Exit 0 if compliant, Exit 1 if non-compliant
 #

--- a/scripts/endpoints/devices/proactive-remediations/keyboard-layout/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/keyboard-layout/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remediate the keyboard layout to UK English
+
+.DESCRIPTION
+    Adds the en-GB language when missing, sets the UK (00000809) and UK Extended (00000452) input method tips, moves en-GB to the first position in the user language list and applies it so UK English becomes the primary keyboard layout.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate keyboard layout to UK English
 # Exit 0 if successful, Exit 1 if failed
 #

--- a/scripts/endpoints/devices/proactive-remediations/language-pack-audit/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/language-pack-audit/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect unnecessary OS language packs
+
+.DESCRIPTION
+    Enumerates installed OS language packs via DISM (Get-WindowsPackage) and exits 1 when any language pack other than the allowed en-GB/en-US set is installed. Only OS language packs are considered; per-user language lists are not inspected.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect unnecessary language packs installed on the system
 # Exit 0 if only essential language packs are installed, Exit 1 if unnecessary packs found
 #
@@ -24,10 +42,10 @@ try {
     # Extract the language tag from each package name, e.g.
     # Microsoft-Windows-Client-LanguagePack-Package~31bf3856ad364e35~amd64~~en-GB~10.0.19041.1
     $installedLanguages = @($languagePacks | ForEach-Object {
-        if ($_.PackageName -match '~([a-zA-Z]{2}-[a-zA-Z]{2})~') {
-            $Matches[1]
-        }
-    } | Sort-Object -Unique)
+            if ($_.PackageName -match '~([a-zA-Z]{2}-[a-zA-Z]{2})~') {
+                $Matches[1]
+            }
+        } | Sort-Object -Unique)
 
     Write-Host "Installed language packs: $($installedLanguages -join ', ')"
 

--- a/scripts/endpoints/devices/proactive-remediations/language-pack-audit/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/language-pack-audit/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remove unnecessary OS language packs
+
+.DESCRIPTION
+    Removes installed OS language packs that are not in the allowed en-GB/en-US set using Remove-WindowsPackage (DISM /Online). Requires an elevated context (Intune Proactive Remediations run as SYSTEM). Exits 0 on success and 1 on failure.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate by removing unnecessary language packs via DISM
 # Exit 0 if successful, Exit 1 if failed
 #

--- a/scripts/endpoints/devices/proactive-remediations/region-language-settings/detect.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/region-language-settings/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect if regional settings match UK standards
+
+.DESCRIPTION
+    Checks the system culture (en-GB), geographic location (GeoId 242, United Kingdom), time zone (GMT Standard Time), system locale and primary user language and exits 1 when any setting deviates from the required UK values.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detect if Windows client device regional settings match UK standards
 # Exit 0 if compliant, Exit 1 if non-compliant
 

--- a/scripts/endpoints/devices/proactive-remediations/region-language-settings/remediate.ps1
+++ b/scripts/endpoints/devices/proactive-remediations/region-language-settings/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Remediate regional settings to UK standards
+
+.DESCRIPTION
+    Sets the geographic location to United Kingdom, time zone to GMT Standard Time and culture to en-GB when they deviate from the required UK values, and reports each applied change.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Remediate Windows client device regional settings to UK standards
 # Exit 0 if successful, Exit 1 if failed
 

--- a/scripts/endpoints/devices/sccm/detect.ps1
+++ b/scripts/endpoints/devices/sccm/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect if the SCCM client is installed
+
+.DESCRIPTION
+    Checks whether the Configuration Manager client is installed by looking for the SMS Agent Host (CcmExec) service running and, as a fallback, the installed client data folder C:\Windows\CCM\ServiceData. The ccmsetup folder is deliberately not used as an indicator because it can exist after a failed install.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detection script for SCCM
 #
 # The installed SCCM client is the SMS Agent Host (CcmExec) service. The
@@ -10,14 +28,14 @@ $ccmService = Get-Service -Name "CcmExec" -ErrorAction SilentlyContinue
 
 if ($ccmService -and $ccmService.Status -eq "Running") {
     Write-Output " SCCM client is installed."
-    Exit 0
+    exit 0
 }
 
 # Fallback: check for the installed client's data folder
 if (Test-Path "C:\Windows\CCM\ServiceData") {
     Write-Output " SCCM client is installed."
-    Exit 0
+    exit 0
 }
 
 Write-Output " SCCM client is NOT installed."
-Exit 1
+exit 1

--- a/scripts/endpoints/devices/sccm/remediate.ps1
+++ b/scripts/endpoints/devices/sccm/remediate.ps1
@@ -32,13 +32,13 @@ $ccmSetupPath = "$env:windir\ccmsetup\ccmsetup.exe"
 # Already installed - nothing to remediate.
 if (Test-Path $ccmSetupPath) {
     Write-Output " SCCM client is installed."
-    Exit 0
+    exit 0
 }
 
 # Client not installed. A source path is required to install it.
 if (-not $SourcePath -or -not (Test-Path $SourcePath)) {
     Write-Error " SCCM client is NOT installed and no valid -SourcePath was provided. Supply a local/UNC path containing ccmsetup.exe (e.g. \\SCCM-SERVER\SCCMContentLib\Client or C:\SCCM)."
-    Exit 1
+    exit 1
 }
 
 # Locate ccmsetup.exe in the source tree (source root or ccmsetup subfolder).
@@ -52,7 +52,7 @@ if (-not (Test-Path $sourceCcmSetup)) {
 
 if (-not (Test-Path $sourceCcmSetup)) {
     Write-Error " ccmsetup.exe was not found under -SourcePath '$SourcePath'. Verify the source tree."
-    Exit 1
+    exit 1
 }
 
 # Build argument list for ccmsetup.exe.
@@ -100,8 +100,8 @@ if ($installSucceeded -and (Test-Path $ccmSetupPath)) {
     else {
         Write-Output " SCCM client installed successfully."
     }
-    Exit 0
+    exit 0
 }
 
 Write-Error " SCCM client installation did not succeed (ccmsetup exit code: $exitCode)."
-Exit 1
+exit 1

--- a/scripts/endpoints/devices/uptime/detect.ps1
+++ b/scripts/endpoints/devices/uptime/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Detect if the device has not been restarted for 4 or more days
+
+.DESCRIPTION
+    Checks the OS uptime (time since last restart, derived from Win32_OperatingSystem.LastBootUpTime) and exits 1 when the device has not been restarted for 4 or more days so the uptime/remediate.ps1 restart notification can run. Sleep/hibernate time does not count towards uptime. Errors default to compliant (exit 0) to avoid false positives.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Detection Script - Check if machine has not been restarted for 4 or more days
 # NOTE: OSUptime derives from Win32_OperatingSystem.LastBootUpTime, i.e. time since the
 # OS was last restarted. Sleep/hibernate time does not count, so this measures "time since
@@ -10,14 +28,14 @@ try {
     
     if ($UptimeDays -ge 4) {
         Write-Output "Device has not been restarted in $UptimeDays days. Needs restart."
-        Exit 1 # Non-compliant (trigger remediation)
+        exit 1 # Non-compliant (trigger remediation)
     }
     else {
         Write-Output "Device has been restarted within the last $UptimeDays days. No action needed."
-        Exit 0 # Compliant (no remediation)
+        exit 0 # Compliant (no remediation)
     }
 }
 catch {
     Write-Output "Failed to get uptime: $_"
-    Exit 0 # Compliant by default on error (no false positives)
+    exit 0 # Compliant by default on error (no false positives)
 }

--- a/scripts/endpoints/devices/uptime/remediate.ps1
+++ b/scripts/endpoints/devices/uptime/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Deploy the restart notification script and scheduled task
+
+.DESCRIPTION
+    Deploys a toast notification script (RestartNotification.ps1) and registers a scheduled task that shows it after the uptime/detect.ps1 script flags a device that has not been restarted for 4+ days. Installs the BurntToast module when missing, downloads the branding logo image, and registers a one-shot scheduled task that triggers 15 seconds after deployment.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 # Wrapper script to deploy and trigger your notification script via scheduled task
 
 # Paths and variables
@@ -24,7 +42,7 @@ if (-not (Get-Module -ListAvailable -Name BurntToast)) {
     }
     catch {
         Write-Error "Failed to install BurntToast module: $_"
-        Exit 1
+        exit 1
     }
 }
 else {
@@ -116,7 +134,7 @@ try {
 }
 catch {
     Write-Error "Failed to save notification script: $_"
-    Exit 1
+    exit 1
 }
 
 # Scheduled task details
@@ -150,8 +168,8 @@ try {
 }
 catch {
     Write-Error "Failed to register scheduled task: $_"
-    Exit 1
+    exit 1
 }
 
 Write-Log "Deployment script completed. Waiting for scheduled task to trigger."
-Exit 0
+exit 0

--- a/scripts/endpoints/devices/winget/_generate-winget-scripts.ps1
+++ b/scripts/endpoints/devices/winget/_generate-winget-scripts.ps1
@@ -48,6 +48,7 @@ $TemplatePath = "$PSScriptRoot\_templates"
 $ScriptsBasePath = $PSScriptRoot
 
 function New-WingetScriptPair {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$WingetId,
         [string]$Category,
@@ -59,7 +60,7 @@ function New-WingetScriptPair {
     $appPath = Join-Path $ScriptsBasePath "$Category\$FolderName"
 
     # Create directory if it doesn't exist
-    if (-not (Test-Path $appPath)) {
+    if (-not (Test-Path $appPath) -and $PSCmdlet.ShouldProcess($appPath, 'Create app directory')) {
         New-Item -Path $appPath -ItemType Directory -Force | Out-Null
         Write-Host "Created directory: $appPath"
     }
@@ -68,7 +69,8 @@ function New-WingetScriptPair {
     $detectTemplate = Get-Content (Join-Path $TemplatePath "detect_v3.ps1") -Raw
     $remediateTemplate = if ($ForceClose) {
         Get-Content (Join-Path $TemplatePath "remediate_v3_force_close.ps1") -Raw
-    } else {
+    }
+    else {
         Get-Content (Join-Path $TemplatePath "remediate_v3_standard.ps1") -Raw
     }
 
@@ -87,8 +89,10 @@ function New-WingetScriptPair {
     $detectPath = Join-Path $appPath "detect.ps1"
     $remediatePath = Join-Path $appPath "remediate.ps1"
 
-    Set-Content -Path $detectPath -Value $detectContent -Force
-    Set-Content -Path $remediatePath -Value $remediateContent -Force
+    if ($PSCmdlet.ShouldProcess($appPath, 'Write detect/remediate script pair')) {
+        Set-Content -Path $detectPath -Value $detectContent -Force
+        Set-Content -Path $remediatePath -Value $remediateContent -Force
+    }
 
     Write-Host "Created scripts for $WingetId in $Category/$FolderName"
 }
@@ -97,7 +101,8 @@ function New-WingetScriptPair {
 foreach ($app in $AppDefinitions) {
     try {
         New-WingetScriptPair -WingetId $app.WingetId -Category $app.Category -FolderName $app.FolderName -ForceClose $app.ForceClose -NotifySeconds $app.NotifySeconds
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to create scripts for $($app.WingetId): $($_.Exception.Message)"
     }
 }

--- a/scripts/endpoints/devices/winget/_templates/detect.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Winget update detection template
+
+.DESCRIPTION
+    Template for winget application update detection scripts. Checks whether the package is installed (preferring the Microsoft.WinGet.Client module in SYSTEM context) and whether an update is available; exits 1 when an update is available so the paired remediation script runs. Replace the APPNAME, WINGETID and PROCESS placeholders before use.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 #Display name of your application (Used for reporting purposes)
 $name = 'APPNAME'
 #winget ID for the package
@@ -13,9 +31,9 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
     try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
     if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
         $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
-        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         #check if there's an available update
-        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        if (-not $package) { Write-Host "$name is not installed on this device."; exit 0 }
         if ($package.IsUpdateAvailable -and $process -ne $null) {
             $verinstalled = $package.InstalledVersion
             $verAvailable = $package.AvailableVersions | Select-Object -Last 1
@@ -25,7 +43,7 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 InstalledVersion = $verInstalled
                 AvailableVersion = $verAvailable
             }
-            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
             exit 1
         }
         if ($package.IsUpdateAvailable -and $process -eq $null) {
@@ -37,7 +55,7 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 InstalledVersion = $verInstalled
                 AvailableVersion = $verAvailable
             }
-            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
             exit 1
         }
         Write-Host "$name upgraded to $($package.InstalledVersion), or $name was already up to date."
@@ -47,59 +65,63 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
 
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
-    if ($wingetexe){
-           $SystemContext = $wingetexe[-1].Path
-    }
+if ($wingetexe) {
+    $SystemContext = $wingetexe[-1].Path
+}
 #create the sysget alias so winget can be ran as system
-new-alias -Name sysget -Value "$systemcontext"
+New-Alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
 $lines = sysget list --exact --id $ID --accept-source-agreements
 try {
-$process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
-#check if there's an available update
-if (($lines -match '\bVersion\s+Available\b' -and $process -ne $null)) {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
-#create custom psobject for reporting the output in intune
-[pscustomobject] @{
-Name = $Name
-InstalledVersion = $verInstalled
-AvailableVersion = $verAvailable
-}
-write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
-exit 1
-}
-if (($lines -match '\bVersion\s+Available\b' -and $process -eq $null)) {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
-#create custom psobject for reporting the output in intune
-[pscustomobject] @{
-Name = $Name
-InstalledVersion = $verInstalled
-AvailableVersion = $verAvailable
-}
-write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
-exit 1
-}else {
-if ($lines -eq "No installed package found matching input criteria.") {write-host "$name is not installed on this device." 
-exit 0
-}else{
-#rechecks the version if it installed and creates values for final output.
-$lines = sysget list --exact --id $ID --accept-source-agreements
-if ($Lines -match '\d+(\.\d+)+') {
-$versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
-}
-#the final output as a pscustomobject
-[pscustomobject] @{
-Name = $name
-InstalledVersion = $VersionInstalled
-}}
-Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
-exit 0
-}
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    #check if there's an available update
+    if (($lines -match '\bVersion\s+Available\b' -and $process -ne $null)) {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+        #create custom psobject for reporting the output in intune
+        [pscustomobject] @{
+            Name = $Name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+        }
+        Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+        exit 1
+    }
+    if (($lines -match '\bVersion\s+Available\b' -and $process -eq $null)) {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+        #create custom psobject for reporting the output in intune
+        [pscustomobject] @{
+            Name = $Name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+        }
+        Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+        exit 1
+    }
+    else {
+        if ($lines -eq "No installed package found matching input criteria.") {
+            Write-Host "$name is not installed on this device." 
+            exit 0
+        }
+        else {
+            #rechecks the version if it installed and creates values for final output.
+            $lines = sysget list --exact --id $ID --accept-source-agreements
+            if ($Lines -match '\d+(\.\d+)+') {
+                $versionavailable, $versioninstalled = (-split $Lines[-1])[-3, -2]
+            }
+            #the final output as a pscustomobject
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $VersionInstalled
+            }
+        }
+        Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
+        exit 0
+    }
 }
 catch {
-  $errMsg = $_.Exception.Message
+    $errMsg = $_.Exception.Message
     Write-Error $errMsg
-   exit 1
+    exit 1
 } 

--- a/scripts/endpoints/devices/winget/_templates/detect_v1_legacy.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v1_legacy.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Legacy winget update detection template (V1)
+
+.DESCRIPTION
+    Template for winget application update detection scripts. Checks whether the package is installed (preferring the Microsoft.WinGet.Client module in SYSTEM context) and whether an update is available; exits 1 when an update is available so the paired remediation script runs. Replace the APPNAME, WINGETID and PROCESS placeholders before use.
+
+.EXAMPLE
+    ./detect.ps1
+
+.NOTES
+    File Name  : detect_v1_legacy.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 #Display name of your application (Used for reporting purposes)
 $name = 'APPNAME'
 #winget ID for the package
@@ -13,9 +31,9 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
     try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
     if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
         $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
-        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         #check if there's an available update
-        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
+        if (-not $package) { Write-Host "$name is not installed on this device."; exit 0 }
         if ($package.IsUpdateAvailable -and $process -ne $null) {
             $verinstalled = $package.InstalledVersion
             $verAvailable = $package.AvailableVersions | Select-Object -Last 1
@@ -25,7 +43,7 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 InstalledVersion = $verInstalled
                 AvailableVersion = $verAvailable
             }
-            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+            Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
             exit 1
         }
         if ($package.IsUpdateAvailable -and $process -eq $null) {
@@ -37,7 +55,7 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 InstalledVersion = $verInstalled
                 AvailableVersion = $verAvailable
             }
-            write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+            Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
             exit 1
         }
         Write-Host "$name upgraded to $($package.InstalledVersion), or $name was already up to date."
@@ -47,59 +65,63 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
 
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
-    if ($wingetexe){
-           $SystemContext = $wingetexe[-1].Path
-    }
+if ($wingetexe) {
+    $SystemContext = $wingetexe[-1].Path
+}
 #create the sysget alias so winget can be ran as system
-new-alias -Name sysget -Value "$systemcontext"
+New-Alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
 $lines = sysget list --exact --id $ID --accept-source-agreements
 try {
-$process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
-#check if there's an available update
-if (($lines -match '\bVersion\s+Available\b' -and $process -ne $null)) {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
-#create custom psobject for reporting the output in intune
-[pscustomobject] @{
-Name = $Name
-InstalledVersion = $verInstalled
-AvailableVersion = $verAvailable
-}
-write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
-exit 1
-}
-if (($lines -match '\bVersion\s+Available\b' -and $process -eq $null)) {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
-#create custom psobject for reporting the output in intune
-[pscustomobject] @{
-Name = $Name
-InstalledVersion = $verInstalled
-AvailableVersion = $verAvailable
-}
-write-host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
-exit 1
-}else {
-if ($lines -eq "No installed package found matching input criteria.") {write-host "$name is not installed on this device." 
-exit 0
-}else{
-#rechecks the version if it installed and creates values for final output.
-$lines = sysget list --exact --id $ID --accept-source-agreements
-if ($Lines -match '\d+(\.\d+)+') {
-$versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
-}
-#the final output as a pscustomobject
-[pscustomobject] @{
-Name = $name
-InstalledVersion = $VersionInstalled
-}}
-Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
-exit 0
-}
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    #check if there's an available update
+    if (($lines -match '\bVersion\s+Available\b' -and $process -ne $null)) {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+        #create custom psobject for reporting the output in intune
+        [pscustomobject] @{
+            Name = $Name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+        }
+        Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable. $Name is currently running, will try again later."
+        exit 1
+    }
+    if (($lines -match '\bVersion\s+Available\b' -and $process -eq $null)) {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+        #create custom psobject for reporting the output in intune
+        [pscustomobject] @{
+            Name = $Name
+            InstalledVersion = $verInstalled
+            AvailableVersion = $verAvailable
+        }
+        Write-Host "Application update available for $Name. Current version is $verinstalled, version available is $verAvailable"
+        exit 1
+    }
+    else {
+        if ($lines -eq "No installed package found matching input criteria.") {
+            Write-Host "$name is not installed on this device." 
+            exit 0
+        }
+        else {
+            #rechecks the version if it installed and creates values for final output.
+            $lines = sysget list --exact --id $ID --accept-source-agreements
+            if ($Lines -match '\d+(\.\d+)+') {
+                $versionavailable, $versioninstalled = (-split $Lines[-1])[-3, -2]
+            }
+            #the final output as a pscustomobject
+            [pscustomobject] @{
+                Name = $name
+                InstalledVersion = $VersionInstalled
+            }
+        }
+        Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
+        exit 0
+    }
 }
 catch {
-  $errMsg = $_.Exception.Message
+    $errMsg = $_.Exception.Message
     Write-Error $errMsg
-   exit 1
+    exit 1
 } 

--- a/scripts/endpoints/devices/winget/_templates/detect_v2.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v2.ps1
@@ -65,7 +65,8 @@ try {
                     AvailableVersion = $verAvailable
                 }
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Host "$name is already up to date (version $versionInstalled)"
@@ -92,7 +93,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -105,7 +107,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
         [pscustomobject] @{
             Name = $name
@@ -113,7 +115,8 @@ try {
             AvailableVersion = $verAvailable
         }
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -125,7 +128,8 @@ try {
             exit 0  # No action needed
         }
     }
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error

--- a/scripts/endpoints/devices/winget/_templates/detect_v3.ps1
+++ b/scripts/endpoints/devices/winget/_templates/detect_v3.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/_templates/remediate.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Winget update remediation template
+
+.DESCRIPTION
+    Template for winget application update remediation scripts. Upgrades the package to the available version without force-closing the application process; exits 0 on success and 1 when the app is running or the upgrade fails. Replace the APPNAME, WINGETID and PROCESS placeholders before use.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 #Display name of your application (Used for reporting purposes)
 $name = 'APPNAME'
 #winget ID for the package
@@ -13,8 +31,8 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
     try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
     if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
         $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
-        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
-        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        if (-not $package) { Write-Host "$name is not installed on this device."; exit 0 }
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         if ($process -eq $null) {
             #run the upgrade
             Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
@@ -29,8 +47,9 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
                 exit 0
             }
-        } else {
-            write-host "$Name is currently running, will try again later."
+        }
+        else {
+            Write-Host "$Name is currently running, will try again later."
             exit 1
         }
     }
@@ -38,45 +57,50 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
 
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
-    if ($wingetexe){
-           $SystemContext = $wingetexe[-1].Path
-    }
+if ($wingetexe) {
+    $SystemContext = $wingetexe[-1].Path
+}
 #create the sysget alias so winget can be ran as system
-new-alias -Name sysget -Value "$systemcontext"
+New-Alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
 $lines = sysget list --exact --id $ID --accept-source-agreements
 #tries to upgrade if the installed version is lower than the available version
 try {
-if ($lines -match '\bVersion\s+Available\b') {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $name"
-Write-Verbose -Verbose "Downloading and Installing $name"
-}
-#checks if your app is running as to not auto-close. change the process value to the app you want.
-$process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
-if ($process -eq $null){
-#run the upgrade
-sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
-#rechecks the version if it installed and creates values for final output.
-$lines = sysget list --exact --id $ID --accept-source-agreements } else {write-host "$Name is currently running, will try again later."
-exit 1
-}
-if ($Lines -match '\d+(\.\d+)+') {
-$versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
+    if ($lines -match '\bVersion\s+Available\b') {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $name"
+        Write-Verbose -Verbose "Downloading and Installing $name"
+    }
+    #checks if your app is running as to not auto-close. change the process value to the app you want.
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    if ($process -eq $null) {
+        #run the upgrade
+        sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
+        #rechecks the version if it installed and creates values for final output.
+        $lines = sysget list --exact --id $ID --accept-source-agreements 
+    }
+    else {
+        Write-Host "$Name is currently running, will try again later."
+        exit 1
+    }
+    if ($Lines -match '\d+(\.\d+)+') {
+        $versionavailable, $versioninstalled = (-split $Lines[-1])[-3, -2]
 
-#the final output as a pscustomobject
-[pscustomobject] @{
-Name = $name
-InstalledVersion = $VersionInstalled}
-exit 0
-} else 
-{
-write-host "$Name is currently running, will try again later."
-exit 1
-} 
+        #the final output as a pscustomobject
+        [pscustomobject] @{
+            Name = $name
+            InstalledVersion = $VersionInstalled
+        }
+        exit 0
+    }
+    else {
+        Write-Host "$Name is currently running, will try again later."
+        exit 1
+    } 
 
-}catch {
-  $errMsg = $_.Exception.Message
+}
+catch {
+    $errMsg = $_.Exception.Message
     Write-Error $errMsg
-   exit 1
-   }
+    exit 1
+}

--- a/scripts/endpoints/devices/winget/_templates/remediate_v1_legacy.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v1_legacy.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Legacy winget update remediation template (V1)
+
+.DESCRIPTION
+    Template for winget application update remediation scripts. Upgrades the package to the available version without force-closing the application process; exits 0 on success and 1 when the app is running or the upgrade fails. Replace the APPNAME, WINGETID and PROCESS placeholders before use.
+
+.EXAMPLE
+    ./remediate.ps1
+
+.NOTES
+    File Name  : remediate_v1_legacy.ps1
+    Author     : Intune / Proactive Remediations
+    Prerequisite: PowerShell 5.1 or later, run in the Intune Proactive Remediation context
+    Version    : 1.0.0
+    Date       : 2026-08-08
+#>
+
 #Display name of your application (Used for reporting purposes)
 $name = 'APPNAME'
 #winget ID for the package
@@ -13,8 +31,8 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
     try { Import-Module Microsoft.WinGet.Client -ErrorAction Stop } catch { }
     if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
         $package = Get-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -ErrorAction SilentlyContinue
-        if (-not $package) { write-host "$name is not installed on this device."; exit 0 }
-        $process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
+        if (-not $package) { Write-Host "$name is not installed on this device."; exit 0 }
+        $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
         if ($process -eq $null) {
             #run the upgrade
             Update-WinGetPackage -Id $ID -MatchOption EqualsCaseInsensitive -Mode Silent -Force -ErrorAction Stop
@@ -29,8 +47,9 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
                 Write-Host "$name upgraded to $versioninstalled, or $name was already up to date."
                 exit 0
             }
-        } else {
-            write-host "$Name is currently running, will try again later."
+        }
+        else {
+            Write-Host "$Name is currently running, will try again later."
             exit 1
         }
     }
@@ -38,45 +57,50 @@ if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client) {
 
 #location of the winget exe
 $wingetexe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe"
-    if ($wingetexe){
-           $SystemContext = $wingetexe[-1].Path
-    }
+if ($wingetexe) {
+    $SystemContext = $wingetexe[-1].Path
+}
 #create the sysget alias so winget can be ran as system
-new-alias -Name sysget -Value "$systemcontext"
+New-Alias -Name sysget -Value "$systemcontext"
 #this gets the info on the app (if it has an update, or not)
 $lines = sysget list --exact --id $ID --accept-source-agreements
 #tries to upgrade if the installed version is lower than the available version
 try {
-if ($lines -match '\bVersion\s+Available\b') {
-$verinstalled, $verAvailable = (-split $lines[-1])[-3,-2]
-Write-Verbose -Verbose "Application update available for $name"
-Write-Verbose -Verbose "Downloading and Installing $name"
-}
-#checks if your app is running as to not auto-close. change the process value to the app you want.
-$process = get-process -name "$AppProcess" -ErrorAction SilentlyContinue
-if ($process -eq $null){
-#run the upgrade
-sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
-#rechecks the version if it installed and creates values for final output.
-$lines = sysget list --exact --id $ID --accept-source-agreements } else {write-host "$Name is currently running, will try again later."
-exit 1
-}
-if ($Lines -match '\d+(\.\d+)+') {
-$versionavailable, $versioninstalled = (-split $Lines[-1])[-3,-2]
+    if ($lines -match '\bVersion\s+Available\b') {
+        $verinstalled, $verAvailable = (-split $lines[-1])[-3, -2]
+        Write-Verbose -Verbose "Application update available for $name"
+        Write-Verbose -Verbose "Downloading and Installing $name"
+    }
+    #checks if your app is running as to not auto-close. change the process value to the app you want.
+    $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
+    if ($process -eq $null) {
+        #run the upgrade
+        sysget upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements
+        #rechecks the version if it installed and creates values for final output.
+        $lines = sysget list --exact --id $ID --accept-source-agreements 
+    }
+    else {
+        Write-Host "$Name is currently running, will try again later."
+        exit 1
+    }
+    if ($Lines -match '\d+(\.\d+)+') {
+        $versionavailable, $versioninstalled = (-split $Lines[-1])[-3, -2]
 
-#the final output as a pscustomobject
-[pscustomobject] @{
-Name = $name
-InstalledVersion = $VersionInstalled}
-exit 0
-} else 
-{
-write-host "$Name is currently running, will try again later."
-exit 1
-} 
+        #the final output as a pscustomobject
+        [pscustomobject] @{
+            Name = $name
+            InstalledVersion = $VersionInstalled
+        }
+        exit 0
+    }
+    else {
+        Write-Host "$Name is currently running, will try again later."
+        exit 1
+    } 
 
-}catch {
-  $errMsg = $_.Exception.Message
+}
+catch {
+    $errMsg = $_.Exception.Message
     Write-Error $errMsg
-   exit 1
-   }
+    exit 1
+}

--- a/scripts/endpoints/devices/winget/_templates/remediate_v2_force_close.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v2_force_close.ps1
@@ -84,7 +84,8 @@ try {
                     Start-Sleep -Seconds 2
                 }
                 Write-Host "$name closed successfully."
-            } else {
+            }
+            else {
                 Write-Host "$name is not currently running."
             }
 
@@ -113,11 +114,13 @@ try {
                         Status = "Force Updated Successfully"
                     }
                     exit 0
-                } else {
+                }
+                else {
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Host "$name is already up to date (version $versionInstalled)"
@@ -145,7 +148,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -177,13 +181,14 @@ try {
             Start-Sleep -Seconds 2
         }
         Write-Host "$name closed successfully."
-    } else {
+    }
+    else {
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Host "Update available for $name : $verInstalled -> $verAvailable"
 
         # Perform upgrade
@@ -205,11 +210,13 @@ try {
                 Status = "Force Updated Successfully"
             }
             exit 0
-        } else {
+        }
+        else {
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -222,7 +229,8 @@ try {
             exit 0
         }
     }
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Error "Failed to update $name : $errMsg"
     exit 1

--- a/scripts/endpoints/devices/winget/_templates/remediate_v2_standard.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v2_standard.ps1
@@ -99,7 +99,8 @@ try {
                     }
                     exit 0
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Host "$name is already up to date (version $versionInstalled)"
@@ -127,7 +128,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -140,7 +142,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Verbose -Verbose "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
         # Auto-detect process name if not provided
@@ -179,7 +181,8 @@ try {
             }
             exit 0
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -192,7 +195,8 @@ try {
             exit 0
         }
     }
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Error "Failed to update $name : $errMsg"
     exit 1

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_force_close.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_force_close.ps1
@@ -71,9 +71,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -83,7 +83,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -107,12 +108,14 @@ function Show-UserNotification {
         }
 
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch {
+    }
+    catch {
         Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
     }
 }
 
 function Stop-ApplicationProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ProcessName,
         [int]$MaxAttempts = $MaxProcessCloseAttempts
@@ -128,7 +131,9 @@ function Stop-ApplicationProcess {
         }
 
         Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
-        Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        if ($PSCmdlet.ShouldProcess($ProcessName, 'Stop application process')) {
+            Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        }
         Start-Sleep -Seconds 2
 
         $attempt++
@@ -188,7 +193,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -262,7 +268,8 @@ try {
 
                 Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
                 Start-Sleep -Seconds $GracePeriodSeconds
-            } else {
+            }
+            else {
                 Write-Log "$name is not currently running." -Level Info
                 Write-Host "$name is not currently running."
             }
@@ -278,7 +285,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -297,7 +305,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -319,12 +328,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -350,7 +361,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -365,7 +377,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -407,14 +420,15 @@ try {
 
         Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
-    } else {
+    }
+    else {
         Write-Log "$name is not currently running." -Level Info
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Execute pre-update hook if defined
@@ -422,7 +436,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -442,7 +457,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -464,12 +480,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -486,12 +504,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_maintenance_window.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_maintenance_window.ps1
@@ -77,9 +77,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -89,7 +89,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -160,7 +161,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -243,12 +245,14 @@ try {
                         }
 
                         Write-Log "$name closed successfully." -Level Info
-                    } else {
+                    }
+                    else {
                         Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
                         Write-Host "$name is currently running. Skipping update."
                         exit 1
                     }
-                } else {
+                }
+                else {
                     Write-Log "$name is not currently running." -Level Info
                 }
 
@@ -257,7 +261,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -276,7 +281,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -299,12 +305,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -330,7 +338,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -345,7 +354,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -359,7 +369,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Auto-detect process name if not provided
@@ -386,12 +396,14 @@ try {
                 }
 
                 Write-Log "$name closed successfully." -Level Info
-            } else {
+            }
+            else {
                 Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
                 Write-Host "$name is currently running. Skipping update."
                 exit 1
             }
-        } else {
+        }
+        else {
             Write-Log "$name is not currently running." -Level Info
         }
 
@@ -400,7 +412,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -420,7 +433,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -443,12 +457,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -465,12 +481,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/_templates/remediate_v3_standard.ps1
+++ b/scripts/endpoints/devices/winget/_templates/remediate_v3_standard.ps1
@@ -63,9 +63,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -75,7 +75,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -125,7 +126,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -202,7 +204,8 @@ try {
                     try {
                         & $PreUpdateScriptBlock
                         Write-Log "Pre-update hook completed successfully" -Level Info
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -222,7 +225,8 @@ try {
                     try {
                         & $PostUpdateScriptBlock
                         Write-Log "Post-update hook completed successfully" -Level Info
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -244,12 +248,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -275,7 +281,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -291,7 +298,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -305,7 +313,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Auto-detect process name if not provided
@@ -335,7 +343,8 @@ try {
             try {
                 & $PreUpdateScriptBlock
                 Write-Log "Pre-update hook completed successfully" -Level Info
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -356,7 +365,8 @@ try {
             try {
                 & $PostUpdateScriptBlock
                 Write-Log "Post-update hook completed successfully" -Level Info
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -378,12 +388,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -400,12 +412,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/browsers/Firefox/detect.ps1
+++ b/scripts/endpoints/devices/winget/browsers/Firefox/detect.ps1
@@ -48,7 +48,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -82,7 +83,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/browsers/Firefox/remediate.ps1
+++ b/scripts/endpoints/devices/winget/browsers/Firefox/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -100,7 +101,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -121,5 +122,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/browsers/GoogleChrome/detect.ps1
+++ b/scripts/endpoints/devices/winget/browsers/GoogleChrome/detect.ps1
@@ -48,7 +48,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -84,7 +85,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/browsers/GoogleChrome/remediate.ps1
+++ b/scripts/endpoints/devices/winget/browsers/GoogleChrome/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -100,7 +101,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -121,5 +122,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Discord/remediate.ps1
@@ -71,9 +71,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -83,7 +83,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -107,12 +108,14 @@ function Show-UserNotification {
         }
 
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch {
+    }
+    catch {
         Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
     }
 }
 
 function Stop-ApplicationProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ProcessName,
         [int]$MaxAttempts = $MaxProcessCloseAttempts
@@ -128,7 +131,9 @@ function Stop-ApplicationProcess {
         }
 
         Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
-        Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        if ($PSCmdlet.ShouldProcess($ProcessName, 'Stop application process')) {
+            Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        }
         Start-Sleep -Seconds 2
 
         $attempt++
@@ -188,7 +193,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -262,7 +268,8 @@ try {
 
                 Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
                 Start-Sleep -Seconds $GracePeriodSeconds
-            } else {
+            }
+            else {
                 Write-Log "$name is not currently running." -Level Info
                 Write-Host "$name is not currently running."
             }
@@ -278,7 +285,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -297,7 +305,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -319,12 +328,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -350,7 +361,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -365,7 +377,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -407,14 +420,15 @@ try {
 
         Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
-    } else {
+    }
+    else {
         Write-Log "$name is not currently running." -Level Info
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Execute pre-update hook if defined
@@ -422,7 +436,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -442,7 +457,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -464,12 +480,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -486,12 +504,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
+++ b/scripts/endpoints/devices/winget/communication/Slack/remediate.ps1
@@ -71,9 +71,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -83,7 +83,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -107,12 +108,14 @@ function Show-UserNotification {
         }
 
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch {
+    }
+    catch {
         Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
     }
 }
 
 function Stop-ApplicationProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ProcessName,
         [int]$MaxAttempts = $MaxProcessCloseAttempts
@@ -128,7 +131,9 @@ function Stop-ApplicationProcess {
         }
 
         Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
-        Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        if ($PSCmdlet.ShouldProcess($ProcessName, 'Stop application process')) {
+            Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        }
         Start-Sleep -Seconds 2
 
         $attempt++
@@ -188,7 +193,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -262,7 +268,8 @@ try {
 
                 Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
                 Start-Sleep -Seconds $GracePeriodSeconds
-            } else {
+            }
+            else {
                 Write-Log "$name is not currently running." -Level Info
                 Write-Host "$name is not currently running."
             }
@@ -278,7 +285,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -297,7 +305,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -319,12 +328,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -350,7 +361,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -365,7 +377,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -407,14 +420,15 @@ try {
 
         Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
-    } else {
+    }
+    else {
         Write-Log "$name is not currently running." -Level Info
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Execute pre-update hook if defined
@@ -422,7 +436,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -442,7 +457,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -464,12 +480,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -486,12 +504,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/AzureCLI/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/AzureCLI/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/AzureCLI/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/AzureCLI/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/Git/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/Git/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/Git/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/Git/remediate.ps1
@@ -51,7 +51,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -112,7 +113,7 @@ try {
     }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         Write-Host "Installing Git update ($($v[0]) -> $($v[1]))..."
 
         Invoke-WingetWithRetry -Arguments "upgrade -e --id $ID --silent --accept-package-agreements --accept-source-agreements" | Out-Null
@@ -127,5 +128,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/OhMyPosh/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/OhMyPosh/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/OhMyPosh/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/OhMyPosh/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/PowerShell7/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/PowerShell7/detect.ps1
@@ -48,7 +48,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -84,7 +85,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = "PowerShell 7"
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/PowerShell7/remediate_maintenance_window.ps1
+++ b/scripts/endpoints/devices/winget/development/PowerShell7/remediate_maintenance_window.ps1
@@ -77,9 +77,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -89,7 +89,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -160,7 +161,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -243,12 +245,14 @@ try {
                         }
 
                         Write-Log "$name closed successfully." -Level Info
-                    } else {
+                    }
+                    else {
                         Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
                         Write-Host "$name is currently running. Skipping update."
                         exit 1
                     }
-                } else {
+                }
+                else {
                     Write-Log "$name is not currently running." -Level Info
                 }
 
@@ -257,7 +261,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -276,7 +281,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -299,12 +305,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -330,7 +338,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -345,7 +354,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -359,7 +369,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Auto-detect process name if not provided
@@ -386,12 +396,14 @@ try {
                 }
 
                 Write-Log "$name closed successfully." -Level Info
-            } else {
+            }
+            else {
                 Write-Log "$name is running. Skipping update (force close disabled)." -Level Warning
                 Write-Host "$name is currently running. Skipping update."
                 exit 1
             }
-        } else {
+        }
+        else {
             Write-Log "$name is not currently running." -Level Info
         }
 
@@ -400,7 +412,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -420,7 +433,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -443,12 +457,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -465,12 +481,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/SSMS/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/SSMS/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/SSMS/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/SSMS/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioCode/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioCode/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioCode/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioCode/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2019/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2019/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2019/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2019/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2022/detect.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2022/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/development/VisualStudioPro2022/remediate.ps1
+++ b/scripts/endpoints/devices/winget/development/VisualStudioPro2022/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/OBS/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/OBS/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/OBS/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/OBS/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/VLCMediaPlayer/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/VLCMediaPlayer/detect.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -89,16 +90,18 @@ try {
     $name = if ($nameMatch) { $nameMatch.Matches[0].Groups[2].Value.Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name is not installed."; exit 0 }
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Host "Update available for $name. Current: $verInstalled, Available: $verAvailable"
         [pscustomobject] @{ Name = $name; InstalledVersion = $verInstalled; AvailableVersion = $verAvailable }
         exit 1
-    } else {
+    }
+    else {
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
             Write-Host "$name is up to date (version $versionInstalled)"
             exit 0
         }
     }
-} catch { Write-Error "Detection failed: $($_.Exception.Message)"; exit 0 }
+}
+catch { Write-Error "Detection failed: $($_.Exception.Message)"; exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/VLCMediaPlayer/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/VLCMediaPlayer/remediate.ps1
@@ -53,7 +53,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -103,7 +104,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         # Check if VLC is playing - don't interrupt user
@@ -125,5 +126,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/Zoom/detect.ps1
+++ b/scripts/endpoints/devices/winget/media/Zoom/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/media/Zoom/remediate.ps1
+++ b/scripts/endpoints/devices/winget/media/Zoom/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader32bit/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/AdobeReader64bit/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/MicrosoftTeams/remediate.ps1
@@ -71,9 +71,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -83,7 +83,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -107,12 +108,14 @@ function Show-UserNotification {
         }
 
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch {
+    }
+    catch {
         Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
     }
 }
 
 function Stop-ApplicationProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ProcessName,
         [int]$MaxAttempts = $MaxProcessCloseAttempts
@@ -128,7 +131,9 @@ function Stop-ApplicationProcess {
         }
 
         Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
-        Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        if ($PSCmdlet.ShouldProcess($ProcessName, 'Stop application process')) {
+            Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        }
         Start-Sleep -Seconds 2
 
         $attempt++
@@ -188,7 +193,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -262,7 +268,8 @@ try {
 
                 Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
                 Start-Sleep -Seconds $GracePeriodSeconds
-            } else {
+            }
+            else {
                 Write-Log "$name is not currently running." -Level Info
                 Write-Host "$name is not currently running."
             }
@@ -278,7 +285,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -297,7 +305,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -319,12 +328,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -350,7 +361,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -365,7 +377,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -407,14 +420,15 @@ try {
 
         Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
-    } else {
+    }
+    else {
         Write-Log "$name is not currently running." -Level Info
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Execute pre-update hook if defined
@@ -422,7 +436,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -442,7 +457,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -464,12 +480,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -486,12 +504,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/NotepadPlusPlus/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/RemoteDesktop/detect.ps1
+++ b/scripts/endpoints/devices/winget/productivity/RemoteDesktop/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/productivity/RemoteDesktop/remediate.ps1
+++ b/scripts/endpoints/devices/winget/productivity/RemoteDesktop/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate_Force_Close.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerFull/remediate_Force_Close.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -103,7 +104,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -124,5 +125,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/TeamViewerHost/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/WinSCP/detect.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/WinSCP/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/remote-access/WinSCP/remediate.ps1
+++ b/scripts/endpoints/devices/winget/remote-access/WinSCP/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2008Redist/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2010Redist/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2012Redist/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x64/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2013Redist-x86/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x64/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/Cpp2015-2019Redist-x86/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/detect.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/remediate.ps1
+++ b/scripts/endpoints/devices/winget/runtimes/EdgeWebView2/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/security/1Password/detect.ps1
+++ b/scripts/endpoints/devices/winget/security/1Password/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/detect.ps1
@@ -66,9 +66,9 @@ function Write-Log {
 
     # Always write to console
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     # Optionally write to file
@@ -79,7 +79,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch {
+        }
+        catch {
             # Fail silently if logging doesn't work
         }
     }
@@ -89,7 +90,8 @@ function Test-NetworkConnectivity {
     try {
         $testConnection = Test-Connection -ComputerName "www.microsoft.com" -Count 1 -Quiet -ErrorAction SilentlyContinue
         return $testConnection
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -138,7 +140,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -208,7 +211,8 @@ try {
                 }
 
                 exit 1  # Trigger remediation
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -235,7 +239,8 @@ try {
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
         Write-Log "Found multiple winget installations, using latest: $SystemContext" -Level Info
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
         Write-Log "Found winget: $SystemContext" -Level Info
     }
@@ -252,7 +257,8 @@ try {
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
             Write-Log "Auto-detected application name: $name" -Level Info
-        } else {
+        }
+        else {
             $name = $ID
             Write-Log "Could not auto-detect name, using ID: $name" -Level Warning
         }
@@ -267,7 +273,7 @@ try {
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
         Write-Host "Application update available for $name. Current: $verInstalled, Available: $verAvailable"
 
@@ -279,7 +285,8 @@ try {
         }
 
         exit 1  # Trigger remediation
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -293,19 +300,22 @@ try {
             }
 
             exit 0  # No action needed
-        } else {
+        }
+        else {
             Write-Log "$name appears to be installed but version info could not be parsed" -Level Warning
             Write-Host "$name is installed but version could not be determined"
             exit 0
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to check $name for updates: $errMsg" -Level Error
     Write-Error "Failed to check $name for updates: $errMsg"
     exit 0  # Don't trigger remediation on error
-} finally {
+}
+finally {
     Write-Log "=== Detection script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
+++ b/scripts/endpoints/devices/winget/utilities/SevenZip/remediate.ps1
@@ -71,9 +71,9 @@ function Write-Log {
     $logMessage = "[$timestamp] [$Level] $Message"
 
     switch ($Level) {
-        'Error'   { Write-Error $Message }
+        'Error' { Write-Error $Message }
         'Warning' { Write-Warning $Message }
-        'Info'    { Write-Host $Message }
+        'Info' { Write-Host $Message }
     }
 
     if ($EnableLogging) {
@@ -83,7 +83,8 @@ function Write-Log {
                 New-Item -Path $logDir -ItemType Directory -Force | Out-Null
             }
             Add-Content -Path $LogPath -Value $logMessage -ErrorAction SilentlyContinue
-        } catch { }
+        }
+        catch { }
     }
 }
 
@@ -107,12 +108,14 @@ function Show-UserNotification {
         }
 
         Write-Log "User notification sent: $AppName will close in $Seconds seconds" -Level Info
-    } catch {
+    }
+    catch {
         Write-Log "Failed to send user notification: $($_.Exception.Message)" -Level Warning
     }
 }
 
 function Stop-ApplicationProcess {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ProcessName,
         [int]$MaxAttempts = $MaxProcessCloseAttempts
@@ -128,7 +131,9 @@ function Stop-ApplicationProcess {
         }
 
         Write-Log "Stopping $ProcessName process (attempt $attempt/$MaxAttempts)..." -Level Info
-        Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        if ($PSCmdlet.ShouldProcess($ProcessName, 'Stop application process')) {
+            Stop-Process -Name $ProcessName -Force -ErrorAction SilentlyContinue
+        }
         Start-Sleep -Seconds 2
 
         $attempt++
@@ -188,7 +193,8 @@ function Invoke-WingetWithRetry {
 
             Write-Log "Winget command exited with code 0x$($p.ExitCode.ToString('X8')) on attempt $attempt" -Level Warning
             if ($stderr) { Write-Log "Winget stderr: $stderr" -Level Warning }
-        } catch {
+        }
+        catch {
             Write-Log "Winget command failed on attempt $attempt : $($_.Exception.Message)" -Level Warning
         }
 
@@ -262,7 +268,8 @@ try {
 
                 Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
                 Start-Sleep -Seconds $GracePeriodSeconds
-            } else {
+            }
+            else {
                 Write-Log "$name is not currently running." -Level Info
                 Write-Host "$name is not currently running."
             }
@@ -278,7 +285,8 @@ try {
                     Write-Log "Executing pre-update hook..." -Level Info
                     try {
                         & $PreUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -297,7 +305,8 @@ try {
                     Write-Log "Executing post-update hook..." -Level Info
                     try {
                         & $PostUpdateScriptBlock
-                    } catch {
+                    }
+                    catch {
                         Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
                     }
                 }
@@ -319,12 +328,14 @@ try {
                     }
 
                     exit 0
-                } else {
+                }
+                else {
                     Write-Log "Failed to verify $name installation after update" -Level Error
                     Write-Error "Failed to verify $name installation after update."
                     exit 1
                 }
-            } else {
+            }
+            else {
                 # No update available
                 $versionInstalled = $package.InstalledVersion
                 Write-Log "$name is already up to date (version $versionInstalled)" -Level Info
@@ -350,7 +361,8 @@ try {
 
     if ($wingetexe.Count -gt 1) {
         $SystemContext = $wingetexe[-1].Path
-    } else {
+    }
+    else {
         $SystemContext = $wingetexe.Path
     }
 
@@ -365,7 +377,8 @@ try {
         $nameMatch = $packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d"
         if ($nameMatch) {
             $name = $nameMatch.Matches[0].Groups[2].Value.Trim()
-        } else {
+        }
+        else {
             $name = $ID
         }
     }
@@ -407,14 +420,15 @@ try {
 
         Write-Log "$name closed successfully. Waiting $GracePeriodSeconds seconds..." -Level Info
         Start-Sleep -Seconds $GracePeriodSeconds
-    } else {
+    }
+    else {
         Write-Log "$name is not currently running." -Level Info
         Write-Host "$name is not currently running."
     }
 
     # Check if update is available
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3,-2]
+        $verInstalled, $verAvailable = (-split $packageInfo[-1])[-3, -2]
         Write-Log "Update available for $name | Installed: $verInstalled | Available: $verAvailable" -Level Info
 
         # Execute pre-update hook if defined
@@ -422,7 +436,8 @@ try {
             Write-Log "Executing pre-update hook..." -Level Info
             try {
                 & $PreUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Pre-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -442,7 +457,8 @@ try {
             Write-Log "Executing post-update hook..." -Level Info
             try {
                 & $PostUpdateScriptBlock
-            } catch {
+            }
+            catch {
                 Write-Log "Post-update hook failed: $($_.Exception.Message)" -Level Warning
             }
         }
@@ -464,12 +480,14 @@ try {
             }
 
             exit 0
-        } else {
+        }
+        else {
             Write-Log "Failed to verify $name installation after update" -Level Error
             Write-Error "Failed to verify $name installation after update."
             exit 1
         }
-    } else {
+    }
+    else {
         # No update available
         if ($packageInfo -match '\d+(\.\d+)+') {
             $versionInstalled = (-split $packageInfo[-1])[-2]
@@ -486,12 +504,14 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     $errMsg = $_.Exception.Message
     Write-Log "ERROR: Failed to update $name : $errMsg" -Level Error
     Write-Error "Failed to update $name : $errMsg"
     exit 1
-} finally {
+}
+finally {
     Write-Log "=== Remediation script completed ===" -Level Info
 }
 #endregion

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/detect.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/remediate.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoDockManager/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/detect.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/detect.ps1
@@ -47,7 +47,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -83,7 +84,8 @@ try {
     $packageInfo = Invoke-WingetWithRetry -Arguments "list --exact --id $ID --accept-source-agreements"
     $name = if ($packageInfo | Select-String -Pattern "^($ID)\s+(.+?)\s+\d") { $Matches[2].Trim() } else { $ID }
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
-    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3,-2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
+    if ($packageInfo -match '\bVersion\s+Available\b') { $v = (-split $packageInfo[-1])[-3, -2]; Write-Host "Update available: $($v[0]) -> $($v[1])"; exit 1 }
     Write-Host "$name is up to date."; exit 0
-} catch { exit 0 }
+}
+catch { exit 0 }
 #endregion

--- a/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/remediate.ps1
+++ b/scripts/endpoints/devices/winget/vendor-specific/LenovoSystemUpdate/remediate.ps1
@@ -50,7 +50,8 @@ function Invoke-WingetWithRetry {
 
             Write-Verbose "Winget exited with code 0x$($process.ExitCode.ToString('X8')) on attempt $attempt" -Verbose:$false
             if ($stderr) { Write-Verbose "Winget stderr: $stderr" -Verbose:$false }
-        } catch { }
+        }
+        catch { }
         Start-Sleep -Seconds 2
         $attempt++
     }
@@ -102,7 +103,7 @@ try {
     if ($packageInfo -match "No installed package found") { Write-Host "$name not installed."; exit 0 }
 
     if ($packageInfo -match '\bVersion\s+Available\b') {
-        $v = (-split $packageInfo[-1])[-3,-2]
+        $v = (-split $packageInfo[-1])[-3, -2]
         $process = Get-Process -Name "$AppProcess" -ErrorAction SilentlyContinue
 
         if ($process) {
@@ -123,5 +124,6 @@ try {
         Write-Error "Verification failed"; exit 1
     }
     Write-Host "$name is up to date."; exit 0
-} catch { Write-Error "Failed: $_"; exit 1 }
+}
+catch { Write-Error "Failed: $_"; exit 1 }
 #endregion


### PR DESCRIPTION
Closes #116 #118 #128

PSSA enforcement campaign for #116 (comment-based help), #118 (ShouldProcess), #128 (style rules).
Fixes: formatter-normalized style, manual casing fixes, comment-based help headers, SupportsShouldProcess retrofits with `$PSCmdlet.ShouldProcess()` guards (no -ConfirmImpact; normal runs stay silent, -WhatIf/-Confirm become available).

## Summary by Sourcery

Add comment-based help and PSSA-compliant style to endpoint scripts and retrofit process-affecting functions and generators with SupportsShouldProcess guards.

Enhancements:
- Normalize PowerShell casing, indentation, and control-flow formatting across endpoint detection and remediation scripts.
- Add detailed comment-based help headers to detection, remediation, driver, Autopatch, security baseline, and utility scripts.
- Wrap process-stopping and update-running functions with CmdletBinding(SupportsShouldProcess) and ShouldProcess checks to support -WhatIf/-Confirm semantics in remediation flows.
- Improve logging and transcript handling in Autopatch, Adobe RUM, winget templates, and proactive remediation scripts for clearer diagnostics.

Tests:
- Add Pester test headers and minor style fixes in Check-DeviceHealthScore and Check-HardwareErrors test suites to align with script documentation.