### PR TITLE
fix: enforce PSSA style/ShouldProcess in infrastructure

### DIFF
--- a/scripts/infrastructure/network/Reset-NetworkStack.ps1
+++ b/scripts/infrastructure/network/Reset-NetworkStack.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Resets Windows network stack to resolve connectivity issues.
 
@@ -135,77 +135,77 @@ try {
     Write-Host "`nResetting Winsock catalog..." -ForegroundColor Yellow
 
     if ($PSCmdlet.ShouldProcess("Winsock catalog", "Reset")) {
-    try {
-        $winsockReset = netsh winsock reset 2>&1
-        Write-Host "✓ Winsock reset successful" -ForegroundColor Green
-        $operations += [PSCustomObject]@{
-            Operation = "Winsock Reset"
-            Status = "Success"
-            Message = "Winsock catalog reset successfully"
+        try {
+            $winsockReset = netsh winsock reset 2>&1
+            Write-Host "✓ Winsock reset successful" -ForegroundColor Green
+            $operations += [PSCustomObject]@{
+                Operation = "Winsock Reset"
+                Status = "Success"
+                Message = "Winsock catalog reset successfully"
+            }
+            $successCount++
+            $restartRequired = $true
         }
-        $successCount++
-        $restartRequired = $true
-    }
-    catch {
-        Write-Warning "Winsock reset failed: $_"
-        $operations += [PSCustomObject]@{
-            Operation = "Winsock Reset"
-            Status = "Failed"
-            Message = $_.Exception.Message
+        catch {
+            Write-Warning "Winsock reset failed: $_"
+            $operations += [PSCustomObject]@{
+                Operation = "Winsock Reset"
+                Status = "Failed"
+                Message = $_.Exception.Message
+            }
+            $failCount++
         }
-        $failCount++
-    }
     }
 
     # Reset TCP/IP stack
     Write-Host "`nResetting TCP/IP stack..." -ForegroundColor Yellow
 
     if ($PSCmdlet.ShouldProcess("TCP/IP stack", "Reset")) {
-    try {
-        $tcpipReset = netsh int ip reset 2>&1
-        Write-Host "✓ TCP/IP stack reset successful" -ForegroundColor Green
-        $operations += [PSCustomObject]@{
-            Operation = "TCP/IP Reset"
-            Status = "Success"
-            Message = "TCP/IP stack reset successfully"
+        try {
+            $tcpipReset = netsh int ip reset 2>&1
+            Write-Host "✓ TCP/IP stack reset successful" -ForegroundColor Green
+            $operations += [PSCustomObject]@{
+                Operation = "TCP/IP Reset"
+                Status = "Success"
+                Message = "TCP/IP stack reset successfully"
+            }
+            $successCount++
+            $restartRequired = $true
         }
-        $successCount++
-        $restartRequired = $true
-    }
-    catch {
-        Write-Warning "TCP/IP reset failed: $_"
-        $operations += [PSCustomObject]@{
-            Operation = "TCP/IP Reset"
-            Status = "Failed"
-            Message = $_.Exception.Message
+        catch {
+            Write-Warning "TCP/IP reset failed: $_"
+            $operations += [PSCustomObject]@{
+                Operation = "TCP/IP Reset"
+                Status = "Failed"
+                Message = $_.Exception.Message
+            }
+            $failCount++
         }
-        $failCount++
-    }
     }
 
     # Reset IPv6
     Write-Host "`nResetting IPv6 configuration..." -ForegroundColor Yellow
 
     if ($PSCmdlet.ShouldProcess("IPv6 configuration", "Reset")) {
-    try {
-        $ipv6Reset = netsh int ipv6 reset 2>&1
-        Write-Host "✓ IPv6 reset successful" -ForegroundColor Green
-        $operations += [PSCustomObject]@{
-            Operation = "IPv6 Reset"
-            Status = "Success"
-            Message = "IPv6 configuration reset successfully"
+        try {
+            $ipv6Reset = netsh int ipv6 reset 2>&1
+            Write-Host "✓ IPv6 reset successful" -ForegroundColor Green
+            $operations += [PSCustomObject]@{
+                Operation = "IPv6 Reset"
+                Status = "Success"
+                Message = "IPv6 configuration reset successfully"
+            }
+            $successCount++
         }
-        $successCount++
-    }
-    catch {
-        Write-Warning "IPv6 reset failed: $_"
-        $operations += [PSCustomObject]@{
-            Operation = "IPv6 Reset"
-            Status = "Failed"
-            Message = $_.Exception.Message
+        catch {
+            Write-Warning "IPv6 reset failed: $_"
+            $operations += [PSCustomObject]@{
+                Operation = "IPv6 Reset"
+                Status = "Failed"
+                Message = $_.Exception.Message
+            }
+            $failCount++
         }
-        $failCount++
-    }
     }
 
     # Flush DNS cache
@@ -349,29 +349,29 @@ try {
 
     # Release and renew DHCP
     if ($PSCmdlet.ShouldProcess("DHCP leases", "Renew")) {
-    Write-Host "`nRenewing DHCP leases..." -ForegroundColor Yellow
+        Write-Host "`nRenewing DHCP leases..." -ForegroundColor Yellow
 
-    try {
-        $releaseResult = ipconfig /release 2>&1
-        Start-Sleep -Seconds 2
-        $renewResult = ipconfig /renew 2>&1
-        Write-Host "✓ DHCP lease renewed" -ForegroundColor Green
-        $operations += [PSCustomObject]@{
-            Operation = "Renew DHCP"
-            Status = "Success"
-            Message = "DHCP lease released and renewed"
+        try {
+            $releaseResult = ipconfig /release 2>&1
+            Start-Sleep -Seconds 2
+            $renewResult = ipconfig /renew 2>&1
+            Write-Host "✓ DHCP lease renewed" -ForegroundColor Green
+            $operations += [PSCustomObject]@{
+                Operation = "Renew DHCP"
+                Status = "Success"
+                Message = "DHCP lease released and renewed"
+            }
+            $successCount++
         }
-        $successCount++
-    }
-    catch {
-        Write-Warning "DHCP renewal failed: $_"
-        $operations += [PSCustomObject]@{
-            Operation = "Renew DHCP"
-            Status = "Failed"
-            Message = $_.Exception.Message
+        catch {
+            Write-Warning "DHCP renewal failed: $_"
+            $operations += [PSCustomObject]@{
+                Operation = "Renew DHCP"
+                Status = "Failed"
+                Message = $_.Exception.Message
+            }
+            $failCount++
         }
-        $failCount++
-    }
     }
 
     # Display summary

--- a/scripts/infrastructure/network/Test-NetworkConnectivity.ps1
+++ b/scripts/infrastructure/network/Test-NetworkConnectivity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Comprehensive network connectivity and troubleshooting script.
 
@@ -83,7 +83,7 @@ $networkDiag = @{
 #region Network Adapter Check
 Write-Host "`nChecking network adapters..." -ForegroundColor Yellow
 try {
-    $adapters = Get-NetAdapter | Where-Object {$_.Status -eq 'Up'}
+    $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' }
 
     foreach ($adapter in $adapters) {
         $ipConfig = Get-NetIPAddress -InterfaceIndex $adapter.ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -110,7 +110,8 @@ try {
                         $adapterInfo.WiFiSignal = $Matches[1] + "%"
                     }
                 }
-            } catch {
+            }
+            catch {
                 # Signal strength not available
             }
         }
@@ -123,7 +124,8 @@ try {
     if ($adapters.Count -eq 0) {
         $networkDiag.Issues += "No active network adapters found"
     }
-} catch {
+}
+catch {
     $networkDiag.Issues += "Could not enumerate network adapters"
 }
 #endregion
@@ -141,15 +143,18 @@ try {
             Write-Host "Gateway ($gateway): Reachable (Avg: $([math]::Round($avgLatency, 2))ms)" -ForegroundColor Green
 
             $networkDiag.Performance.GatewayLatency = [math]::Round($avgLatency, 2)
-        } else {
+        }
+        else {
             Write-Host "Gateway ($gateway): Unreachable" -ForegroundColor Red
             $networkDiag.Issues += "Cannot reach default gateway: $gateway"
         }
-    } else {
+    }
+    else {
         Write-Host "No default gateway configured" -ForegroundColor Yellow
         $networkDiag.Warnings += "No default gateway found"
     }
-} catch {
+}
+catch {
     $networkDiag.Warnings += "Could not test gateway connectivity"
 }
 #endregion
@@ -158,7 +163,7 @@ try {
 Write-Host "`nTesting DNS resolution..." -ForegroundColor Yellow
 try {
     # Get system DNS servers
-    $systemDNS = (Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object {$_.ServerAddresses.Count -gt 0} | Select-Object -First 1).ServerAddresses
+    $systemDNS = (Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object { $_.ServerAddresses.Count -gt 0 } | Select-Object -First 1).ServerAddresses
 
     $networkDiag.DNS.SystemDNS = $systemDNS -join ", "
 
@@ -168,7 +173,8 @@ try {
     if ($dnsTest) {
         Write-Host "DNS Resolution: Working" -ForegroundColor Green
         $networkDiag.DNS.Status = "Working"
-    } else {
+    }
+    else {
         Write-Host "DNS Resolution: Failed" -ForegroundColor Red
         $networkDiag.Issues += "DNS resolution is not working"
         $networkDiag.DNS.Status = "Failed"
@@ -181,14 +187,17 @@ try {
 
             if ($dnsServerTest) {
                 Write-Host "  Public DNS ($dnsServer): Working" -ForegroundColor Green
-            } else {
+            }
+            else {
                 Write-Host "  Public DNS ($dnsServer): Failed" -ForegroundColor Yellow
             }
-        } catch {
+        }
+        catch {
             Write-Host "  Public DNS ($dnsServer): Failed" -ForegroundColor Yellow
         }
     }
-} catch {
+}
+catch {
     $networkDiag.Warnings += "Could not fully test DNS"
 }
 #endregion
@@ -208,7 +217,8 @@ foreach ($endpoint in $TestEndpoints) {
             }
 
             Write-Host "  $endpoint : Reachable ($([math]::Round($avgLatency, 2))ms)" -ForegroundColor Green
-        } else {
+        }
+        else {
             # Try HTTP/HTTPS if ping fails (some servers block ICMP)
             try {
                 $httpTest = Invoke-WebRequest -Uri "https://$endpoint" -Method Head -TimeoutSec 5 -ErrorAction SilentlyContinue
@@ -220,7 +230,8 @@ foreach ($endpoint in $TestEndpoints) {
                         AvgLatency = "N/A"
                     }
                     Write-Host "  $endpoint : Reachable (HTTPS)" -ForegroundColor Green
-                } else {
+                }
+                else {
                     $connectivityInfo = @{
                         Endpoint = $endpoint
                         Status = "Unreachable"
@@ -228,7 +239,8 @@ foreach ($endpoint in $TestEndpoints) {
                     }
                     Write-Host "  $endpoint : Unreachable" -ForegroundColor Red
                 }
-            } catch {
+            }
+            catch {
                 $connectivityInfo = @{
                     Endpoint = $endpoint
                     Status = "Unreachable"
@@ -239,7 +251,8 @@ foreach ($endpoint in $TestEndpoints) {
         }
 
         $networkDiag.Connectivity += $connectivityInfo
-    } catch {
+    }
+    catch {
         Write-Host "  $endpoint : Test Failed" -ForegroundColor Yellow
     }
 }
@@ -258,25 +271,29 @@ try {
     if ($networkPerf) {
         Write-Host "Network performance metrics collected" -ForegroundColor Green
     }
-} catch {
+}
+catch {
     Write-Host "Could not collect network performance metrics" -ForegroundColor Yellow
 }
 #endregion
 
 # Determine overall status
-$reachableCount = ($networkDiag.Connectivity | Where-Object {$_.Status -match "Reachable"}).Count
+$reachableCount = ($networkDiag.Connectivity | Where-Object { $_.Status -match "Reachable" }).Count
 $totalTests = $networkDiag.Connectivity.Count
 
 if ($networkDiag.Issues.Count -eq 0 -and $reachableCount -eq $totalTests) {
     $networkDiag.OverallStatus = "Excellent"
     $statusColor = "Green"
-} elseif ($networkDiag.Issues.Count -eq 0 -and $reachableCount -ge ($totalTests * 0.8)) {
+}
+elseif ($networkDiag.Issues.Count -eq 0 -and $reachableCount -ge ($totalTests * 0.8)) {
     $networkDiag.OverallStatus = "Good"
     $statusColor = "Green"
-} elseif ($networkDiag.Issues.Count -le 2) {
+}
+elseif ($networkDiag.Issues.Count -le 2) {
     $networkDiag.OverallStatus = "Degraded"
     $statusColor = "Yellow"
-} else {
+}
+else {
     $networkDiag.OverallStatus = "Poor"
     $statusColor = "Red"
 }
@@ -284,7 +301,7 @@ if ($networkDiag.Issues.Count -eq 0 -and $reachableCount -eq $totalTests) {
 #region Display Summary
 Write-Host "`n=== Network Diagnostic Summary ===" -ForegroundColor Cyan
 Write-Host "Overall Status: $($networkDiag.OverallStatus)" -ForegroundColor $statusColor
-Write-Host "Endpoints Reachable: $reachableCount / $totalTests" -ForegroundColor $(if ($reachableCount -eq $totalTests) {'Green'} elseif ($reachableCount -ge ($totalTests * 0.8)) {'Yellow'} else {'Red'})
+Write-Host "Endpoints Reachable: $reachableCount / $totalTests" -ForegroundColor $(if ($reachableCount -eq $totalTests) { 'Green' } elseif ($reachableCount -ge ($totalTests * 0.8)) { 'Yellow' } else { 'Red' })
 
 if ($networkDiag.Issues.Count -gt 0) {
     Write-Host "`nIssues Found:" -ForegroundColor Red

--- a/scripts/infrastructure/network/Test-NetworkDiagnostics.ps1
+++ b/scripts/infrastructure/network/Test-NetworkDiagnostics.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Performs comprehensive network diagnostics and troubleshooting.
 
@@ -367,7 +367,8 @@ try {
             $issuesHtml += "<li>$([System.Net.WebUtility]::HtmlEncode("$issue"))</li>"
         }
         $issuesHtml += "</ul>"
-    } else {
+    }
+    else {
         $issuesHtml = "<p style='color: green;'><strong>No issues detected</strong></p>"
     }
 

--- a/scripts/infrastructure/print/Get-PrintServerHealth.ps1
+++ b/scripts/infrastructure/print/Get-PrintServerHealth.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Monitors print server health and identifies printing issues.
 
@@ -46,21 +46,21 @@
     Compatible with Windows Server 2016, 2019, 2022
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ClearStuckJobs,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$StuckJobThresholdHours = 2,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckDrivers,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -130,7 +130,7 @@ $spoolPath = "$env:SystemRoot\System32\spool\PRINTERS"
 $spoolDrive = Split-Path -Path $spoolPath -Qualifier
 
 try {
-    $drive = Get-PSDrive -Name ($spoolDrive -replace ':','') -ErrorAction Stop
+    $drive = Get-PSDrive -Name ($spoolDrive -replace ':', '') -ErrorAction Stop
     $freeSpaceGB = [math]::Round($drive.Free / 1GB, 2)
     $usedPercent = [math]::Round(($drive.Used / ($drive.Used + $drive.Free)) * 100, 2)
 
@@ -171,8 +171,8 @@ try {
     foreach ($printer in $printers) {
         # Check printer status
         $status = if ($printer.PrinterStatus -eq 'Normal') { "Pass" }
-                 elseif ($printer.PrinterStatus -match 'Error|Offline') { "Fail" }
-                 else { "Warning" }
+        elseif ($printer.PrinterStatus -match 'Error|Offline') { "Fail" }
+        else { "Warning" }
 
         if ($status -eq "Fail") {
             Write-Host "    [Fail] $($printer.Name): $($printer.PrinterStatus)" -ForegroundColor Red
@@ -285,7 +285,7 @@ try {
     $errorEvents = Get-WinEvent -FilterHashtable @{
         LogName = 'System'
         ProviderName = 'Microsoft-Windows-PrintService'
-        Level = 2,3  # Error and Warning
+        Level = 2, 3  # Error and Warning
         StartTime = (Get-Date).AddHours(-24)
     } -MaxEvents 50 -ErrorAction SilentlyContinue
 

--- a/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
+++ b/scripts/infrastructure/virtualization/Get-HyperVHealth.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Performs comprehensive health check of Hyper-V host and virtual machines.
 
@@ -49,19 +49,19 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeVMs,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckReplication,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckSnapshots,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 

--- a/scripts/infrastructure/virtualization/Get-VMwareHealth.ps1
+++ b/scripts/infrastructure/virtualization/Get-VMwareHealth.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     VMware vSphere/ESXi health monitoring.
 .DESCRIPTION
@@ -23,7 +23,8 @@ try {
     Import-Module VMware.PowerCLI -ErrorAction Stop
     Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false -Scope Session | Out-Null
     Write-Host "[+] PowerCLI module loaded" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Host "[!] PowerCLI not installed. Run: Install-Module VMware.PowerCLI" -ForegroundColor Red
     exit 1
 }
@@ -32,11 +33,13 @@ Write-Host "[*] Connecting to vCenter: $vCenter" -ForegroundColor Cyan
 try {
     if ($Credential) {
         Connect-VIServer -Server $vCenter -Credential $Credential -ErrorAction Stop | Out-Null
-    } else {
+    }
+    else {
         Connect-VIServer -Server $vCenter -ErrorAction Stop | Out-Null
     }
     Write-Host "[+] Connected to vCenter" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Host "[!] Failed to connect to vCenter: $_" -ForegroundColor Red
     exit 1
 }
@@ -44,14 +47,14 @@ try {
 # Get ESXi hosts
 Write-Host "[*] Checking ESXi hosts..." -ForegroundColor Cyan
 $vmHosts = Get-VMHost
-$connectedHosts = ($vmHosts | Where-Object {$_.ConnectionState -eq "Connected"}).Count
+$connectedHosts = ($vmHosts | Where-Object { $_.ConnectionState -eq "Connected" }).Count
 Write-Host "[+] Found $($vmHosts.Count) hosts ($connectedHosts connected)" -ForegroundColor Green
 
 # Get VMs
 if ($IncludeVMs) {
     Write-Host "[*] Checking virtual machines..." -ForegroundColor Cyan
     $vms = Get-VM
-    $poweredOnVMs = ($vms | Where-Object {$_.PowerState -eq "PoweredOn"}).Count
+    $poweredOnVMs = ($vms | Where-Object { $_.PowerState -eq "PoweredOn" }).Count
     Write-Host "[+] Found $($vms.Count) VMs ($poweredOnVMs powered on)" -ForegroundColor Green
 }
 
@@ -60,7 +63,7 @@ Write-Host "[*] Checking datastores..." -ForegroundColor Cyan
 $datastores = Get-Datastore
 foreach ($ds in $datastores) {
     $freePercent = [math]::Round(($ds.FreeSpaceGB / $ds.CapacityGB) * 100, 1)
-    $color = if ($freePercent -lt 10) {"Red"} elseif ($freePercent -lt 20) {"Yellow"} else {"Green"}
+    $color = if ($freePercent -lt 10) { "Red" } elseif ($freePercent -lt 20) { "Yellow" } else { "Green" }
     Write-Host "  - $($ds.Name): $($ds.FreeSpaceGB) GB free ($freePercent%)" -ForegroundColor $color
 }
 

--- a/scripts/infrastructure/web/iis/Backup-IISConfiguration.ps1
+++ b/scripts/infrastructure/web/iis/Backup-IISConfiguration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Backup and restore IIS configuration.
 
@@ -107,7 +107,8 @@ if ($Restore) {
     Write-Host "`n[!] IIS needs to be restarted for changes to take effect" -ForegroundColor Yellow
     Write-Host "[*] Run: iisreset /noforce" -ForegroundColor Cyan
 
-} else {
+}
+else {
     # Create backup
     Write-Host "`n[*] Creating IIS configuration backup..." -ForegroundColor Cyan
 

--- a/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISHealthCheck.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Comprehensive IIS health check and configuration audit.
 
@@ -138,7 +138,8 @@ try {
         exit 1
     }
     Write-StatusMessage "IIS is installed and accessible" -Status Success
-} catch {
+}
+catch {
     Write-StatusMessage "Error checking IIS installation: $_" -Status Error
     exit 1
 }
@@ -149,7 +150,8 @@ try {
     $iisVersion = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\InetStp").VersionString
     $results.IISVersion = $iisVersion
     Write-StatusMessage "IIS Version: $iisVersion" -Status Success
-} catch {
+}
+catch {
     Write-StatusMessage "Could not determine IIS version" -Status Warning
 }
 
@@ -185,8 +187,9 @@ try {
         $results.ApplicationPools += $poolInfo
     }
 
-    Write-StatusMessage "Found $($appPools.Count) application pools ($poolIssues issues)" -Status $(if ($poolIssues -eq 0) {"Success"} else {"Warning"})
-} catch {
+    Write-StatusMessage "Found $($appPools.Count) application pools ($poolIssues issues)" -Status $(if ($poolIssues -eq 0) { "Success" } else { "Warning" })
+}
+catch {
     Write-StatusMessage "Error analyzing application pools: $_" -Status Error
 }
 
@@ -225,8 +228,9 @@ try {
         $results.Websites += $siteInfo
     }
 
-    Write-StatusMessage "Found $($websites.Count) websites ($siteIssues issues)" -Status $(if ($siteIssues -eq 0) {"Success"} else {"Warning"})
-} catch {
+    Write-StatusMessage "Found $($websites.Count) websites ($siteIssues issues)" -Status $(if ($siteIssues -eq 0) { "Success" } else { "Warning" })
+}
+catch {
     Write-StatusMessage "Error analyzing websites: $_" -Status Error
 }
 
@@ -262,7 +266,7 @@ if ($CheckSSLCertificates) {
                         NotBefore = $cert.NotBefore
                         NotAfter = $cert.NotAfter
                         DaysToExpire = $daysToExpire
-                        Status = if ($daysToExpire -lt 0) {"Expired"} elseif ($daysToExpire -lt 30) {"Expiring Soon"} else {"Valid"}
+                        Status = if ($daysToExpire -lt 0) { "Expired" } elseif ($daysToExpire -lt 30) { "Expiring Soon" } else { "Valid" }
                     }
 
                     if ($certInfo.Status -ne "Valid") {
@@ -270,14 +274,16 @@ if ($CheckSSLCertificates) {
                     }
 
                     $results.SSLCertificates += $certInfo
-                } else {
+                }
+                else {
                     $certIssues++
                 }
             }
         }
 
-        Write-StatusMessage "Checked $($httpsBindings.Count) HTTPS bindings ($certIssues issues)" -Status $(if ($certIssues -eq 0) {"Success"} else {"Warning"})
-    } catch {
+        Write-StatusMessage "Checked $($httpsBindings.Count) HTTPS bindings ($certIssues issues)" -Status $(if ($certIssues -eq 0) { "Success" } else { "Warning" })
+    }
+    catch {
         Write-StatusMessage "Error checking SSL certificates: $_" -Status Error
     }
 }
@@ -299,13 +305,15 @@ if ($IncludePerformanceCounters) {
             try {
                 $value = (Get-Counter -Counter $counter -SampleInterval 1 -MaxSamples 1 -ErrorAction SilentlyContinue).CounterSamples.CookedValue
                 $results.PerformanceData[$counter] = $value
-            } catch {
+            }
+            catch {
                 # Counter might not exist
             }
         }
 
         Write-StatusMessage "Performance data collected" -Status Success
-    } catch {
+    }
+    catch {
         Write-StatusMessage "Error collecting performance data: $_" -Status Warning
     }
 }
@@ -331,10 +339,12 @@ if ($AnalyzeLogFiles) {
             }
 
             Write-StatusMessage "Analyzed $totalLogs log files ($([math]::Round($totalSize, 2)) MB)" -Status Success
-        } else {
+        }
+        else {
             Write-StatusMessage "Log file path not found: $logPath" -Status Warning
         }
-    } catch {
+    }
+    catch {
         Write-StatusMessage "Error analyzing log files: $_" -Status Error
     }
 }
@@ -374,12 +384,12 @@ if ($CheckSSLCertificates) {
 
 # Determine overall health
 $results.OverallHealth = if ($healthScore -ge 90) { "Excellent" }
-                         elseif ($healthScore -ge 75) { "Good" }
-                         elseif ($healthScore -ge 50) { "Fair" }
-                         else { "Poor" }
+elseif ($healthScore -ge 75) { "Good" }
+elseif ($healthScore -ge 50) { "Fair" }
+else { "Poor" }
 
 Write-StatusMessage "Overall IIS Health: $($results.OverallHealth) (Score: $healthScore/100)" -Status $(
-    if ($healthScore -ge 75) {"Success"} elseif ($healthScore -ge 50) {"Warning"} else {"Error"}
+    if ($healthScore -ge 75) { "Success" } elseif ($healthScore -ge 50) { "Warning" } else { "Error" }
 )
 
 # Display Summary
@@ -451,8 +461,8 @@ if ($ExportHTML) {
     # Application Pools Table
     $html += "<h2>Application Pools ($($results.ApplicationPools.Count))</h2><table><tr><th>Name</th><th>State</th><th>Runtime Version</th><th>Pipeline Mode</th><th>Start Mode</th><th>Issues</th></tr>"
     foreach ($pool in $results.ApplicationPools) {
-        $stateClass = if ($pool.State -eq "Started") {"status-started"} else {"status-stopped"}
-        $issuesText = if ($pool.Issues.Count -gt 0) {$pool.Issues -join ", "} else {"None"}
+        $stateClass = if ($pool.State -eq "Started") { "status-started" } else { "status-stopped" }
+        $issuesText = if ($pool.Issues.Count -gt 0) { $pool.Issues -join ", " } else { "None" }
         $html += "<tr><td>$($pool.Name)</td><td class='$stateClass'>$($pool.State)</td><td>$($pool.ManagedRuntimeVersion)</td><td>$($pool.ManagedPipelineMode)</td><td>$($pool.StartMode)</td><td>$issuesText</td></tr>"
     }
     $html += "</table>"
@@ -460,8 +470,8 @@ if ($ExportHTML) {
     # Websites Table
     $html += "<h2>Websites ($($results.Websites.Count))</h2><table><tr><th>Name</th><th>State</th><th>Application Pool</th><th>Bindings</th><th>Physical Path</th><th>Issues</th></tr>"
     foreach ($site in $results.Websites) {
-        $stateClass = if ($site.State -eq "Started") {"status-started"} else {"status-stopped"}
-        $issuesText = if ($site.Issues.Count -gt 0) {$site.Issues -join ", "} else {"None"}
+        $stateClass = if ($site.State -eq "Started") { "status-started" } else { "status-stopped" }
+        $issuesText = if ($site.Issues.Count -gt 0) { $site.Issues -join ", " } else { "None" }
         $html += "<tr><td>$($site.Name)</td><td class='$stateClass'>$($site.State)</td><td>$($site.ApplicationPool)</td><td>$($site.Bindings)</td><td>$($site.PhysicalPath)</td><td>$issuesText</td></tr>"
     }
     $html += "</table>"
@@ -496,4 +506,4 @@ if ($ExportCSV) {
 Write-ColorOutput "`nHealth check complete!`n" -Color Green
 
 # Exit with appropriate code
-exit $(if ($healthScore -ge 75) {0} else {1})
+exit $(if ($healthScore -ge 75) { 0 } else { 1 })

--- a/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
+++ b/scripts/infrastructure/web/iis/Get-IISLogAnalyzer.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Advanced IIS log file analysis and reporting.
 
@@ -123,19 +123,21 @@ foreach ($file in $logFiles) {
                         Port = $fields[6]
                         Username = $fields[7]
                         ServerIP = $fields[8]
-                        UserAgent = if ($fields.Count -gt 9) {$fields[9]} else {""}
-                        Referer = if ($fields.Count -gt 10) {$fields[10]} else {""}
-                        StatusCode = if ($fields.Count -gt 11) {$fields[11]} else {"200"}
-                        SubStatus = if ($fields.Count -gt 12) {$fields[12]} else {"0"}
-                        TimeTaken = if ($fields.Count -gt 14) {[int]$fields[14]} else {0}
-                        BytesSent = if ($fields.Count -gt 13) {[int]$fields[13]} else {0}
+                        UserAgent = if ($fields.Count -gt 9) { $fields[9] } else { "" }
+                        Referer = if ($fields.Count -gt 10) { $fields[10] } else { "" }
+                        StatusCode = if ($fields.Count -gt 11) { $fields[11] } else { "200" }
+                        SubStatus = if ($fields.Count -gt 12) { $fields[12] } else { "0" }
+                        TimeTaken = if ($fields.Count -gt 14) { [int]$fields[14] } else { 0 }
+                        BytesSent = if ($fields.Count -gt 13) { [int]$fields[13] } else { 0 }
                     }
                 }
-            } catch {
+            }
+            catch {
                 $parseErrors++
             }
         }
-    } catch {
+    }
+    catch {
         Write-Host "[!] Error reading $($file.Name): $_" -ForegroundColor Yellow
     }
 }
@@ -154,21 +156,21 @@ Write-Host "`n[*] Performing analysis..." -ForegroundColor Cyan
 
 # Top URLs
 $analysis.TopURLs = $entries | Group-Object UriStem | Sort-Object Count -Descending | Select-Object -First $Top |
-    ForEach-Object { [PSCustomObject]@{URL = $_.Name; Requests = $_.Count} }
+    ForEach-Object { [PSCustomObject]@{URL = $_.Name; Requests = $_.Count } }
 
 # Status codes
 $analysis.StatusCodes = $entries | Group-Object StatusCode | Sort-Object Count -Descending |
-    ForEach-Object { [PSCustomObject]@{StatusCode = $_.Name; Count = $_.Count; Percentage = [math]::Round(($_.Count / $entries.Count) * 100, 2)} }
+    ForEach-Object { [PSCustomObject]@{StatusCode = $_.Name; Count = $_.Count; Percentage = [math]::Round(($_.Count / $entries.Count) * 100, 2) } }
 
 # Top client IPs
 $analysis.TopIPs = $entries | Group-Object ClientIP | Sort-Object Count -Descending | Select-Object -First $Top |
-    ForEach-Object { [PSCustomObject]@{IP = $_.Name; Requests = $_.Count} }
+    ForEach-Object { [PSCustomObject]@{IP = $_.Name; Requests = $_.Count } }
 
 # Error analysis (4xx and 5xx)
 $errors = $entries | Where-Object { [int]$_.StatusCode -ge 400 }
 $analysis.ErrorCount = $errors.Count
 $analysis.TopErrors = $errors | Group-Object UriStem | Sort-Object Count -Descending | Select-Object -First $Top |
-    ForEach-Object { [PSCustomObject]@{URL = $_.Name; ErrorCount = $_.Count} }
+    ForEach-Object { [PSCustomObject]@{URL = $_.Name; ErrorCount = $_.Count } }
 
 # Performance metrics
 $analysis.AvgResponseTime = [math]::Round(($entries | Measure-Object TimeTaken -Average).Average, 2)
@@ -184,10 +186,10 @@ if ($IncludeSecurityAnalysis) {
     Write-Host "[*] Performing security analysis..." -ForegroundColor Cyan
 
     $suspiciousPatterns = @(
-        @{Name = "SQL Injection"; Pattern = "(\%27)|(')|(--)|(\%23)|(#)|(union)|(select)|(insert)|(drop)|(update)|(delete)|(exec)"}
-        @{Name = "XSS Attempts"; Pattern = "(<script|javascript:|onerror=|onload=)"}
-        @{Name = "Path Traversal"; Pattern = "(\.\./|\.\.\\|%2e%2e)"}
-        @{Name = 'Command Injection'; Pattern = '(\||;|`|\\$\(|\${)'}
+        @{Name = "SQL Injection"; Pattern = "(\%27)|(')|(--)|(\%23)|(#)|(union)|(select)|(insert)|(drop)|(update)|(delete)|(exec)" }
+        @{Name = "XSS Attempts"; Pattern = "(<script|javascript:|onerror=|onload=)" }
+        @{Name = "Path Traversal"; Pattern = "(\.\./|\.\.\\|%2e%2e)" }
+        @{Name = 'Command Injection'; Pattern = '(\||;|`|\\$\(|\${)' }
     )
 
     $analysis.SecurityThreats = @()
@@ -209,7 +211,7 @@ Write-Host "Total Requests: $($entries.Count)" -ForegroundColor White
 Write-Host "Date Range: $($entries[0].Date) to $($entries[-1].Date)" -ForegroundColor White
 Write-Host "Total Bandwidth: $($analysis.TotalBandwidthGB) GB" -ForegroundColor White
 Write-Host "Average Response Time: $($analysis.AvgResponseTime) ms" -ForegroundColor White
-Write-Host "Errors (4xx/5xx): $($analysis.ErrorCount)" -ForegroundColor $(if ($analysis.ErrorCount -gt 100) {"Red"} else {"Green"})
+Write-Host "Errors (4xx/5xx): $($analysis.ErrorCount)" -ForegroundColor $(if ($analysis.ErrorCount -gt 100) { "Red" } else { "Green" })
 
 Write-Host "`nTop 10 URLs:" -ForegroundColor Yellow
 $analysis.TopURLs | Select-Object -First 10 | Format-Table -AutoSize

--- a/scripts/infrastructure/web/iis/Optimize-IISConfiguration.ps1
+++ b/scripts/infrastructure/web/iis/Optimize-IISConfiguration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Optimize IIS configuration for performance and security.
 
@@ -117,10 +117,10 @@ if ($ApplySecurityHardening) {
             $sitePath = "IIS:\Sites\$($site.Name)"
 
             # Add custom headers
-            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name='X-Frame-Options';value='SAMEORIGIN'} -ErrorAction SilentlyContinue
-            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name='X-Content-Type-Options';value='nosniff'} -ErrorAction SilentlyContinue
-            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name='X-XSS-Protection';value='1; mode=block'} -ErrorAction SilentlyContinue
-            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name='Strict-Transport-Security';value='max-age=31536000; includeSubDomains'} -ErrorAction SilentlyContinue
+            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name = 'X-Frame-Options'; value = 'SAMEORIGIN' } -ErrorAction SilentlyContinue
+            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name = 'X-Content-Type-Options'; value = 'nosniff' } -ErrorAction SilentlyContinue
+            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name = 'X-XSS-Protection'; value = '1; mode=block' } -ErrorAction SilentlyContinue
+            Add-WebConfigurationProperty -PSPath $sitePath -Filter "system.webServer/httpProtocol/customHeaders" -Name "." -Value @{name = 'Strict-Transport-Security'; value = 'max-age=31536000; includeSubDomains' } -ErrorAction SilentlyContinue
         }
         $changes += "Added security headers to $($sites.Count) sites"
         Write-Host "[+] Security headers configured" -ForegroundColor Green
@@ -153,7 +153,8 @@ if ($changes.Count -gt 0) {
     }
     Write-Host "`n[!] Note: Some changes may require IIS restart to take effect" -ForegroundColor Yellow
     Write-Host "[*] To restart IIS: iisreset /noforce" -ForegroundColor Cyan
-} else {
+}
+else {
     Write-Host "  No changes applied (use -WhatIf to preview or specify optimization switches)" -ForegroundColor Yellow
 }
 

--- a/scripts/infrastructure/windows/active-directory/Find-InactiveADComputers.ps1
+++ b/scripts/infrastructure/windows/active-directory/Find-InactiveADComputers.ps1
@@ -59,27 +59,27 @@
     LastLogonTimestamp may be up to 14 days behind actual logon
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$InactiveDays = 90,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SearchBase,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDisabled,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OperatingSystem,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$DisableInactive,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -117,7 +117,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -154,11 +154,11 @@ function Find-InactiveComputers {
         # Build filter
         $filter = "LastLogonTimeStamp -lt '$cutoffDate' -or LastLogonTimeStamp -notlike '*'"
 
-        if(-not $IncludeDisabled) {
+        if (-not $IncludeDisabled) {
             $filter = "($filter) -and Enabled -eq 'True'"
         }
 
-        if($OperatingSystem) {
+        if ($OperatingSystem) {
             $filter = "($filter) -and OperatingSystem -like '$OperatingSystem'"
         }
 
@@ -166,11 +166,11 @@ function Find-InactiveComputers {
         $searchParams = @{
             Filter = $filter
             Properties = 'Name', 'DNSHostName', 'OperatingSystem', 'OperatingSystemVersion',
-                        'LastLogonTimeStamp', 'PasswordLastSet', 'Enabled', 'Description',
-                        'Created', 'Modified', 'DistinguishedName'
+            'LastLogonTimeStamp', 'PasswordLastSet', 'Enabled', 'Description',
+            'Created', 'Modified', 'DistinguishedName'
         }
 
-        if($SearchBase) {
+        if ($SearchBase) {
             $searchParams['SearchBase'] = $SearchBase
             Write-Host "  Search Base: $SearchBase" -ForegroundColor Gray
         }
@@ -180,17 +180,19 @@ function Find-InactiveComputers {
 
         Write-ColorOutput "  Found $($computers.Count) inactive computer account(s)" -Level Info
 
-        foreach($computer in $computers) {
+        foreach ($computer in $computers) {
             # Convert LastLogonTimestamp
-            $lastLogon = if($computer.LastLogonTimeStamp) {
+            $lastLogon = if ($computer.LastLogonTimeStamp) {
                 [DateTime]::FromFileTime($computer.LastLogonTimeStamp)
-            } else {
+            }
+            else {
                 $null
             }
 
-            $inactiveDayCount = if($lastLogon) {
+            $inactiveDayCount = if ($lastLogon) {
                 [math]::Round(((Get-Date) - $lastLogon).TotalDays, 0)
-            } else {
+            }
+            else {
                 [math]::Round(((Get-Date) - $computer.Created).TotalDays, 0)
             }
 
@@ -212,7 +214,7 @@ function Find-InactiveComputers {
             $script:report.InactiveComputers += $computerInfo
             $script:report.Summary.TotalInactive++
 
-            if($computer.Enabled) {
+            if ($computer.Enabled) {
                 $script:report.Summary.Enabled++
             }
             else {
@@ -220,7 +222,7 @@ function Find-InactiveComputers {
             }
 
             # Categorize by OS
-            $osType = if($computer.OperatingSystem -like "*Server*") {
+            $osType = if ($computer.OperatingSystem -like "*Server*") {
                 $script:report.Summary.Servers++
                 "Server"
             }
@@ -230,8 +232,8 @@ function Find-InactiveComputers {
             }
 
             # Track OS distribution
-            $os = if($computer.OperatingSystem) { $computer.OperatingSystem } else { 'Unknown' }
-            if($script:report.OperatingSystems.ContainsKey($os)) {
+            $os = if ($computer.OperatingSystem) { $computer.OperatingSystem } else { 'Unknown' }
+            if ($script:report.OperatingSystems.ContainsKey($os)) {
                 $script:report.OperatingSystems[$os]++
             }
             else {
@@ -246,19 +248,21 @@ function Find-InactiveComputers {
 }
 
 function Disable-InactiveComputerAccounts {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     Write-Host "`nDisabling inactive computer accounts..." -ForegroundColor Yellow
 
-    $toDisable = $script:report.InactiveComputers | Where-Object {$_.Enabled -eq $true}
+    $toDisable = $script:report.InactiveComputers | Where-Object { $_.Enabled -eq $true }
 
-    if($toDisable.Count -eq 0) {
+    if ($toDisable.Count -eq 0) {
         Write-Host "  No enabled inactive accounts to disable" -ForegroundColor Gray
         return
     }
 
     Write-ColorOutput "  $($toDisable.Count) account(s) will be disabled" -Level Warning
 
-    foreach($computer in $toDisable) {
-        if($PSCmdlet.ShouldProcess($computer.Name, "Disable computer account")) {
+    foreach ($computer in $toDisable) {
+        if ($PSCmdlet.ShouldProcess($computer.Name, "Disable computer account")) {
             try {
                 Disable-ADAccount -Identity $computer.DistinguishedName -ErrorAction Stop
                 $script:report.Summary.AccountsDisabled++
@@ -273,7 +277,7 @@ function Disable-InactiveComputerAccounts {
         }
     }
 
-    if(-not $WhatIfPreference) {
+    if (-not $WhatIfPreference) {
         Write-ColorOutput "`n  Disabled $($script:report.Summary.AccountsDisabled) account(s)" -Level Success
     }
 }
@@ -286,7 +290,7 @@ function Show-Summary {
     Write-Host "Scan Time: $($script:report.ScanTime)"
     Write-Host "Inactivity Threshold: $($script:report.InactiveDays) days"
 
-    if($script:report.SearchBase) {
+    if ($script:report.SearchBase) {
         Write-Host "Search Base: $($script:report.SearchBase)"
     }
 
@@ -297,7 +301,7 @@ function Show-Summary {
     Write-Host "  Servers: $($script:report.Summary.Servers)"
     Write-Host "  Workstations: $($script:report.Summary.Workstations)"
 
-    if($script:report.Summary.AccountsDisabled -gt 0) {
+    if ($script:report.Summary.AccountsDisabled -gt 0) {
         Write-ColorOutput "  Accounts Disabled: $($script:report.Summary.AccountsDisabled)" -Level Success
     }
 
@@ -308,7 +312,7 @@ function Show-Summary {
         Select-Object Name, OperatingSystem, Enabled, InactiveDays, LastLogon |
         Format-Table -AutoSize
 
-    if($script:report.OperatingSystems.Count -gt 0) {
+    if ($script:report.OperatingSystems.Count -gt 0) {
         Write-Host "`nOperating System Distribution:" -ForegroundColor Cyan
         $script:report.OperatingSystems.GetEnumerator() |
             Sort-Object Value -Descending |
@@ -448,24 +452,24 @@ Write-Host "`n========================================" -ForegroundColor Cyan
 Write-Host "  Inactive Computer Accounts Finder" -ForegroundColor Cyan
 Write-Host "========================================`n" -ForegroundColor Cyan
 
-if(-not (Test-ADModule)) {
+if (-not (Test-ADModule)) {
     exit 1
 }
 
 Find-InactiveComputers
 
-if($DisableInactive) {
+if ($DisableInactive) {
     Disable-InactiveComputerAccounts
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/active-directory/Get-ADHealthCheck.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ADHealthCheck.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Comprehensive Active Directory health check for domain controllers.
 
@@ -51,19 +51,19 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$DomainController,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeReplication,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeEventLogs,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -97,7 +97,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Critical' { 'Red' }
         'Error' { 'Red' }
         'Warning' { 'Yellow' }
@@ -157,7 +157,7 @@ function Get-FSMORoles {
             DomainNamingMaster = $forest.DomainNamingMaster
         }
 
-        foreach($role in $script:report.FSMORoles.GetEnumerator()) {
+        foreach ($role in $script:report.FSMORoles.GetEnumerator()) {
             Write-Host "  $($role.Key): $($role.Value)" -ForegroundColor Gray
         }
     }
@@ -170,7 +170,7 @@ function Test-DomainControllers {
     Write-Host "`nTesting domain controllers..." -ForegroundColor Cyan
 
     try {
-        if($DomainController) {
+        if ($DomainController) {
             $dcs = @(Get-ADDomainController -Identity $DomainController)
         }
         else {
@@ -179,7 +179,7 @@ function Test-DomainControllers {
 
         Write-ColorOutput "  Found $($dcs.Count) domain controller(s)" -Level Info
 
-        foreach($dc in $dcs) {
+        foreach ($dc in $dcs) {
             Write-Host "`n  Testing: $($dc.Name)" -ForegroundColor Cyan
 
             $dcHealth = [PSCustomObject]@{
@@ -204,7 +204,7 @@ function Test-DomainControllers {
             try {
                 $ping = Test-Connection -ComputerName $dc.HostName -Count 2 -Quiet
                 $dcHealth.Ping = $ping
-                if($ping) {
+                if ($ping) {
                     Write-ColorOutput "    [OK] Ping successful" -Level Success
                 }
                 else {
@@ -232,7 +232,7 @@ function Test-DomainControllers {
 
             # SYSVOL share test
             $sysvolPath = "\\$($dc.HostName)\SYSVOL"
-            if(Test-Path $sysvolPath -ErrorAction SilentlyContinue) {
+            if (Test-Path $sysvolPath -ErrorAction SilentlyContinue) {
                 $dcHealth.SYSVOLAccessible = $true
                 Write-ColorOutput "    [OK] SYSVOL accessible" -Level Success
             }
@@ -244,7 +244,7 @@ function Test-DomainControllers {
 
             # NETLOGON share test
             $netlogonPath = "\\$($dc.HostName)\NETLOGON"
-            if(Test-Path $netlogonPath -ErrorAction SilentlyContinue) {
+            if (Test-Path $netlogonPath -ErrorAction SilentlyContinue) {
                 $dcHealth.NETLOGONAccessible = $true
                 Write-ColorOutput "    [OK] NETLOGON accessible" -Level Success
             }
@@ -256,12 +256,12 @@ function Test-DomainControllers {
 
             # Service status checks
             $services = @('NTDS', 'DNS', 'kdc', 'Netlogon')
-            foreach($serviceName in $services) {
+            foreach ($serviceName in $services) {
                 try {
                     $service = Get-Service -ComputerName $dc.HostName -Name $serviceName -ErrorAction Stop
                     $dcHealth.Services[$serviceName] = $service.Status
 
-                    if($service.Status -eq 'Running') {
+                    if ($service.Status -eq 'Running') {
                         Write-ColorOutput "    [OK] $serviceName service running" -Level Success
                     }
                     else {
@@ -278,16 +278,16 @@ function Test-DomainControllers {
 
             # Time synchronization check
             try {
-                $dcTime = Invoke-Command -ComputerName $dc.HostName -ScriptBlock {Get-Date} -ErrorAction Stop
+                $dcTime = Invoke-Command -ComputerName $dc.HostName -ScriptBlock { Get-Date } -ErrorAction Stop
                 $localTime = Get-Date
                 $timeDiff = ($dcTime - $localTime).TotalSeconds
 
                 $dcHealth.TimeDifference = [math]::Round($timeDiff, 2)
 
-                if([math]::Abs($timeDiff) -le 5) {
+                if ([math]::Abs($timeDiff) -le 5) {
                     Write-ColorOutput "    [OK] Time sync OK (difference: $([math]::Round($timeDiff, 2))s)" -Level Success
                 }
-                elseif([math]::Abs($timeDiff) -le 300) {
+                elseif ([math]::Abs($timeDiff) -le 300) {
                     Write-ColorOutput "    [WARNING] Time difference: $([math]::Round($timeDiff, 2))s" -Level Warning
                     $script:report.Warnings += "$($dc.Name): Time difference $([math]::Round($timeDiff, 2))s"
                 }
@@ -302,7 +302,7 @@ function Test-DomainControllers {
             }
 
             # Set overall health status
-            if($dcHealth.HealthStatus -ne 'Critical') {
+            if ($dcHealth.HealthStatus -ne 'Critical') {
                 $dcHealth.HealthStatus = 'Healthy'
             }
 
@@ -324,11 +324,11 @@ function Get-ReplicationStatus {
         # enumerate domain controllers and query each one, aggregating the results.
         $replSummary = @()
         $dcs = Get-ADDomainController -Filter *
-        foreach($dc in $dcs) {
+        foreach ($dc in $dcs) {
             $replSummary += Get-ADReplicationPartnerMetadata -Target $dc.HostName -Scope Domain
         }
 
-        foreach($repl in $replSummary) {
+        foreach ($repl in $replSummary) {
             $lastSuccess = $repl.LastReplicationSuccess
             $lastAttempt = $repl.LastReplicationAttempt
             $consecutiveFailures = $repl.ConsecutiveReplicationFailures
@@ -336,11 +336,11 @@ function Get-ReplicationStatus {
             $status = 'Healthy'
             $age = ((Get-Date) - $lastSuccess).TotalHours
 
-            if($consecutiveFailures -gt 0) {
+            if ($consecutiveFailures -gt 0) {
                 $status = 'Failed'
                 $script:report.Issues += "Replication failure: $($repl.Server) to $($repl.Partner)"
             }
-            elseif($age -gt 24) {
+            elseif ($age -gt 24) {
                 $status = 'Warning'
                 $script:report.Warnings += "Replication stale: $($repl.Server) to $($repl.Partner) (last success $([math]::Round($age, 1))h ago)"
             }
@@ -377,19 +377,19 @@ function Get-ADEventLogs {
     $since = (Get-Date).AddHours(-24)
 
     try {
-        $dcs = if($DomainController) { @($DomainController) } else { (Get-ADDomainController -Filter *).HostName }
+        $dcs = if ($DomainController) { @($DomainController) } else { (Get-ADDomainController -Filter *).HostName }
 
-        foreach($dc in $dcs) {
+        foreach ($dc in $dcs) {
             Write-Host "  Checking $dc..." -ForegroundColor Gray
 
             try {
                 $events = Get-WinEvent -ComputerName $dc -FilterHashtable @{
                     LogName = 'Directory Service', 'DFS Replication'
-                    Level = 1,2
+                    Level = 1, 2
                     StartTime = $since
                 } -MaxEvents 50 -ErrorAction SilentlyContinue
 
-                foreach($event in $events) {
+                foreach ($event in $events) {
                     $script:report.EventLogErrors += [PSCustomObject]@{
                         Server = $dc
                         TimeCreated = $event.TimeCreated
@@ -401,7 +401,7 @@ function Get-ADEventLogs {
                     }
                 }
 
-                if($events) {
+                if ($events) {
                     Write-ColorOutput "    Found $($events.Count) error(s) in last 24h" -Level Warning
                 }
                 else {
@@ -427,27 +427,27 @@ function Show-Summary {
     Write-Host "Scan Time: $($script:report.ScanTime)"
 
     # Determine overall health
-    if($script:report.Issues.Count -gt 0) {
+    if ($script:report.Issues.Count -gt 0) {
         $script:report.HealthStatus = 'Critical'
     }
-    elseif($script:report.Warnings.Count -gt 0) {
+    elseif ($script:report.Warnings.Count -gt 0) {
         $script:report.HealthStatus = 'Warning'
     }
 
     Write-Host "`nOverall Health: " -NoNewline
-    $healthColor = switch($script:report.HealthStatus) {
+    $healthColor = switch ($script:report.HealthStatus) {
         'Critical' { 'Red' }
         'Warning' { 'Yellow' }
         default { 'Green' }
     }
     Write-Host $script:report.HealthStatus -ForegroundColor $healthColor
 
-    if($script:report.Issues.Count -gt 0) {
+    if ($script:report.Issues.Count -gt 0) {
         Write-Host "`nCritical Issues:" -ForegroundColor Red
         $script:report.Issues | ForEach-Object { Write-ColorOutput "  - $_" -Level Error }
     }
 
-    if($script:report.Warnings.Count -gt 0) {
+    if ($script:report.Warnings.Count -gt 0) {
         Write-Host "`nWarnings:" -ForegroundColor Yellow
         $script:report.Warnings | ForEach-Object { Write-ColorOutput "  - $_" -Level Warning }
     }
@@ -466,7 +466,7 @@ function Show-Summary {
 function Export-HTMLReport {
     $reportPath = "$ReportDir\ADHealthCheck_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
-    $healthColor = switch($script:report.HealthStatus) {
+    $healthColor = switch ($script:report.HealthStatus) {
         'Critical' { '#dc3545' }
         'Warning' { '#ffc107' }
         default { '#28a745' }
@@ -576,7 +576,7 @@ Write-Host "`n========================================" -ForegroundColor Cyan
 Write-Host "  Active Directory Health Check" -ForegroundColor Cyan
 Write-Host "========================================`n" -ForegroundColor Cyan
 
-if(-not (Test-ADModule)) {
+if (-not (Test-ADModule)) {
     exit 1
 }
 
@@ -584,17 +584,17 @@ Get-DomainInfo
 Get-FSMORoles
 Test-DomainControllers
 
-if($IncludeReplication) {
+if ($IncludeReplication) {
     Get-ReplicationStatus
 }
 
-if($IncludeEventLogs) {
+if ($IncludeEventLogs) {
     Get-ADEventLogs
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }

--- a/scripts/infrastructure/windows/active-directory/Get-ServiceAccountAudit.ps1
+++ b/scripts/infrastructure/windows/active-directory/Get-ServiceAccountAudit.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Audits service accounts in Active Directory for security and compliance.
 
@@ -247,7 +247,8 @@ try {
                 SPNs = ($msa.ServicePrincipalNames -join "; ")
                 PrincipalsAllowedToRetrieve = if ($msa.'PrincipalsAllowedToRetrieveManagedPassword') {
                     ($msa.'PrincipalsAllowedToRetrieveManagedPassword' -join "; ")
-                } else {
+                }
+                else {
                     "None"
                 }
             }

--- a/scripts/infrastructure/windows/backup-recovery/Get-BackupStatus.ps1
+++ b/scripts/infrastructure/windows/backup-recovery/Get-BackupStatus.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Verifies Windows Server Backup status and configuration.
 
@@ -129,11 +129,11 @@ try {
         $report.BackupPolicy = @{
             Schedule = $policy.Schedule
             BackupTargets = @($policy.BackupTargets | ForEach-Object {
-                @{
-                    TargetType = $_.TargetType
-                    TargetPath = $_.TargetPath
-                }
-            })
+                    @{
+                        TargetType = $_.TargetType
+                        TargetPath = $_.TargetPath
+                    }
+                })
             VolumesToBackup = @($policy.VolumesToBackup)
             BMREnabled = $policy.BMRBackupEnabled
             SystemStateEnabled = $policy.SystemStateBackupEnabled
@@ -326,7 +326,8 @@ try {
             $issuesHtml += "<li>$([System.Net.WebUtility]::HtmlEncode("$issue"))</li>"
         }
         $issuesHtml += "</ul>"
-    } else {
+    }
+    else {
         "<p style='color: green;'><strong>No issues detected</strong></p>"
     }
 

--- a/scripts/infrastructure/windows/backup-recovery/Manage-RestorePoints.ps1
+++ b/scripts/infrastructure/windows/backup-recovery/Manage-RestorePoints.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Manages system restore points on Windows servers and workstations.
 
@@ -118,18 +118,19 @@ switch ($Action) {
                 Write-Host ""
 
                 $restorePoints | Format-Table -AutoSize -Property @(
-                    @{Label="Sequence"; Expression={$_.SequenceNumber}},
-                    @{Label="Created"; Expression={$_.CreationTime.ToString('yyyy-MM-dd HH:mm:ss')}},
-                    @{Label="Description"; Expression={$_.Description}},
-                    @{Label="Type"; Expression={
-                        switch ($_.RestorePointType) {
-                            0 { "Application Install" }
-                            1 { "Application Uninstall" }
-                            12 { "Modify Settings" }
-                            13 { "Cancelled Operation" }
-                            default { "Unknown ($($_.RestorePointType))" }
+                    @{Label = "Sequence"; Expression = { $_.SequenceNumber } },
+                    @{Label = "Created"; Expression = { $_.CreationTime.ToString('yyyy-MM-dd HH:mm:ss') } },
+                    @{Label = "Description"; Expression = { $_.Description } },
+                    @{Label = "Type"; Expression = {
+                            switch ($_.RestorePointType) {
+                                0 { "Application Install" }
+                                1 { "Application Uninstall" }
+                                12 { "Modify Settings" }
+                                13 { "Cancelled Operation" }
+                                default { "Unknown ($($_.RestorePointType))" }
+                            }
                         }
-                    }}
+                    }
                 )
 
                 # Show most recent

--- a/scripts/infrastructure/windows/backup-recovery/Test-BackupIntegrity.ps1
+++ b/scripts/infrastructure/windows/backup-recovery/Test-BackupIntegrity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Tests integrity and validity of Windows Server Backup archives.
 
@@ -50,22 +50,22 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$BackupLocation,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$TestRestore,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckVSS,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$DaysToCheck = 7,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 

--- a/scripts/infrastructure/windows/group-policy/Backup-GroupPolicies.ps1
+++ b/scripts/infrastructure/windows/group-policy/Backup-GroupPolicies.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Backs up all Group Policy Objects in the domain to a specified location.
 
@@ -141,20 +141,20 @@ try {
 
             # Create detailed backup record
             $backupLog += [PSCustomObject]@{
-                GPOName           = $gpo.DisplayName
-                GUID              = $gpo.Id
-                BackupTime        = Get-Date
-                BackupID          = $backupInfo.Id
-                Status            = "Success"
-                GpoStatus         = $gpo.GpoStatus
-                Created           = $gpo.CreationTime
-                Modified          = $gpo.ModificationTime
-                LinkCount         = $linkCount
-                WMIFilter         = $wmiFilter
-                Owner             = $gpo.Owner
-                ComputerEnabled   = $gpo.Computer.Enabled
-                UserEnabled       = $gpo.User.Enabled
-                Error             = ""
+                GPOName = $gpo.DisplayName
+                GUID = $gpo.Id
+                BackupTime = Get-Date
+                BackupID = $backupInfo.Id
+                Status = "Success"
+                GpoStatus = $gpo.GpoStatus
+                Created = $gpo.CreationTime
+                Modified = $gpo.ModificationTime
+                LinkCount = $linkCount
+                WMIFilter = $wmiFilter
+                Owner = $gpo.Owner
+                ComputerEnabled = $gpo.Computer.Enabled
+                UserEnabled = $gpo.User.Enabled
+                Error = ""
             }
 
             $successCount++
@@ -165,20 +165,20 @@ try {
             Write-Host "  ✗ $($gpo.DisplayName): $($_.Exception.Message)" -ForegroundColor Red
 
             $backupLog += [PSCustomObject]@{
-                GPOName           = $gpo.DisplayName
-                GUID              = $gpo.Id
-                BackupTime        = Get-Date
-                BackupID          = "N/A"
-                Status            = "Failed"
-                GpoStatus         = $gpo.GpoStatus
-                Created           = $gpo.CreationTime
-                Modified          = $gpo.ModificationTime
-                LinkCount         = 0
-                WMIFilter         = ""
-                Owner             = $gpo.Owner
-                ComputerEnabled   = $false
-                UserEnabled       = $false
-                Error             = $_.Exception.Message
+                GPOName = $gpo.DisplayName
+                GUID = $gpo.Id
+                BackupTime = Get-Date
+                BackupID = "N/A"
+                Status = "Failed"
+                GpoStatus = $gpo.GpoStatus
+                Created = $gpo.CreationTime
+                Modified = $gpo.ModificationTime
+                LinkCount = 0
+                WMIFilter = ""
+                Owner = $gpo.Owner
+                ComputerEnabled = $false
+                UserEnabled = $false
+                Error = $_.Exception.Message
             }
         }
     }
@@ -192,14 +192,14 @@ try {
 
     # Create backup manifest
     $manifest = @{
-        BackupDate        = Get-Date
-        Domain            = $domainName
-        TotalGPOs         = $totalGPOs
+        BackupDate = Get-Date
+        Domain = $domainName
+        TotalGPOs = $totalGPOs
         SuccessfulBackups = $successCount
-        FailedBackups     = $failCount
-        BackupPath        = $backupFolder
-        Comment           = $Comment
-        BackupBy          = "$env:USERDOMAIN\$env:USERNAME"
+        FailedBackups = $failCount
+        BackupPath = $backupFolder
+        Comment = $Comment
+        BackupBy = "$env:USERDOMAIN\$env:USERNAME"
     }
 
     $manifestPath = Join-Path -Path $backupFolder -ChildPath "BackupManifest.json"

--- a/scripts/infrastructure/windows/group-policy/Find-GPOConflicts.ps1
+++ b/scripts/infrastructure/windows/group-policy/Find-GPOConflicts.ps1
@@ -108,11 +108,11 @@ try {
 
     foreach ($gpo in $partiallyDisabledGPOs) {
         $issues += [PSCustomObject]@{
-            Type        = "Partially Disabled GPO"
-            Severity    = "Warning"
-            GPOName     = $gpo.DisplayName
+            Type = "Partially Disabled GPO"
+            Severity = "Warning"
+            GPOName = $gpo.DisplayName
             Description = "GPO has $($gpo.GpoStatus)"
-            Impact      = "Some settings may not apply as expected"
+            Impact = "Some settings may not apply as expected"
             Recommendation = "Review if this is intentional, otherwise enable all settings"
         }
     }
@@ -138,11 +138,11 @@ try {
             if ($linkCount -gt 0) {
                 $emptyLinkedCount++
                 $issues += [PSCustomObject]@{
-                    Type        = "Empty Linked GPO"
-                    Severity    = "Warning"
-                    GPOName     = $gpo.DisplayName
+                    Type = "Empty Linked GPO"
+                    Severity = "Warning"
+                    GPOName = $gpo.DisplayName
                     Description = "GPO is empty but linked to $linkCount location(s)"
-                    Impact      = "Unnecessary processing overhead"
+                    Impact = "Unnecessary processing overhead"
                     Recommendation = "Remove links or delete GPO if not needed"
                 }
             }
@@ -158,11 +158,11 @@ try {
 
     foreach ($duplicate in $duplicateNames) {
         $issues += [PSCustomObject]@{
-            Type        = "Duplicate GPO Names"
-            Severity    = "High"
-            GPOName     = $duplicate.Name
+            Type = "Duplicate GPO Names"
+            Severity = "High"
+            GPOName = $duplicate.Name
             Description = "Multiple GPOs ($($duplicate.Count)) with the same name"
-            Impact      = "Confusion in management and troubleshooting"
+            Impact = "Confusion in management and troubleshooting"
             Recommendation = "Rename GPOs to have unique names"
         }
     }
@@ -193,11 +193,11 @@ try {
 
     if ($loopbackGPOs.Count -gt 1) {
         $issues += [PSCustomObject]@{
-            Type        = "Multiple Loopback Policies"
-            Severity    = "High"
-            GPOName     = ($loopbackGPOs.DisplayName -join ", ")
+            Type = "Multiple Loopback Policies"
+            Severity = "High"
+            GPOName = ($loopbackGPOs.DisplayName -join ", ")
             Description = "$($loopbackGPOs.Count) GPOs configure loopback processing"
-            Impact      = "Conflicting loopback modes may cause unexpected behavior"
+            Impact = "Conflicting loopback modes may cause unexpected behavior"
             Recommendation = "Consolidate loopback processing configuration into single GPO"
         }
     }
@@ -221,11 +221,11 @@ try {
                         $similarNames += $similarity
 
                         $warnings += [PSCustomObject]@{
-                            Type        = "Similar GPO Names"
-                            Severity    = "Low"
-                            GPOName     = $similarity
+                            Type = "Similar GPO Names"
+                            Severity = "Low"
+                            GPOName = $similarity
                             Description = "GPOs have similar names"
-                            Impact      = "May indicate duplicate policies or cause confusion"
+                            Impact = "May indicate duplicate policies or cause confusion"
                             Recommendation = "Review if these are duplicate policies"
                         }
                     }
@@ -254,11 +254,11 @@ try {
             if ($authenticatedUsersDenied) {
                 $securityFilterIssues++
                 $issues += [PSCustomObject]@{
-                    Type        = "Security Filtering Issue"
-                    Severity    = "Medium"
-                    GPOName     = $gpo.DisplayName
+                    Type = "Security Filtering Issue"
+                    Severity = "Medium"
+                    GPOName = $gpo.DisplayName
                     Description = "Authenticated Users explicitly denied GpoApply"
-                    Impact      = "GPO may not apply as expected without specific security group filtering"
+                    Impact = "GPO may not apply as expected without specific security group filtering"
                     Recommendation = "Ensure appropriate security groups are added for GPO application"
                 }
             }
@@ -271,11 +271,11 @@ try {
             if (-not $applyPermissions) {
                 $securityFilterIssues++
                 $issues += [PSCustomObject]@{
-                    Type        = "No Apply Permissions"
-                    Severity    = "High"
-                    GPOName     = $gpo.DisplayName
+                    Type = "No Apply Permissions"
+                    Severity = "High"
+                    GPOName = $gpo.DisplayName
                     Description = "No security principals have GpoApply permission"
-                    Impact      = "GPO will not apply to any users or computers"
+                    Impact = "GPO will not apply to any users or computers"
                     Recommendation = "Add appropriate security principals with GpoApply permission"
                 }
             }
@@ -298,11 +298,11 @@ try {
 
         foreach ($ou in $blockedOUs) {
             $warnings += [PSCustomObject]@{
-                Type        = "Inheritance Blocked"
-                Severity    = "Medium"
-                GPOName     = "N/A"
+                Type = "Inheritance Blocked"
+                Severity = "Medium"
+                GPOName = "N/A"
                 Description = "OU '$($ou.Name)' has GPO inheritance blocked"
-                Impact      = "Parent GPOs will not apply to this OU"
+                Impact = "Parent GPOs will not apply to this OU"
                 Recommendation = "Ensure this is intentional and necessary"
             }
         }
@@ -367,10 +367,10 @@ try {
 
     <h2>Summary</h2>
     <table>
-        <tr><td><strong>High Severity Issues</strong></td><td>$(($allFindings | Where-Object Severity -eq 'High').Count)</td></tr>
-        <tr><td><strong>Medium Severity Issues</strong></td><td>$(($allFindings | Where-Object Severity -eq 'Medium').Count)</td></tr>
-        <tr><td><strong>Warnings</strong></td><td>$(($allFindings | Where-Object Severity -eq 'Warning').Count)</td></tr>
-        <tr><td><strong>Low Priority</strong></td><td>$(($allFindings | Where-Object Severity -eq 'Low').Count)</td></tr>
+        <tr><td><strong>High Severity Issues</strong></td><td>$(($allFindings | Where-Object Severity -EQ 'High').Count)</td></tr>
+        <tr><td><strong>Medium Severity Issues</strong></td><td>$(($allFindings | Where-Object Severity -EQ 'Medium').Count)</td></tr>
+        <tr><td><strong>Warnings</strong></td><td>$(($allFindings | Where-Object Severity -EQ 'Warning').Count)</td></tr>
+        <tr><td><strong>Low Priority</strong></td><td>$(($allFindings | Where-Object Severity -EQ 'Low').Count)</td></tr>
     </table>
 
     <h2>Issues and Conflicts</h2>
@@ -386,13 +386,14 @@ try {
 "@
 
     foreach ($finding in $allFindings | Sort-Object -Property @{Expression = {
-        switch ($_.Severity) {
-            'High' { 1 }
-            'Medium' { 2 }
-            'Warning' { 3 }
-            'Low' { 4 }
-        }
-    }}, Type) {
+                switch ($_.Severity) {
+                    'High' { 1 }
+                    'Medium' { 2 }
+                    'Warning' { 3 }
+                    'Low' { 4 }
+                }
+            }
+        }, Type) {
         $rowClass = switch ($finding.Severity) {
             'High' { 'high' }
             'Medium' { 'medium' }
@@ -424,10 +425,10 @@ try {
     # Display summary
     Write-Host "`n=== Analysis Complete ===" -ForegroundColor Green
     Write-Host "Total Issues Found: $($allFindings.Count)" -ForegroundColor Cyan
-    Write-Host "  High Severity: $(($allFindings | Where-Object Severity -eq 'High').Count)" -ForegroundColor Red
-    Write-Host "  Medium Severity: $(($allFindings | Where-Object Severity -eq 'Medium').Count)" -ForegroundColor Yellow
-    Write-Host "  Warnings: $(($allFindings | Where-Object Severity -eq 'Warning').Count)" -ForegroundColor Yellow
-    Write-Host "  Low Priority: $(($allFindings | Where-Object Severity -eq 'Low').Count)" -ForegroundColor Cyan
+    Write-Host "  High Severity: $(($allFindings | Where-Object Severity -EQ 'High').Count)" -ForegroundColor Red
+    Write-Host "  Medium Severity: $(($allFindings | Where-Object Severity -EQ 'Medium').Count)" -ForegroundColor Yellow
+    Write-Host "  Warnings: $(($allFindings | Where-Object Severity -EQ 'Warning').Count)" -ForegroundColor Yellow
+    Write-Host "  Low Priority: $(($allFindings | Where-Object Severity -EQ 'Low').Count)" -ForegroundColor Cyan
 
 }
 catch {

--- a/scripts/infrastructure/windows/group-policy/Get-GPOReport.ps1
+++ b/scripts/infrastructure/windows/group-policy/Get-GPOReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Generates comprehensive Group Policy Object (GPO) reports for domain analysis.
 
@@ -143,7 +143,7 @@ try {
         $userVersion = $gpo.User.DSVersion
 
         $isEmpty = ((-not $computerEnabled) -and (-not $userEnabled)) -or
-                   (($computerVersion -eq 0) -and ($userVersion -eq 0))
+        (($computerVersion -eq 0) -and ($userVersion -eq 0))
 
         if ($isEmpty) {
             $emptyGPOs += $gpo
@@ -154,20 +154,20 @@ try {
 
         # Create summary object
         $gpoSummary += [PSCustomObject]@{
-            Name              = $gpoName
-            GUID              = $gpoGuid
-            Status            = $gpoStatus
-            Created           = $gpoCreated
-            Modified          = $gpoModified
-            LinkCount         = $linkCount
-            IsUnlinked        = $isUnlinked
-            IsEmpty           = $isEmpty
-            ComputerEnabled   = $computerEnabled
-            UserEnabled       = $userEnabled
-            ComputerVersion   = $computerVersion
-            UserVersion       = $userVersion
-            WMIFilter         = $wmiFilter
-            Owner             = $gpo.Owner
+            Name = $gpoName
+            GUID = $gpoGuid
+            Status = $gpoStatus
+            Created = $gpoCreated
+            Modified = $gpoModified
+            LinkCount = $linkCount
+            IsUnlinked = $isUnlinked
+            IsEmpty = $isEmpty
+            ComputerEnabled = $computerEnabled
+            UserEnabled = $userEnabled
+            ComputerVersion = $computerVersion
+            UserVersion = $userVersion
+            WMIFilter = $wmiFilter
+            Owner = $gpo.Owner
         }
 
         # Generate individual GPO reports

--- a/scripts/infrastructure/windows/monitoring/Get-EventLogReport.ps1
+++ b/scripts/infrastructure/windows/monitoring/Get-EventLogReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Parses and analyzes Windows event logs for critical errors and security events.
 
@@ -56,30 +56,30 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('System','Application','Security','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('System', 'Application', 'Security', 'All')]
     [string]$LogName = 'All',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Hours = 24,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Days,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$MaxEvents = 1000,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Critical','Error','Warning','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Critical', 'Error', 'Warning', 'All')]
     [string]$Severity = 'Error',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$GroupBySource
 )
 
@@ -113,7 +113,7 @@ $script:report = @{
 }
 
 # Determine time range
-if($Days) {
+if ($Days) {
     $script:startTime = (Get-Date).AddDays(-$Days)
     $script:report.TimeRange = "Last $Days days"
 }
@@ -125,7 +125,7 @@ else {
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Critical' { 'Red' }
         'Error' { 'Red' }
         'Warning' { 'Yellow' }
@@ -138,11 +138,11 @@ function Write-ColorOutput {
 function Get-SeverityLevel {
     param([string]$Severity)
 
-    switch($Severity) {
+    switch ($Severity) {
         'Critical' { return @(1) }
-        'Error' { return @(1,2) }
-        'Warning' { return @(1,2,3) }
-        'All' { return @(0,1,2,3,4) }
+        'Error' { return @(1, 2) }
+        'Warning' { return @(1, 2, 3) }
+        'All' { return @(0, 1, 2, 3, 4) }
     }
 }
 
@@ -168,14 +168,14 @@ function Get-EventLogAnalysis {
         }
 
         $levels = Get-SeverityLevel -Severity $Severity
-        if($Severity -ne 'All') {
+        if ($Severity -ne 'All') {
             $filterHash['Level'] = $levels
         }
 
         $events = Get-WinEvent -FilterHashtable $filterHash -MaxEvents $MaxEvents -ErrorAction SilentlyContinue
 
-        if($events) {
-            foreach($event in $events) {
+        if ($events) {
+            foreach ($event in $events) {
                 $eventInfo = [PSCustomObject]@{
                     TimeCreated = $event.TimeCreated
                     LogName = $event.LogName
@@ -192,7 +192,7 @@ function Get-EventLogAnalysis {
                 $script:report.AllEvents += $eventInfo
 
                 # Count by severity
-                switch($event.Level) {
+                switch ($event.Level) {
                     1 {
                         $logReport.CriticalCount++
                         $script:report.Summary.CriticalCount++
@@ -208,7 +208,7 @@ function Get-EventLogAnalysis {
                 }
 
                 # Track event sources
-                if($logReport.TopSources.ContainsKey($event.ProviderName)) {
+                if ($logReport.TopSources.ContainsKey($event.ProviderName)) {
                     $logReport.TopSources[$event.ProviderName]++
                 }
                 else {
@@ -238,9 +238,9 @@ function Get-TopEventSources {
 
     $allSources = @{}
 
-    foreach($log in $script:report.Logs) {
-        foreach($source in $log.TopSources.GetEnumerator()) {
-            if($allSources.ContainsKey($source.Key)) {
+    foreach ($log in $script:report.Logs) {
+        foreach ($source in $log.TopSources.GetEnumerator()) {
+            if ($allSources.ContainsKey($source.Key)) {
                 $allSources[$source.Key] += $source.Value
             }
             else {
@@ -269,38 +269,38 @@ function Show-Summary {
     Write-Host "Scan Time: $($script:report.ScanTime)"
     Write-Host "`nTotal Events: $($script:report.Summary.TotalEvents)"
 
-    if($script:report.Summary.CriticalCount -gt 0) {
+    if ($script:report.Summary.CriticalCount -gt 0) {
         Write-ColorOutput "Critical: $($script:report.Summary.CriticalCount)" -Level Critical
     }
-    if($script:report.Summary.ErrorCount -gt 0) {
+    if ($script:report.Summary.ErrorCount -gt 0) {
         Write-ColorOutput "Errors: $($script:report.Summary.ErrorCount)" -Level Error
     }
-    if($script:report.Summary.WarningCount -gt 0) {
+    if ($script:report.Summary.WarningCount -gt 0) {
         Write-ColorOutput "Warnings: $($script:report.Summary.WarningCount)" -Level Warning
     }
 
-    if($script:report.TopSources.Count -gt 0) {
+    if ($script:report.TopSources.Count -gt 0) {
         Write-Host "`nTop Event Sources:" -ForegroundColor Cyan
-        foreach($source in $script:report.TopSources) {
+        foreach ($source in $script:report.TopSources) {
             Write-Host "  $($source.Source): $($source.EventCount) events"
         }
     }
 
     # Show recent critical/error events
     $recentCritical = $script:report.AllEvents |
-        Where-Object {$_.Level -le 2} |
+        Where-Object { $_.Level -le 2 } |
         Sort-Object TimeCreated -Descending |
         Select-Object -First 5
 
-    if($recentCritical) {
+    if ($recentCritical) {
         Write-Host "`nRecent Critical/Error Events:" -ForegroundColor Cyan
-        foreach($event in $recentCritical) {
-            $levelColor = if($event.Level -eq 1) { 'Red' } else { 'Yellow' }
+        foreach ($event in $recentCritical) {
+            $levelColor = if ($event.Level -eq 1) { 'Red' } else { 'Yellow' }
             Write-Host "  [$($event.TimeCreated)] " -NoNewline
             Write-Host "$($event.LevelDisplayName) " -ForegroundColor $levelColor -NoNewline
             Write-Host "- $($event.Source) (Event $($event.EventID))"
             $message = $event.Message
-            if($message.Length -gt 100) {
+            if ($message.Length -gt 100) {
                 $message = $message.Substring(0, 100) + "..."
             }
             Write-Host "    $message" -ForegroundColor Gray
@@ -429,7 +429,7 @@ Write-Host "Severity Filter: $Severity"
 Write-Host "Max Events per Log: $MaxEvents"
 Write-Host "`nAnalyzing logs..." -ForegroundColor Cyan
 
-if($LogName -eq 'All') {
+if ($LogName -eq 'All') {
     Get-EventLogAnalysis -Log 'System'
     Get-EventLogAnalysis -Log 'Application'
     Get-EventLogAnalysis -Log 'Security'
@@ -441,12 +441,12 @@ else {
 Get-TopEventSources
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/monitoring/Get-PerformanceReport.ps1
+++ b/scripts/infrastructure/windows/monitoring/Get-PerformanceReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Generates comprehensive performance metrics and bottleneck analysis for Windows Server.
 
@@ -51,22 +51,22 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$DurationMinutes = 5,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$SampleInterval = 5,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDiskIO,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeNetworkStats,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -119,7 +119,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -146,7 +146,7 @@ function Collect-PerformanceData {
         '\Memory\% Committed Bytes In Use'
     )
 
-    if($IncludeDiskIO) {
+    if ($IncludeDiskIO) {
         $counters += '\PhysicalDisk(_Total)\Disk Reads/sec'
         $counters += '\PhysicalDisk(_Total)\Disk Writes/sec'
         $counters += '\PhysicalDisk(_Total)\Avg. Disk sec/Read'
@@ -154,7 +154,7 @@ function Collect-PerformanceData {
         $counters += '\PhysicalDisk(_Total)\Current Disk Queue Length'
     }
 
-    if($IncludeNetworkStats) {
+    if ($IncludeNetworkStats) {
         $counters += '\Network Interface(*)\Bytes Total/sec'
     }
 
@@ -164,7 +164,7 @@ function Collect-PerformanceData {
     $script:report.Memory.TotalGB = [math]::Round($totalMemoryMB / 1024, 2)
 
     # Collect samples
-    for($i = 1; $i -le $sampleCount; $i++) {
+    for ($i = 1; $i -le $sampleCount; $i++) {
         $percentComplete = [math]::Round(($i / $sampleCount) * 100, 0)
         Write-Progress -Activity "Collecting Performance Data" -Status "$percentComplete% Complete" -PercentComplete $percentComplete
 
@@ -172,12 +172,12 @@ function Collect-PerformanceData {
             $sample = Get-Counter -Counter $counters -ErrorAction Stop
 
             # CPU
-            $cpuSample = $sample.CounterSamples | Where-Object {$_.Path -like '*Processor(_Total)*'}
+            $cpuSample = $sample.CounterSamples | Where-Object { $_.Path -like '*Processor(_Total)*' }
             $cpuValue = [math]::Round($cpuSample.CookedValue, 2)
             $script:report.CPU.Samples += $cpuValue
 
             # Memory
-            $availableMemMB = ($sample.CounterSamples | Where-Object {$_.Path -like '*Available MBytes*'}).CookedValue
+            $availableMemMB = ($sample.CounterSamples | Where-Object { $_.Path -like '*Available MBytes*' }).CookedValue
             $usedMemoryMB = $totalMemoryMB - $availableMemMB
             $usedMemoryGB = [math]::Round($usedMemoryMB / 1024, 2)
             $usedMemoryPercent = [math]::Round(($usedMemoryMB / $totalMemoryMB) * 100, 2)
@@ -189,12 +189,12 @@ function Collect-PerformanceData {
             }
 
             # Disk I/O (if enabled)
-            if($IncludeDiskIO) {
-                $diskReads = ($sample.CounterSamples | Where-Object {$_.Path -like '*Disk Reads/sec*'}).CookedValue
-                $diskWrites = ($sample.CounterSamples | Where-Object {$_.Path -like '*Disk Writes/sec*'}).CookedValue
-                $diskReadLatency = ($sample.CounterSamples | Where-Object {$_.Path -like '*Avg. Disk sec/Read*'}).CookedValue
-                $diskWriteLatency = ($sample.CounterSamples | Where-Object {$_.Path -like '*Avg. Disk sec/Write*'}).CookedValue
-                $diskQueue = ($sample.CounterSamples | Where-Object {$_.Path -like '*Current Disk Queue*'}).CookedValue
+            if ($IncludeDiskIO) {
+                $diskReads = ($sample.CounterSamples | Where-Object { $_.Path -like '*Disk Reads/sec*' }).CookedValue
+                $diskWrites = ($sample.CounterSamples | Where-Object { $_.Path -like '*Disk Writes/sec*' }).CookedValue
+                $diskReadLatency = ($sample.CounterSamples | Where-Object { $_.Path -like '*Avg. Disk sec/Read*' }).CookedValue
+                $diskWriteLatency = ($sample.CounterSamples | Where-Object { $_.Path -like '*Avg. Disk sec/Write*' }).CookedValue
+                $diskQueue = ($sample.CounterSamples | Where-Object { $_.Path -like '*Current Disk Queue*' }).CookedValue
 
                 $script:report.DiskIO += @{
                     Timestamp = Get-Date
@@ -207,19 +207,19 @@ function Collect-PerformanceData {
             }
 
             # Network (if enabled)
-            if($IncludeNetworkStats) {
-                $networkSamples = $sample.CounterSamples | Where-Object {$_.Path -like '*Network Interface*Bytes Total*'}
-                foreach($netSample in $networkSamples) {
+            if ($IncludeNetworkStats) {
+                $networkSamples = $sample.CounterSamples | Where-Object { $_.Path -like '*Network Interface*Bytes Total*' }
+                foreach ($netSample in $networkSamples) {
                     $adapterName = $netSample.InstanceName
                     $bytesPerSec = $netSample.CookedValue
 
-                    $existing = $script:report.Network | Where-Object {$_.AdapterName -eq $adapterName}
-                    if(-not $existing) {
+                    $existing = $script:report.Network | Where-Object { $_.AdapterName -eq $adapterName }
+                    if (-not $existing) {
                         $script:report.Network += @{
                             AdapterName = $adapterName
                             Samples = @()
                         }
-                        $existing = $script:report.Network | Where-Object {$_.AdapterName -eq $adapterName}
+                        $existing = $script:report.Network | Where-Object { $_.AdapterName -eq $adapterName }
                     }
 
                     $existing.Samples += @{
@@ -234,7 +234,7 @@ function Collect-PerformanceData {
             Write-Warning "Error collecting sample $i : $($_.Exception.Message)"
         }
 
-        if($i -lt $sampleCount) {
+        if ($i -lt $sampleCount) {
             Start-Sleep -Seconds $SampleInterval
         }
     }
@@ -247,7 +247,7 @@ function Analyze-PerformanceData {
     Write-Host "`nAnalyzing performance data..." -ForegroundColor Cyan
 
     # CPU Analysis
-    if($script:report.CPU.Samples.Count -gt 0) {
+    if ($script:report.CPU.Samples.Count -gt 0) {
         $cpuStats = $script:report.CPU.Samples | Measure-Object -Average -Minimum -Maximum
         $script:report.CPU.Average = [math]::Round($cpuStats.Average, 2)
         $script:report.CPU.Min = [math]::Round($cpuStats.Minimum, 2)
@@ -261,19 +261,19 @@ function Analyze-PerformanceData {
         Write-Host "  CPU: Avg=$($script:report.CPU.Average)%, Min=$($script:report.CPU.Min)%, Max=$($script:report.CPU.Max)%, 95th=%$($script:report.CPU.Peak95Percentile)%"
 
         # CPU Bottleneck detection
-        if($script:report.CPU.Average -gt 80) {
+        if ($script:report.CPU.Average -gt 80) {
             $script:report.Bottlenecks += "High average CPU utilization ($($script:report.CPU.Average)%)"
         }
-        if($script:report.CPU.Peak95Percentile -gt 90) {
+        if ($script:report.CPU.Peak95Percentile -gt 90) {
             $script:report.Bottlenecks += "CPU spikes detected (95th percentile: $($script:report.CPU.Peak95Percentile)%)"
         }
     }
 
     # Memory Analysis
-    if($script:report.Memory.Samples.Count -gt 0) {
-        $avgUsedGB = ($script:report.Memory.Samples | ForEach-Object {$_.UsedGB} | Measure-Object -Average).Average
-        $avgUsedPercent = ($script:report.Memory.Samples | ForEach-Object {$_.UsedPercent} | Measure-Object -Average).Average
-        $peakSample = $script:report.Memory.Samples | Sort-Object {$_.UsedPercent} -Descending | Select-Object -First 1
+    if ($script:report.Memory.Samples.Count -gt 0) {
+        $avgUsedGB = ($script:report.Memory.Samples | ForEach-Object { $_.UsedGB } | Measure-Object -Average).Average
+        $avgUsedPercent = ($script:report.Memory.Samples | ForEach-Object { $_.UsedPercent } | Measure-Object -Average).Average
+        $peakSample = $script:report.Memory.Samples | Sort-Object { $_.UsedPercent } -Descending | Select-Object -First 1
 
         $script:report.Memory.AverageUsedGB = [math]::Round($avgUsedGB, 2)
         $script:report.Memory.AverageUsedPercent = [math]::Round($avgUsedPercent, 2)
@@ -283,39 +283,39 @@ function Analyze-PerformanceData {
         Write-Host "  Memory: Avg=$($script:report.Memory.AverageUsedPercent)%, Peak=$($script:report.Memory.PeakUsedPercent)%"
 
         # Memory bottleneck detection
-        if($script:report.Memory.AverageUsedPercent -gt 85) {
+        if ($script:report.Memory.AverageUsedPercent -gt 85) {
             $script:report.Bottlenecks += "High memory utilization ($($script:report.Memory.AverageUsedPercent)%)"
         }
     }
 
     # Disk I/O Analysis
-    if($script:report.DiskIO.Count -gt 0) {
-        $avgReads = ($script:report.DiskIO | ForEach-Object {$_.ReadsPerSec} | Measure-Object -Average).Average
-        $avgWrites = ($script:report.DiskIO | ForEach-Object {$_.WritesPerSec} | Measure-Object -Average).Average
-        $avgReadLatency = ($script:report.DiskIO | ForEach-Object {$_.ReadLatencyMs} | Measure-Object -Average).Average
-        $avgWriteLatency = ($script:report.DiskIO | ForEach-Object {$_.WriteLatencyMs} | Measure-Object -Average).Average
-        $avgQueue = ($script:report.DiskIO | ForEach-Object {$_.QueueLength} | Measure-Object -Average).Average
+    if ($script:report.DiskIO.Count -gt 0) {
+        $avgReads = ($script:report.DiskIO | ForEach-Object { $_.ReadsPerSec } | Measure-Object -Average).Average
+        $avgWrites = ($script:report.DiskIO | ForEach-Object { $_.WritesPerSec } | Measure-Object -Average).Average
+        $avgReadLatency = ($script:report.DiskIO | ForEach-Object { $_.ReadLatencyMs } | Measure-Object -Average).Average
+        $avgWriteLatency = ($script:report.DiskIO | ForEach-Object { $_.WriteLatencyMs } | Measure-Object -Average).Average
+        $avgQueue = ($script:report.DiskIO | ForEach-Object { $_.QueueLength } | Measure-Object -Average).Average
 
         Write-Host "  Disk I/O: Reads=$([math]::Round($avgReads, 2))/s, Writes=$([math]::Round($avgWrites, 2))/s"
         Write-Host "  Disk Latency: Read=$([math]::Round($avgReadLatency, 2))ms, Write=$([math]::Round($avgWriteLatency, 2))ms"
         Write-Host "  Disk Queue: Avg=$([math]::Round($avgQueue, 2))"
 
         # Disk bottleneck detection
-        if($avgReadLatency -gt 25 -or $avgWriteLatency -gt 25) {
+        if ($avgReadLatency -gt 25 -or $avgWriteLatency -gt 25) {
             $script:report.Bottlenecks += "High disk latency detected (Read: $([math]::Round($avgReadLatency, 2))ms, Write: $([math]::Round($avgWriteLatency, 2))ms)"
         }
-        if($avgQueue -gt 2) {
+        if ($avgQueue -gt 2) {
             $script:report.Bottlenecks += "High disk queue length ($([math]::Round($avgQueue, 2)))"
         }
     }
 
     # Network Analysis
-    if($script:report.Network.Count -gt 0) {
+    if ($script:report.Network.Count -gt 0) {
         Write-Host "  Network Adapters:"
-        foreach($adapter in $script:report.Network) {
-            if($adapter.Samples.Count -gt 0) {
-                $avgMbps = ($adapter.Samples | ForEach-Object {$_.MbitsPerSec} | Measure-Object -Average).Average
-                $peakMbps = ($adapter.Samples | ForEach-Object {$_.MbitsPerSec} | Measure-Object -Maximum).Maximum
+        foreach ($adapter in $script:report.Network) {
+            if ($adapter.Samples.Count -gt 0) {
+                $avgMbps = ($adapter.Samples | ForEach-Object { $_.MbitsPerSec } | Measure-Object -Average).Average
+                $peakMbps = ($adapter.Samples | ForEach-Object { $_.MbitsPerSec } | Measure-Object -Maximum).Maximum
                 Write-Host "    $($adapter.AdapterName): Avg=$([math]::Round($avgMbps, 2)) Mbps, Peak=$([math]::Round($peakMbps, 2)) Mbps"
             }
         }
@@ -329,16 +329,16 @@ function Get-TopProcesses {
     $script:report.TopProcesses.ByCPU = Get-Process |
         Sort-Object CPU -Descending |
         Select-Object -First 10 ProcessName, Id,
-        @{Name='CPU(s)';Expression={[math]::Round($_.CPU, 2)}},
-        @{Name='MemoryMB';Expression={[math]::Round($_.WorkingSet64/1MB, 2)}},
-        @{Name='Threads';Expression={$_.Threads.Count}}
+        @{Name = 'CPU(s)'; Expression = { [math]::Round($_.CPU, 2) } },
+        @{Name = 'MemoryMB'; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 2) } },
+        @{Name = 'Threads'; Expression = { $_.Threads.Count } }
 
     # Top Memory processes
     $script:report.TopProcesses.ByMemory = Get-Process |
         Sort-Object WorkingSet64 -Descending |
         Select-Object -First 10 ProcessName, Id,
-        @{Name='MemoryMB';Expression={[math]::Round($_.WorkingSet64/1MB, 2)}},
-        @{Name='CPU(s)';Expression={[math]::Round($_.CPU, 2)}}
+        @{Name = 'MemoryMB'; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 2) } },
+        @{Name = 'CPU(s)'; Expression = { [math]::Round($_.CPU, 2) } }
 
     Write-Host "  Captured top 10 processes by CPU and Memory"
 }
@@ -362,9 +362,9 @@ function Show-Summary {
     Write-Host "  Average Used: $($script:report.Memory.AverageUsedGB) GB ($($script:report.Memory.AverageUsedPercent)%)"
     Write-Host "  Peak Used: $($script:report.Memory.PeakUsedGB) GB ($($script:report.Memory.PeakUsedPercent)%)"
 
-    if($script:report.Bottlenecks.Count -gt 0) {
+    if ($script:report.Bottlenecks.Count -gt 0) {
         Write-Host "`nPerformance Bottlenecks Detected:" -ForegroundColor Yellow
-        foreach($bottleneck in $script:report.Bottlenecks) {
+        foreach ($bottleneck in $script:report.Bottlenecks) {
             Write-ColorOutput "  ! $bottleneck" -Level Warning
         }
     }
@@ -496,7 +496,7 @@ function Export-CSVReport {
     $reportPath = "$ReportDir\PerformanceData_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $csvData = @()
-    for($i = 0; $i -lt $script:report.CPU.Samples.Count; $i++) {
+    for ($i = 0; $i -lt $script:report.CPU.Samples.Count; $i++) {
         $csvData += [PSCustomObject]@{
             Sample = $i + 1
             CPU = $script:report.CPU.Samples[$i]
@@ -520,12 +520,12 @@ Analyze-PerformanceData
 Get-TopProcesses
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/monitoring/Monitor-ServerHealth.ps1
+++ b/scripts/infrastructure/windows/monitoring/Monitor-ServerHealth.ps1
@@ -134,82 +134,82 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportReport,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('High','Medium','Low')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('High', 'Medium', 'Low')]
     [string]$AlertThreshold = 'Medium',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$CheckServices,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$EmailReport,
 
     # Feature toggles
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDiskIO,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeWindowsUpdate,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeSecurity,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeNetworkTests,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeApplications,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeCertificates,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeScheduledTasks,
 
     # Export options
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportJSON,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowProgress,
 
     # Email parameters
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SMTPServer,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$SMTPPort = 25,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$EmailFrom,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string[]]$EmailTo,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$EmailSubject = "Server Health Report - $env:COMPUTERNAME",
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$UseSSL,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [PSCredential]$SMTPCredential,
 
     # Application-specific
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckIIS,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckSQLServer,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckHyperV,
 
     # Certificate warning threshold
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$CertificateWarningDays = 30
 )
 
@@ -388,7 +388,7 @@ $script:healthReport = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Critical' { 'Red' }
         'Warning' { 'Yellow' }
         'Success' { 'Green' }
@@ -402,6 +402,7 @@ function Update-Progress {
     .SYNOPSIS
         Updates progress bar for health checks.
     #>
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [int]$Current,
         [int]$Total,
@@ -409,14 +410,16 @@ function Update-Progress {
         [string]$Status
     )
 
-    if(-not $ShowProgress) { return }
+    if (-not $ShowProgress) { return }
 
     $percentComplete = [math]::Round(($Current / $Total) * 100, 0)
 
-    Write-Progress -Activity $Activity `
-                   -Status $Status `
-                   -PercentComplete $percentComplete `
-                   -CurrentOperation "Step $Current of $Total"
+    if ($PSCmdlet.ShouldProcess($Activity, 'Update progress')) {
+        Write-Progress -Activity $Activity `
+            -Status $Status `
+            -PercentComplete $percentComplete `
+            -CurrentOperation "Step $Current of $Total"
+    }
 }
 
 function Show-InteractiveMenu {
@@ -440,7 +443,7 @@ function Show-InteractiveMenu {
 
     $preset = Read-Host "Enter preset number (1-5) or press Enter for custom"
 
-    switch($preset) {
+    switch ($preset) {
         '1' {
             # Quick Check - just basic monitoring (default behavior)
             $script:ShowProgress = $true
@@ -491,13 +494,13 @@ function Show-InteractiveMenu {
 
             $selection = Read-Host "Your selection"
 
-            if($selection -eq 'all') {
+            if ($selection -eq 'all') {
                 $selection = '1,2,3,4,5,6,7,8'
             }
 
             $choices = $selection -split ','
-            foreach($choice in $choices) {
-                switch($choice.Trim()) {
+            foreach ($choice in $choices) {
+                switch ($choice.Trim()) {
                     '1' { $script:IncludeDiskIO = $true }
                     '2' { $script:IncludeWindowsUpdate = $true }
                     '3' { $script:IncludeSecurity = $true }
@@ -519,17 +522,17 @@ function Show-InteractiveMenu {
     # Export options
     Write-Host "`nExport Options:" -ForegroundColor Yellow
     $exportHtml = Read-Host "Export HTML report? (Y/N)"
-    if($exportHtml -eq 'Y' -or $exportHtml -eq 'y') {
+    if ($exportHtml -eq 'Y' -or $exportHtml -eq 'y') {
         $script:ExportReport = $true
     }
 
     $exportJson = Read-Host "Export JSON report? (Y/N)"
-    if($exportJson -eq 'Y' -or $exportJson -eq 'y') {
+    if ($exportJson -eq 'Y' -or $exportJson -eq 'y') {
         $script:ExportJSON = $true
     }
 
     $showProg = Read-Host "Show progress indicators? (Y/N)"
-    if($showProg -eq 'Y' -or $showProg -eq 'y') {
+    if ($showProg -eq 'Y' -or $showProg -eq 'y') {
         $script:ShowProgress = $true
     }
 
@@ -541,7 +544,7 @@ function Get-CPUHealth {
     Write-Verbose "Checking CPU utilization..."
 
     $cpuSamples = @()
-    for($i = 0; $i -lt 5; $i++) {
+    for ($i = 0; $i -lt 5; $i++) {
         $cpu = Get-Counter '\Processor(_Total)\% Processor Time' -ErrorAction SilentlyContinue
         $cpuSamples += $cpu.CounterSamples[0].CookedValue
         Start-Sleep -Seconds 1
@@ -554,15 +557,15 @@ function Get-CPUHealth {
         Status = 'OK'
     }
 
-    if($avgCPU -ge $script:threshold.CPUCritical) {
+    if ($avgCPU -ge $script:threshold.CPUCritical) {
         $script:healthReport.CPU.Status = 'Critical'
         $script:healthReport.Status = 'Critical'
         $script:healthReport.Issues += "CPU utilization critical: $([math]::Round($avgCPU, 2))%"
         Write-ColorOutput "  [CRITICAL] CPU: $([math]::Round($avgCPU, 2))%" -Level Critical
     }
-    elseif($avgCPU -ge $script:threshold.CPUWarning) {
+    elseif ($avgCPU -ge $script:threshold.CPUWarning) {
         $script:healthReport.CPU.Status = 'Warning'
-        if($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
+        if ($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
         $script:healthReport.Warnings += "CPU utilization elevated: $([math]::Round($avgCPU, 2))%"
         Write-ColorOutput "  [WARNING] CPU: $([math]::Round($avgCPU, 2))%" -Level Warning
     }
@@ -572,8 +575,8 @@ function Get-CPUHealth {
 
     # Get top CPU processes
     $topProcesses = Get-Process | Sort-Object CPU -Descending | Select-Object -First 5 |
-        Select-Object ProcessName, @{Name='CPU';Expression={[math]::Round($_.CPU, 2)}},
-        @{Name='MemoryMB';Expression={[math]::Round($_.WorkingSet64/1MB, 2)}}
+        Select-Object ProcessName, @{Name = 'CPU'; Expression = { [math]::Round($_.CPU, 2) } },
+        @{Name = 'MemoryMB'; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 2) } }
     $script:healthReport.CPU.TopProcesses = $topProcesses
 }
 
@@ -581,8 +584,8 @@ function Get-MemoryHealth {
     Write-Verbose "Checking memory utilization..."
 
     $os = Get-CimInstance Win32_OperatingSystem
-    $totalMemoryGB = [math]::Round($os.TotalVisibleMemorySize/1MB, 2)
-    $freeMemoryGB = [math]::Round($os.FreePhysicalMemory/1MB, 2)
+    $totalMemoryGB = [math]::Round($os.TotalVisibleMemorySize / 1MB, 2)
+    $freeMemoryGB = [math]::Round($os.FreePhysicalMemory / 1MB, 2)
     $usedMemoryGB = $totalMemoryGB - $freeMemoryGB
     $memoryUsedPercent = [math]::Round(($usedMemoryGB / $totalMemoryGB) * 100, 2)
 
@@ -594,15 +597,15 @@ function Get-MemoryHealth {
         Status = 'OK'
     }
 
-    if($memoryUsedPercent -ge $script:threshold.MemoryCritical) {
+    if ($memoryUsedPercent -ge $script:threshold.MemoryCritical) {
         $script:healthReport.Memory.Status = 'Critical'
         $script:healthReport.Status = 'Critical'
         $script:healthReport.Issues += "Memory utilization critical: $memoryUsedPercent%"
         Write-ColorOutput "  [CRITICAL] Memory: $memoryUsedPercent% ($usedMemoryGB GB / $totalMemoryGB GB)" -Level Critical
     }
-    elseif($memoryUsedPercent -ge $script:threshold.MemoryWarning) {
+    elseif ($memoryUsedPercent -ge $script:threshold.MemoryWarning) {
         $script:healthReport.Memory.Status = 'Warning'
-        if($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
+        if ($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
         $script:healthReport.Warnings += "Memory utilization elevated: $memoryUsedPercent%"
         Write-ColorOutput "  [WARNING] Memory: $memoryUsedPercent% ($usedMemoryGB GB / $totalMemoryGB GB)" -Level Warning
     }
@@ -612,35 +615,35 @@ function Get-MemoryHealth {
 
     # Get top memory processes
     $topProcesses = Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 5 |
-        Select-Object ProcessName, @{Name='MemoryMB';Expression={[math]::Round($_.WorkingSet64/1MB, 2)}}
+        Select-Object ProcessName, @{Name = 'MemoryMB'; Expression = { [math]::Round($_.WorkingSet64 / 1MB, 2) } }
     $script:healthReport.Memory.TopProcesses = $topProcesses
 }
 
 function Get-DiskHealth {
     Write-Verbose "Checking disk space..."
 
-    $disks = Get-Volume | Where-Object {$_.DriveLetter -and $_.DriveType -eq 'Fixed'}
+    $disks = Get-Volume | Where-Object { $_.DriveLetter -and $_.DriveType -eq 'Fixed' }
 
-    foreach($disk in $disks) {
+    foreach ($disk in $disks) {
         $freeSpacePercent = [math]::Round(($disk.SizeRemaining / $disk.Size) * 100, 2)
         $diskInfo = @{
             DriveLetter = $disk.DriveLetter
             Label = $disk.FileSystemLabel
-            TotalGB = [math]::Round($disk.Size/1GB, 2)
-            FreeGB = [math]::Round($disk.SizeRemaining/1GB, 2)
+            TotalGB = [math]::Round($disk.Size / 1GB, 2)
+            FreeGB = [math]::Round($disk.SizeRemaining / 1GB, 2)
             FreePercent = $freeSpacePercent
             Status = 'OK'
         }
 
-        if($freeSpacePercent -le $script:threshold.DiskCritical) {
+        if ($freeSpacePercent -le $script:threshold.DiskCritical) {
             $diskInfo.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "Drive $($disk.DriveLetter): critically low space ($freeSpacePercent%)"
             Write-ColorOutput "  [CRITICAL] Drive $($disk.DriveLetter): $freeSpacePercent% free ($($diskInfo.FreeGB) GB / $($diskInfo.TotalGB) GB)" -Level Critical
         }
-        elseif($freeSpacePercent -le $script:threshold.DiskWarning) {
+        elseif ($freeSpacePercent -le $script:threshold.DiskWarning) {
             $diskInfo.Status = 'Warning'
-            if($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
+            if ($script:healthReport.Status -ne 'Critical') { $script:healthReport.Status = 'Warning' }
             $script:healthReport.Warnings += "Drive $($disk.DriveLetter): low space ($freeSpacePercent%)"
             Write-ColorOutput "  [WARNING] Drive $($disk.DriveLetter): $freeSpacePercent% free ($($diskInfo.FreeGB) GB / $($diskInfo.TotalGB) GB)" -Level Warning
         }
@@ -662,15 +665,15 @@ function Get-ServiceHealth {
     )
 
     # Add user-specified services
-    if($CheckServices) {
+    if ($CheckServices) {
         $criticalServices += $CheckServices -split ','
     }
 
     $allHealthy = $true
-    foreach($serviceName in $criticalServices) {
+    foreach ($serviceName in $criticalServices) {
         $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 
-        if($service) {
+        if ($service) {
             $serviceInfo = @{
                 Name = $service.Name
                 DisplayName = $service.DisplayName
@@ -679,7 +682,7 @@ function Get-ServiceHealth {
                 Health = 'OK'
             }
 
-            if($service.Status -ne 'Running' -and $service.StartType -eq 'Automatic') {
+            if ($service.Status -ne 'Running' -and $service.StartType -eq 'Automatic') {
                 $serviceInfo.Health = 'Critical'
                 $script:healthReport.Status = 'Critical'
                 $script:healthReport.Issues += "Critical service stopped: $($service.DisplayName)"
@@ -691,7 +694,7 @@ function Get-ServiceHealth {
         }
     }
 
-    if($allHealthy) {
+    if ($allHealthy) {
         Write-ColorOutput "  [OK] All critical services running" -Level Success
     }
 }
@@ -705,19 +708,19 @@ function Get-EventLogHealth {
     try {
         $systemErrors = Get-WinEvent -FilterHashtable @{
             LogName = 'System'
-            Level = 1,2
+            Level = 1, 2
             StartTime = $since
         } -MaxEvents 50 -ErrorAction SilentlyContinue
 
         $appErrors = Get-WinEvent -FilterHashtable @{
             LogName = 'Application'
-            Level = 1,2
+            Level = 1, 2
             StartTime = $since
         } -MaxEvents 50 -ErrorAction SilentlyContinue
 
         $allErrors = @($systemErrors) + @($appErrors) | Sort-Object TimeCreated -Descending
 
-        foreach($err in $allErrors | Select-Object -First 10) {
+        foreach ($err in $allErrors | Select-Object -First 10) {
             $criticalErrors += @{
                 TimeCreated = $err.TimeCreated
                 LogName = $err.LogName
@@ -730,11 +733,11 @@ function Get-EventLogHealth {
 
         $script:healthReport.EventLogErrors = $criticalErrors
 
-        if($criticalErrors.Count -gt 20) {
+        if ($criticalErrors.Count -gt 20) {
             $script:healthReport.Warnings += "High volume of errors in event logs (last 24h): $($criticalErrors.Count)"
             Write-ColorOutput "  [WARNING] Found $($criticalErrors.Count) critical errors in last 24 hours" -Level Warning
         }
-        elseif($criticalErrors.Count -gt 0) {
+        elseif ($criticalErrors.Count -gt 0) {
             Write-ColorOutput "  [INFO] Found $($criticalErrors.Count) errors in last 24 hours"
         }
         else {
@@ -749,9 +752,9 @@ function Get-EventLogHealth {
 function Get-NetworkHealth {
     Write-Verbose "Checking network adapters..."
 
-    $adapters = Get-NetAdapter | Where-Object {$_.Status -eq 'Up'}
+    $adapters = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' }
 
-    foreach($adapter in $adapters) {
+    foreach ($adapter in $adapters) {
         $adapterInfo = @{
             Name = $adapter.Name
             InterfaceDescription = $adapter.InterfaceDescription
@@ -793,14 +796,14 @@ function Get-DiskIOHealth {
         Monitors disk I/O performance metrics.
     #>
 
-    if(-not $IncludeDiskIO) { return }
+    if (-not $IncludeDiskIO) { return }
 
     Write-Verbose "Checking disk I/O performance..."
     $script:healthReport.DiskIO.Enabled = $true
 
     try {
         $samples = @()
-        for($i = 0; $i -lt 3; $i++) {
+        for ($i = 0; $i -lt 3; $i++) {
             $counters = Get-Counter @(
                 '\PhysicalDisk(_Total)\Disk Reads/sec',
                 '\PhysicalDisk(_Total)\Disk Writes/sec',
@@ -817,7 +820,7 @@ function Get-DiskIOHealth {
                 QueueLength = $counters.CounterSamples[4].CookedValue
             }
 
-            if($i -lt 2) { Start-Sleep -Seconds 2 }
+            if ($i -lt 2) { Start-Sleep -Seconds 2 }
         }
 
         $script:healthReport.DiskIO.Samples = $samples
@@ -827,12 +830,12 @@ function Get-DiskIOHealth {
         $script:healthReport.DiskIO.AverageWriteLatencyMs = [math]::Round(($samples | Measure-Object -Property WriteLatency -Average).Average, 2)
         $script:healthReport.DiskIO.AverageQueueLength = [math]::Round(($samples | Measure-Object -Property QueueLength -Average).Average, 2)
 
-        if($script:healthReport.DiskIO.AverageReadLatencyMs -gt 25 -or $script:healthReport.DiskIO.AverageWriteLatencyMs -gt 25) {
+        if ($script:healthReport.DiskIO.AverageReadLatencyMs -gt 25 -or $script:healthReport.DiskIO.AverageWriteLatencyMs -gt 25) {
             $script:healthReport.DiskIO.Status = 'Warning'
             $script:healthReport.Warnings += "High disk latency detected (Read: $($script:healthReport.DiskIO.AverageReadLatencyMs)ms, Write: $($script:healthReport.DiskIO.AverageWriteLatencyMs)ms)"
             Write-ColorOutput "  [WARNING] Disk I/O: High latency" -Level Warning
         }
-        elseif($script:healthReport.DiskIO.AverageQueueLength -gt 2) {
+        elseif ($script:healthReport.DiskIO.AverageQueueLength -gt 2) {
             $script:healthReport.DiskIO.Status = 'Warning'
             $script:healthReport.Warnings += "High disk queue length: $($script:healthReport.DiskIO.AverageQueueLength)"
             Write-ColorOutput "  [WARNING] Disk I/O: High queue length" -Level Warning
@@ -856,12 +859,12 @@ function Get-AdvancedPerformanceMetrics {
 
     try {
         $pageFile = Get-CimInstance Win32_PageFileUsage -ErrorAction SilentlyContinue
-        if($pageFile) {
+        if ($pageFile) {
             $script:healthReport.AdvancedPerformance.PageFile.TotalSizeMB = $pageFile.AllocatedBaseSize
             $script:healthReport.AdvancedPerformance.PageFile.UsedMB = $pageFile.CurrentUsage
             $script:healthReport.AdvancedPerformance.PageFile.UsedPercent = [math]::Round(($pageFile.CurrentUsage / $pageFile.AllocatedBaseSize) * 100, 2)
 
-            if($script:healthReport.AdvancedPerformance.PageFile.UsedPercent -gt 80) {
+            if ($script:healthReport.AdvancedPerformance.PageFile.UsedPercent -gt 80) {
                 $script:healthReport.AdvancedPerformance.PageFile.Status = 'Warning'
                 $script:healthReport.Warnings += "Page file usage high: $($script:healthReport.AdvancedPerformance.PageFile.UsedPercent)%"
             }
@@ -871,12 +874,12 @@ function Get-AdvancedPerformanceMetrics {
         $script:healthReport.AdvancedPerformance.Processes = $os.NumberOfProcesses
 
         $threadCounter = Get-Counter '\System\Threads' -ErrorAction SilentlyContinue
-        if($threadCounter) {
+        if ($threadCounter) {
             $script:healthReport.AdvancedPerformance.Threads = [int]$threadCounter.CounterSamples[0].CookedValue
         }
 
         $handleCounter = Get-Counter '\Process(_Total)\Handle Count' -ErrorAction SilentlyContinue
-        if($handleCounter) {
+        if ($handleCounter) {
             $script:healthReport.AdvancedPerformance.Handles = [int]$handleCounter.CounterSamples[0].CookedValue
         }
 
@@ -893,16 +896,16 @@ function Get-WindowsUpdateHealth {
         Checks Windows Update status and pending updates.
     #>
 
-    if(-not $IncludeWindowsUpdate) { return }
+    if (-not $IncludeWindowsUpdate) { return }
 
     Write-Verbose "Checking Windows Update status..."
     $script:healthReport.WindowsUpdate.Enabled = $true
 
     try {
         $wuService = Get-Service -Name wuauserv -ErrorAction SilentlyContinue
-        if($wuService) {
+        if ($wuService) {
             $script:healthReport.WindowsUpdate.WindowsUpdateService = $wuService.Status
-            if($wuService.Status -ne 'Running' -and $wuService.StartType -eq 'Automatic') {
+            if ($wuService.Status -ne 'Running' -and $wuService.StartType -eq 'Automatic') {
                 $script:healthReport.Warnings += "Windows Update service is not running"
             }
         }
@@ -913,8 +916,8 @@ function Get-WindowsUpdateHealth {
             'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
         )
 
-        foreach($key in $rebootKeys) {
-            if(Test-Path $key) {
+        foreach ($key in $rebootKeys) {
+            if (Test-Path $key) {
                 $rebootPending = $true
                 break
             }
@@ -926,29 +929,29 @@ function Get-WindowsUpdateHealth {
         $searchResult = $updateSearcher.Search("IsInstalled=0 and IsHidden=0")
 
         $script:healthReport.WindowsUpdate.UpdatesPending = $searchResult.Updates.Count
-        foreach($update in $searchResult.Updates) {
+        foreach ($update in $searchResult.Updates) {
             $script:healthReport.WindowsUpdate.PendingUpdates += @{
                 Title = $update.Title
-                Severity = if($update.MsrcSeverity) { $update.MsrcSeverity } else { 'Unknown' }
+                Severity = if ($update.MsrcSeverity) { $update.MsrcSeverity } else { 'Unknown' }
                 IsDownloaded = $update.IsDownloaded
                 IsMandatory = $update.IsMandatory
-                KB = if($update.KBArticleIDs.Count -gt 0) { $update.KBArticleIDs[0] } else { 'N/A' }
+                KB = if ($update.KBArticleIDs.Count -gt 0) { $update.KBArticleIDs[0] } else { 'N/A' }
             }
         }
 
         $updateHistory = $updateSearcher.QueryHistory(0, 10)
         $successfulUpdates = $updateHistory | Where-Object { $_.ResultCode -eq 2 } | Sort-Object Date -Descending
-        if($successfulUpdates) {
+        if ($successfulUpdates) {
             $script:healthReport.WindowsUpdate.LastSuccessfulUpdate = $successfulUpdates[0].Date
             $script:healthReport.WindowsUpdate.UpdatesInstalled = $successfulUpdates.Count
         }
 
-        if($script:healthReport.WindowsUpdate.UpdatesPending -gt 10) {
+        if ($script:healthReport.WindowsUpdate.UpdatesPending -gt 10) {
             $script:healthReport.WindowsUpdate.Status = 'Warning'
             $script:healthReport.Warnings += "Many pending updates: $($script:healthReport.WindowsUpdate.UpdatesPending)"
             Write-ColorOutput "  [WARNING] Windows Update: $($script:healthReport.WindowsUpdate.UpdatesPending) pending updates" -Level Warning
         }
-        elseif($rebootPending) {
+        elseif ($rebootPending) {
             $script:healthReport.WindowsUpdate.Status = 'Warning'
             $script:healthReport.Warnings += "Reboot required for updates"
             Write-ColorOutput "  [WARNING] Windows Update: Reboot required" -Level Warning
@@ -968,15 +971,15 @@ function Get-SecurityHealth {
         Monitors security settings: Firewall, Defender, failed logins.
     #>
 
-    if(-not $IncludeSecurity) { return }
+    if (-not $IncludeSecurity) { return }
 
     Write-Verbose "Checking security configuration..."
     $script:healthReport.Security.Enabled = $true
 
     try {
         $fwProfiles = Get-NetFirewallProfile -ErrorAction Stop
-        foreach($profile in $fwProfiles) {
-            switch($profile.Name) {
+        foreach ($profile in $fwProfiles) {
+            switch ($profile.Name) {
                 'Domain' { $script:healthReport.Security.Firewall.DomainProfile = $profile.Enabled }
                 'Private' { $script:healthReport.Security.Firewall.PrivateProfile = $profile.Enabled }
                 'Public' { $script:healthReport.Security.Firewall.PublicProfile = $profile.Enabled }
@@ -984,10 +987,10 @@ function Get-SecurityHealth {
         }
 
         $allEnabled = ($script:healthReport.Security.Firewall.DomainProfile -and
-                       $script:healthReport.Security.Firewall.PrivateProfile -and
-                       $script:healthReport.Security.Firewall.PublicProfile)
+            $script:healthReport.Security.Firewall.PrivateProfile -and
+            $script:healthReport.Security.Firewall.PublicProfile)
 
-        if(-not $allEnabled) {
+        if (-not $allEnabled) {
             $script:healthReport.Security.Firewall.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "Windows Firewall is disabled on one or more profiles"
@@ -1003,26 +1006,26 @@ function Get-SecurityHealth {
 
     try {
         $defenderService = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
-        if($defenderService) {
+        if ($defenderService) {
             $script:healthReport.Security.Defender.ServiceRunning = ($defenderService.Status -eq 'Running')
 
             $mpPreference = Get-MpPreference -ErrorAction SilentlyContinue
             $mpComputerStatus = Get-MpComputerStatus -ErrorAction SilentlyContinue
 
-            if($mpPreference) {
+            if ($mpPreference) {
                 $script:healthReport.Security.Defender.RealTimeProtection = $mpPreference.DisableRealtimeMonitoring -eq $false
             }
 
-            if($mpComputerStatus) {
+            if ($mpComputerStatus) {
                 $script:healthReport.Security.Defender.SignatureAge = $mpComputerStatus.AntivirusSignatureAge
                 $script:healthReport.Security.Defender.LastScan = $mpComputerStatus.QuickScanEndTime
 
-                if($mpComputerStatus.AntivirusSignatureAge -gt 7) {
+                if ($mpComputerStatus.AntivirusSignatureAge -gt 7) {
                     $script:healthReport.Security.Defender.Status = 'Warning'
                     $script:healthReport.Warnings += "Defender signatures outdated: $($mpComputerStatus.AntivirusSignatureAge) days"
                     Write-ColorOutput "  [WARNING] Defender: Signatures $($mpComputerStatus.AntivirusSignatureAge) days old" -Level Warning
                 }
-                elseif(-not $script:healthReport.Security.Defender.RealTimeProtection) {
+                elseif (-not $script:healthReport.Security.Defender.RealTimeProtection) {
                     $script:healthReport.Security.Defender.Status = 'Critical'
                     $script:healthReport.Status = 'Critical'
                     $script:healthReport.Issues += "Defender real-time protection is disabled"
@@ -1046,10 +1049,10 @@ function Get-SecurityHealth {
             StartTime = $since
         } -MaxEvents 100 -ErrorAction SilentlyContinue
 
-        if($failedLogins) {
+        if ($failedLogins) {
             $script:healthReport.Security.FailedLogins.Last24Hours = $failedLogins.Count
 
-            foreach($login in ($failedLogins | Select-Object -First 10)) {
+            foreach ($login in ($failedLogins | Select-Object -First 10)) {
                 $xml = [xml]$login.ToXml()
                 $script:healthReport.Security.FailedLogins.RecentAttempts += @{
                     TimeCreated = $login.TimeCreated
@@ -1060,7 +1063,7 @@ function Get-SecurityHealth {
                 }
             }
 
-            if($failedLogins.Count -gt 50) {
+            if ($failedLogins.Count -gt 50) {
                 $script:healthReport.Security.FailedLogins.Status = 'Warning'
                 $script:healthReport.Warnings += "High number of failed login attempts: $($failedLogins.Count)"
                 Write-ColorOutput "  [WARNING] Security: $($failedLogins.Count) failed logins in 24h" -Level Warning
@@ -1084,7 +1087,7 @@ function Get-NetworkConnectivityHealth {
         Tests network connectivity to gateway, DNS, and internet.
     #>
 
-    if(-not $IncludeNetworkTests) { return }
+    if (-not $IncludeNetworkTests) { return }
 
     Write-Verbose "Testing network connectivity..."
     $script:healthReport.NetworkTests.Enabled = $true
@@ -1095,7 +1098,7 @@ function Get-NetworkConnectivityHealth {
         $script:healthReport.NetworkTests.Gateway.IP = $gatewayIP
 
         $ping = Test-Connection -ComputerName $gatewayIP -Count 2 -ErrorAction SilentlyContinue
-        if($ping) {
+        if ($ping) {
             $script:healthReport.NetworkTests.Gateway.Reachable = $true
             $script:healthReport.NetworkTests.Gateway.Latency = [math]::Round(($ping.ResponseTime | Measure-Object -Average).Average, 2)
             Write-ColorOutput "  [OK] Gateway: $gatewayIP ($($script:healthReport.NetworkTests.Gateway.Latency)ms)" -Level Success
@@ -1113,10 +1116,10 @@ function Get-NetworkConnectivityHealth {
 
     try {
         $dnsServers = Get-DnsClientServerAddress -AddressFamily IPv4 |
-            Where-Object {$_.ServerAddresses.Count -gt 0} |
+            Where-Object { $_.ServerAddresses.Count -gt 0 } |
             Select-Object -First 1
 
-        if($dnsServers) {
+        if ($dnsServers) {
             $dnsIP = $dnsServers.ServerAddresses[0]
             $script:healthReport.NetworkTests.DNS.PrimaryServer = $dnsIP
 
@@ -1126,7 +1129,7 @@ function Get-NetworkConnectivityHealth {
             $dnsTest = Resolve-DnsName -Name 'www.microsoft.com' -ErrorAction SilentlyContinue
             $script:healthReport.NetworkTests.DNS.ResolutionWorking = ($dnsTest -ne $null)
 
-            if($script:healthReport.NetworkTests.DNS.ResolutionWorking) {
+            if ($script:healthReport.NetworkTests.DNS.ResolutionWorking) {
                 Write-ColorOutput "  [OK] DNS: Server $dnsIP, resolution working" -Level Success
             }
             else {
@@ -1145,7 +1148,7 @@ function Get-NetworkConnectivityHealth {
         $script:healthReport.NetworkTests.Internet.Target = $internetTarget
 
         $internetPing = Test-Connection -ComputerName $internetTarget -Count 2 -ErrorAction SilentlyContinue
-        if($internetPing) {
+        if ($internetPing) {
             $script:healthReport.NetworkTests.Internet.Reachable = $true
             $script:healthReport.NetworkTests.Internet.Latency = [math]::Round(($internetPing.ResponseTime | Measure-Object -Average).Average, 2)
             Write-ColorOutput "  [OK] Internet: Reachable ($($script:healthReport.NetworkTests.Internet.Latency)ms)" -Level Success
@@ -1166,7 +1169,7 @@ function Get-CertificateHealth {
         Checks certificate expiration in local computer stores.
     #>
 
-    if(-not $IncludeCertificates) { return }
+    if (-not $IncludeCertificates) { return }
 
     Write-Verbose "Checking certificate expiration..."
     $script:healthReport.Certificates.Enabled = $true
@@ -1181,11 +1184,11 @@ function Get-CertificateHealth {
         $now = Get-Date
         $warningDate = $now.AddDays($CertificateWarningDays)
 
-        foreach($storePath in $storePaths) {
-            if(Test-Path $storePath) {
+        foreach ($storePath in $storePaths) {
+            if (Test-Path $storePath) {
                 $certs = Get-ChildItem -Path $storePath -ErrorAction SilentlyContinue
 
-                foreach($cert in $certs) {
+                foreach ($cert in $certs) {
                     $daysUntilExpiry = ($cert.NotAfter - $now).Days
 
                     $certInfo = @{
@@ -1198,11 +1201,11 @@ function Get-CertificateHealth {
                         Status = 'OK'
                     }
 
-                    if($cert.NotAfter -lt $now) {
+                    if ($cert.NotAfter -lt $now) {
                         $certInfo.Status = 'Expired'
                         $script:healthReport.Certificates.Expired++
                     }
-                    elseif($cert.NotAfter -lt $warningDate) {
+                    elseif ($cert.NotAfter -lt $warningDate) {
                         $certInfo.Status = 'Expiring'
                         $script:healthReport.Certificates.Expiring++
                     }
@@ -1212,13 +1215,13 @@ function Get-CertificateHealth {
             }
         }
 
-        if($script:healthReport.Certificates.Expired -gt 0) {
+        if ($script:healthReport.Certificates.Expired -gt 0) {
             $script:healthReport.Certificates.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "Expired certificates found: $($script:healthReport.Certificates.Expired)"
             Write-ColorOutput "  [CRITICAL] Certificates: $($script:healthReport.Certificates.Expired) expired" -Level Critical
         }
-        elseif($script:healthReport.Certificates.Expiring -gt 0) {
+        elseif ($script:healthReport.Certificates.Expiring -gt 0) {
             $script:healthReport.Certificates.Status = 'Warning'
             $script:healthReport.Warnings += "Certificates expiring soon: $($script:healthReport.Certificates.Expiring)"
             Write-ColorOutput "  [WARNING] Certificates: $($script:healthReport.Certificates.Expiring) expiring within $CertificateWarningDays days" -Level Warning
@@ -1238,16 +1241,16 @@ function Get-ScheduledTasksHealth {
         Monitors scheduled tasks for failures and disabled tasks.
     #>
 
-    if(-not $IncludeScheduledTasks) { return }
+    if (-not $IncludeScheduledTasks) { return }
 
     Write-Verbose "Checking scheduled tasks..."
     $script:healthReport.ScheduledTasks.Enabled = $true
 
     try {
         $tasks = Get-ScheduledTask -ErrorAction Stop |
-            Where-Object {$_.TaskPath -notlike '\Microsoft\*'}
+            Where-Object { $_.TaskPath -notlike '\Microsoft\*' }
 
-        foreach($task in $tasks) {
+        foreach ($task in $tasks) {
             $taskInfo = Get-ScheduledTaskInfo -TaskName $task.TaskName -TaskPath $task.TaskPath -ErrorAction SilentlyContinue
 
             $taskData = @{
@@ -1260,12 +1263,12 @@ function Get-ScheduledTasksHealth {
                 Status = 'OK'
             }
 
-            if($taskInfo.LastTaskResult -ne 0 -and $taskInfo.LastTaskResult -ne $null) {
+            if ($taskInfo.LastTaskResult -ne 0 -and $taskInfo.LastTaskResult -ne $null) {
                 $taskData.Status = 'Failed'
                 $script:healthReport.ScheduledTasks.Failed++
             }
 
-            if($task.State -eq 'Disabled') {
+            if ($task.State -eq 'Disabled') {
                 $taskData.Status = 'Disabled'
                 $script:healthReport.ScheduledTasks.Disabled++
             }
@@ -1273,7 +1276,7 @@ function Get-ScheduledTasksHealth {
             $script:healthReport.ScheduledTasks.Tasks += $taskData
         }
 
-        if($script:healthReport.ScheduledTasks.Failed -gt 0) {
+        if ($script:healthReport.ScheduledTasks.Failed -gt 0) {
             $script:healthReport.ScheduledTasks.Status = 'Warning'
             $script:healthReport.Warnings += "Failed scheduled tasks: $($script:healthReport.ScheduledTasks.Failed)"
             Write-ColorOutput "  [WARNING] Scheduled Tasks: $($script:healthReport.ScheduledTasks.Failed) failed" -Level Warning
@@ -1293,7 +1296,7 @@ function Get-IISHealth {
         Monitors IIS application pools and websites (if IIS is installed).
     #>
 
-    if(-not $CheckIIS -and -not $IncludeApplications) { return }
+    if (-not $CheckIIS -and -not $IncludeApplications) { return }
 
     Write-Verbose "Checking IIS health..."
     $script:healthReport.Applications.IIS.Enabled = $true
@@ -1309,12 +1312,12 @@ function Get-IISHealth {
 
     try {
         $iisService = Get-Service -Name W3SVC -ErrorAction SilentlyContinue
-        if($iisService) {
+        if ($iisService) {
             $script:healthReport.Applications.IIS.Running = ($iisService.Status -eq 'Running')
         }
 
         $appPools = Get-IISAppPool -ErrorAction Stop
-        foreach($pool in $appPools) {
+        foreach ($pool in $appPools) {
             $poolInfo = @{
                 Name = $pool.Name
                 State = $pool.State
@@ -1324,7 +1327,7 @@ function Get-IISHealth {
                 Status = 'OK'
             }
 
-            if($pool.State -ne 'Started') {
+            if ($pool.State -ne 'Started') {
                 $script:healthReport.Applications.IIS.FailedPools++
                 $poolInfo.Status = 'Stopped'
             }
@@ -1333,7 +1336,7 @@ function Get-IISHealth {
         }
 
         $sites = Get-IISSite -ErrorAction Stop
-        foreach($site in $sites) {
+        foreach ($site in $sites) {
             $siteInfo = @{
                 Name = $site.Name
                 State = $site.State
@@ -1343,7 +1346,7 @@ function Get-IISHealth {
                 Status = 'OK'
             }
 
-            if($site.State -ne 'Started') {
+            if ($site.State -ne 'Started') {
                 $script:healthReport.Applications.IIS.StoppedSites++
                 $siteInfo.Status = 'Stopped'
             }
@@ -1351,14 +1354,14 @@ function Get-IISHealth {
             $script:healthReport.Applications.IIS.Websites += $siteInfo
         }
 
-        if($script:healthReport.Applications.IIS.FailedPools -gt 0 -or
-           $script:healthReport.Applications.IIS.StoppedSites -gt 0) {
+        if ($script:healthReport.Applications.IIS.FailedPools -gt 0 -or
+            $script:healthReport.Applications.IIS.StoppedSites -gt 0) {
             $script:healthReport.Applications.IIS.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "IIS: $($script:healthReport.Applications.IIS.FailedPools) stopped pools, $($script:healthReport.Applications.IIS.StoppedSites) stopped sites"
             Write-ColorOutput "  [CRITICAL] IIS: Stopped application pools or websites detected" -Level Critical
         }
-        elseif(-not $script:healthReport.Applications.IIS.Running) {
+        elseif (-not $script:healthReport.Applications.IIS.Running) {
             $script:healthReport.Applications.IIS.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "IIS service is not running"
@@ -1379,13 +1382,13 @@ function Get-SQLServerHealth {
         Monitors SQL Server instances and databases (if SQL Server is installed).
     #>
 
-    if(-not $CheckSQLServer -and -not $IncludeApplications) { return }
+    if (-not $CheckSQLServer -and -not $IncludeApplications) { return }
 
     Write-Verbose "Checking SQL Server health..."
     $script:healthReport.Applications.SQLServer.Enabled = $true
 
-    $sqlService = Get-Service -Name 'MSSQLSERVER','MSSQL$*' -ErrorAction SilentlyContinue
-    if(-not $sqlService) {
+    $sqlService = Get-Service -Name 'MSSQLSERVER', 'MSSQL$*' -ErrorAction SilentlyContinue
+    if (-not $sqlService) {
         Write-ColorOutput "  [INFO] SQL Server not installed" -Level Info
         return
     }
@@ -1393,7 +1396,7 @@ function Get-SQLServerHealth {
     $script:healthReport.Applications.SQLServer.Installed = $true
     $script:healthReport.Applications.SQLServer.Running = ($sqlService[0].Status -eq 'Running')
 
-    if(-not $script:healthReport.Applications.SQLServer.Running) {
+    if (-not $script:healthReport.Applications.SQLServer.Running) {
         $script:healthReport.Applications.SQLServer.Status = 'Critical'
         $script:healthReport.Status = 'Critical'
         $script:healthReport.Issues += "SQL Server service is not running"
@@ -1415,7 +1418,7 @@ function Get-HyperVHealth {
         Monitors Hyper-V host and virtual machines (if Hyper-V is installed).
     #>
 
-    if(-not $CheckHyperV -and -not $IncludeApplications) { return }
+    if (-not $CheckHyperV -and -not $IncludeApplications) { return }
 
     Write-Verbose "Checking Hyper-V health..."
     $script:healthReport.Applications.HyperV.Enabled = $true
@@ -1431,11 +1434,11 @@ function Get-HyperVHealth {
 
     try {
         $vmmsService = Get-Service -Name vmms -ErrorAction SilentlyContinue
-        if($vmmsService) {
+        if ($vmmsService) {
             $script:healthReport.Applications.HyperV.Running = ($vmmsService.Status -eq 'Running')
         }
 
-        if(-not $script:healthReport.Applications.HyperV.Running) {
+        if (-not $script:healthReport.Applications.HyperV.Running) {
             $script:healthReport.Applications.HyperV.Status = 'Critical'
             $script:healthReport.Status = 'Critical'
             $script:healthReport.Issues += "Hyper-V service is not running"
@@ -1444,20 +1447,20 @@ function Get-HyperVHealth {
         }
 
         $vms = Get-VM -ErrorAction Stop
-        foreach($vm in $vms) {
+        foreach ($vm in $vms) {
             $vmInfo = @{
                 Name = $vm.Name
                 State = $vm.State
                 CPUUsage = $vm.CPUUsage
                 MemoryMB = [math]::Round($vm.MemoryAssigned / 1MB, 0)
                 Uptime = $vm.Uptime
-                Status = if($vm.State -eq 'Running') { 'OK' } else { 'Stopped' }
+                Status = if ($vm.State -eq 'Running') { 'OK' } else { 'Stopped' }
             }
 
             $script:healthReport.Applications.HyperV.VirtualMachines += $vmInfo
         }
 
-        $runningVMs = ($vms | Where-Object {$_.State -eq 'Running'}).Count
+        $runningVMs = ($vms | Where-Object { $_.State -eq 'Running' }).Count
         Write-ColorOutput "  [OK] Hyper-V: $($vms.Count) VMs ($runningVMs running)" -Level Success
     }
     catch {
@@ -1494,9 +1497,9 @@ function Send-EmailReport {
         [string]$HTMLReportPath
     )
 
-    if(-not $EmailReport) { return }
+    if (-not $EmailReport) { return }
 
-    if(-not $SMTPServer -or -not $EmailFrom -or -not $EmailTo) {
+    if (-not $SMTPServer -or -not $EmailFrom -or -not $EmailTo) {
         Write-ColorOutput "`n[WARNING] Email reporting requires -SMTPServer, -EmailFrom, and -EmailTo parameters" -Level Warning
         return
     }
@@ -1552,20 +1555,20 @@ function Send-EmailReport {
         # preserving the port, SSL, credential, and attachment parameters.
         $smtpClient = New-Object System.Net.Mail.SmtpClient($SMTPServer, $SMTPPort)
         $smtpClient.EnableSsl = [bool]$UseSSL
-        if($SMTPCredential) {
+        if ($SMTPCredential) {
             $smtpClient.Credentials = $SMTPCredential.GetNetworkCredential()
         }
 
         $mailMessage = New-Object System.Net.Mail.MailMessage
         $mailMessage.From = (New-Object System.Net.Mail.MailAddress($EmailFrom))
-        foreach($recipient in $EmailTo) {
+        foreach ($recipient in $EmailTo) {
             $mailMessage.To.Add($recipient)
         }
         $mailMessage.Subject = $EmailSubject
         $mailMessage.Body = $emailBody
         $mailMessage.IsBodyHtml = $true
 
-        if($HTMLReportPath -and (Test-Path $HTMLReportPath)) {
+        if ($HTMLReportPath -and (Test-Path $HTMLReportPath)) {
             $mailMessage.Attachments.Add((New-Object System.Net.Mail.Attachment($HTMLReportPath)))
         }
 
@@ -1583,7 +1586,7 @@ function Send-EmailReport {
 function Export-HTMLReport {
     $reportPath = "$ReportDir\ServerHealth_$($env:COMPUTERNAME)_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
 
-    $statusColor = switch($script:healthReport.Status) {
+    $statusColor = switch ($script:healthReport.Status) {
         'Critical' { '#dc3545' }
         'Warning' { '#ffc107' }
         default { '#28a745' }
@@ -1856,30 +1859,30 @@ function Export-HTMLReport {
 
 # Check if running in interactive mode (no significant parameters provided)
 $interactiveModeParams = @('IncludeDiskIO', 'IncludeWindowsUpdate', 'IncludeSecurity', 'IncludeNetworkTests',
-                           'IncludeApplications', 'IncludeCertificates', 'IncludeScheduledTasks',
-                           'CheckIIS', 'CheckSQLServer', 'CheckHyperV', 'ExportJSON', 'ShowProgress')
+    'IncludeApplications', 'IncludeCertificates', 'IncludeScheduledTasks',
+    'CheckIIS', 'CheckSQLServer', 'CheckHyperV', 'ExportJSON', 'ShowProgress')
 
 $hasOptionalParams = $false
-foreach($param in $interactiveModeParams) {
-    if(Get-Variable -Name $param -ValueOnly -ErrorAction SilentlyContinue) {
+foreach ($param in $interactiveModeParams) {
+    if (Get-Variable -Name $param -ValueOnly -ErrorAction SilentlyContinue) {
         $hasOptionalParams = $true
         break
     }
 }
 
-if(-not $hasOptionalParams -and -not $ExportReport -and -not $EmailReport) {
+if (-not $hasOptionalParams -and -not $ExportReport -and -not $EmailReport) {
     Show-InteractiveMenu
 }
 
 # Calculate total steps for progress tracking
 $totalSteps = 7  # Base checks (CPU, Memory, Disk, Services, Events, Network, SystemInfo)
-if($IncludeDiskIO) { $totalSteps++ }
-if($IncludeWindowsUpdate) { $totalSteps++ }
-if($IncludeSecurity) { $totalSteps++ }
-if($IncludeNetworkTests) { $totalSteps++ }
-if($IncludeCertificates) { $totalSteps++ }
-if($IncludeScheduledTasks) { $totalSteps++ }
-if($CheckIIS -or $IncludeApplications) { $totalSteps += 3 }  # IIS, SQL, Hyper-V
+if ($IncludeDiskIO) { $totalSteps++ }
+if ($IncludeWindowsUpdate) { $totalSteps++ }
+if ($IncludeSecurity) { $totalSteps++ }
+if ($IncludeNetworkTests) { $totalSteps++ }
+if ($IncludeCertificates) { $totalSteps++ }
+if ($IncludeScheduledTasks) { $totalSteps++ }
+if ($CheckIIS -or $IncludeApplications) { $totalSteps += 3 }  # IIS, SQL, Hyper-V
 $totalSteps++  # Advanced metrics (always runs)
 
 $currentStep = 0
@@ -1903,7 +1906,7 @@ Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server H
 Get-DiskHealth
 
 # Optional: Disk I/O
-if($IncludeDiskIO) {
+if ($IncludeDiskIO) {
     Write-Host "`nChecking Disk I/O..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Disk I/O..."
     Get-DiskIOHealth
@@ -1925,54 +1928,54 @@ Get-NetworkHealth
 Get-AdvancedPerformanceMetrics
 
 # Optional: Windows Update
-if($IncludeWindowsUpdate) {
+if ($IncludeWindowsUpdate) {
     Write-Host "`nChecking Windows Update..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Windows Update..."
     Get-WindowsUpdateHealth
 }
 
 # Optional: Security
-if($IncludeSecurity) {
+if ($IncludeSecurity) {
     Write-Host "`nChecking Security..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Security..."
     Get-SecurityHealth
 }
 
 # Optional: Network Tests
-if($IncludeNetworkTests) {
+if ($IncludeNetworkTests) {
     Write-Host "`nTesting Network Connectivity..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Testing Network..."
     Get-NetworkConnectivityHealth
 }
 
 # Optional: Certificates
-if($IncludeCertificates) {
+if ($IncludeCertificates) {
     Write-Host "`nChecking Certificates..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Certificates..."
     Get-CertificateHealth
 }
 
 # Optional: Scheduled Tasks
-if($IncludeScheduledTasks) {
+if ($IncludeScheduledTasks) {
     Write-Host "`nChecking Scheduled Tasks..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Scheduled Tasks..."
     Get-ScheduledTasksHealth
 }
 
 # Optional: Applications
-if($CheckIIS -or $IncludeApplications) {
+if ($CheckIIS -or $IncludeApplications) {
     Write-Host "`nChecking IIS..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking IIS..."
     Get-IISHealth
 }
 
-if($CheckSQLServer -or $IncludeApplications) {
+if ($CheckSQLServer -or $IncludeApplications) {
     Write-Host "`nChecking SQL Server..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking SQL Server..."
     Get-SQLServerHealth
 }
 
-if($CheckHyperV -or $IncludeApplications) {
+if ($CheckHyperV -or $IncludeApplications) {
     Write-Host "`nChecking Hyper-V..." -ForegroundColor Cyan
     Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server Health Check" -Status "Checking Hyper-V..."
     Get-HyperVHealth
@@ -1983,7 +1986,7 @@ Update-Progress -Current (++$currentStep) -Total $totalSteps -Activity "Server H
 Get-SystemInfo
 
 # Complete progress
-if($ShowProgress) {
+if ($ShowProgress) {
     Write-Progress -Activity "Server Health Check" -Completed
 }
 
@@ -1993,35 +1996,35 @@ Write-Host "  Health Check Summary" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "Server: $($script:healthReport.ServerName)"
 Write-Host "Status: " -NoNewline
-switch($script:healthReport.Status) {
+switch ($script:healthReport.Status) {
     'Critical' { Write-Host "CRITICAL" -ForegroundColor Red }
     'Warning' { Write-Host "WARNING" -ForegroundColor Yellow }
     default { Write-Host "HEALTHY" -ForegroundColor Green }
 }
 
-if($script:healthReport.Issues.Count -gt 0) {
+if ($script:healthReport.Issues.Count -gt 0) {
     Write-Host "`nCritical Issues:" -ForegroundColor Red
     $script:healthReport.Issues | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
 }
 
-if($script:healthReport.Warnings.Count -gt 0) {
+if ($script:healthReport.Warnings.Count -gt 0) {
     Write-Host "`nWarnings:" -ForegroundColor Yellow
     $script:healthReport.Warnings | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
 }
 
 # Export reports
 $htmlPath = $null
-if($ExportReport) {
+if ($ExportReport) {
     Write-Host "`nGenerating HTML report..." -ForegroundColor Cyan
     $htmlPath = Export-HTMLReport
 }
 
-if($ExportJSON) {
+if ($ExportJSON) {
     Write-Host "Generating JSON report..." -ForegroundColor Cyan
     Export-JSONReport
 }
 
-if($EmailReport) {
+if ($EmailReport) {
     Write-Host "Sending email report..." -ForegroundColor Cyan
     Send-EmailReport -HTMLReportPath $htmlPath
 }

--- a/scripts/infrastructure/windows/network/Get-FirewallRulesReport.ps1
+++ b/scripts/infrastructure/windows/network/Get-FirewallRulesReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Documents and exports Windows Firewall rules for Windows Server 2016-2022.
 
@@ -50,26 +50,26 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Inbound','Outbound','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Inbound', 'Outbound', 'All')]
     [string]$Direction = 'All',
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Enabled','Disabled','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Enabled', 'Disabled', 'All')]
     [string]$Enabled = 'Enabled',
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Allow','Block','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Allow', 'Block', 'All')]
     [string]$Action = 'All',
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Domain','Private','Public','Any','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Domain', 'Private', 'Public', 'Any', 'All')]
     [string]$Profile = 'All',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -112,7 +112,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -129,32 +129,32 @@ function Get-FirewallRules {
     $rules = Get-NetFirewallRule
 
     # Apply filters
-    if($Direction -ne 'All') {
-        $rules = $rules | Where-Object {$_.Direction -eq $Direction}
+    if ($Direction -ne 'All') {
+        $rules = $rules | Where-Object { $_.Direction -eq $Direction }
     }
 
-    if($Enabled -eq 'Enabled') {
-        $rules = $rules | Where-Object {$_.Enabled -eq 'True'}
+    if ($Enabled -eq 'Enabled') {
+        $rules = $rules | Where-Object { $_.Enabled -eq 'True' }
     }
-    elseif($Enabled -eq 'Disabled') {
-        $rules = $rules | Where-Object {$_.Enabled -eq 'False'}
-    }
-
-    if($Action -ne 'All') {
-        $rules = $rules | Where-Object {$_.Action -eq $Action}
+    elseif ($Enabled -eq 'Disabled') {
+        $rules = $rules | Where-Object { $_.Enabled -eq 'False' }
     }
 
-    if($Profile -ne 'All') {
-        $rules = $rules | Where-Object {$_.Profile -match $Profile}
+    if ($Action -ne 'All') {
+        $rules = $rules | Where-Object { $_.Action -eq $Action }
+    }
+
+    if ($Profile -ne 'All') {
+        $rules = $rules | Where-Object { $_.Profile -match $Profile }
     }
 
     Write-ColorOutput "  Found $($rules.Count) matching firewall rules" -Level Info
     Write-Host "  Collecting rule details..." -ForegroundColor Gray
 
     $ruleCount = 0
-    foreach($rule in $rules) {
+    foreach ($rule in $rules) {
         $ruleCount++
-        if($ruleCount % 100 -eq 0) {
+        if ($ruleCount % 100 -eq 0) {
             Write-Progress -Activity "Processing firewall rules" -Status "Processed $ruleCount of $($rules.Count)" -PercentComplete (($ruleCount / $rules.Count) * 100)
         }
 
@@ -171,13 +171,13 @@ function Get-FirewallRules {
             Direction = $rule.Direction
             Action = $rule.Action
             Profile = $rule.Profile
-            LocalPort = if($portFilter.LocalPort) { $portFilter.LocalPort -join ',' } else { 'Any' }
-            RemotePort = if($portFilter.RemotePort) { $portFilter.RemotePort -join ',' } else { 'Any' }
-            Protocol = if($portFilter.Protocol) { $portFilter.Protocol } else { 'Any' }
-            Program = if($appFilter.Program) { $appFilter.Program } else { 'Any' }
-            Service = if($serviceFilter.Service) { $serviceFilter.Service } else { 'Any' }
-            LocalAddress = if($addressFilter.LocalAddress) { $addressFilter.LocalAddress -join ',' } else { 'Any' }
-            RemoteAddress = if($addressFilter.RemoteAddress) { $addressFilter.RemoteAddress -join ',' } else { 'Any' }
+            LocalPort = if ($portFilter.LocalPort) { $portFilter.LocalPort -join ',' } else { 'Any' }
+            RemotePort = if ($portFilter.RemotePort) { $portFilter.RemotePort -join ',' } else { 'Any' }
+            Protocol = if ($portFilter.Protocol) { $portFilter.Protocol } else { 'Any' }
+            Program = if ($appFilter.Program) { $appFilter.Program } else { 'Any' }
+            Service = if ($serviceFilter.Service) { $serviceFilter.Service } else { 'Any' }
+            LocalAddress = if ($addressFilter.LocalAddress) { $addressFilter.LocalAddress -join ',' } else { 'Any' }
+            RemoteAddress = if ($addressFilter.RemoteAddress) { $addressFilter.RemoteAddress -join ',' } else { 'Any' }
             Description = $rule.Description
             Group = $rule.Group
             EdgeTraversal = $rule.EdgeTraversalPolicy
@@ -188,21 +188,21 @@ function Get-FirewallRules {
         # Update statistics
         $script:report.Summary.TotalRules++
 
-        if($rule.Direction -eq 'Inbound') {
+        if ($rule.Direction -eq 'Inbound') {
             $script:report.Summary.InboundRules++
         }
         else {
             $script:report.Summary.OutboundRules++
         }
 
-        if($rule.Action -eq 'Allow') {
+        if ($rule.Action -eq 'Allow') {
             $script:report.Summary.AllowRules++
         }
         else {
             $script:report.Summary.BlockRules++
         }
 
-        if($rule.Enabled -eq 'True') {
+        if ($rule.Enabled -eq 'True') {
             $script:report.Summary.EnabledRules++
         }
         else {
@@ -218,7 +218,7 @@ function Get-FirewallProfiles {
 
     $profiles = Get-NetFirewallProfile
 
-    foreach($profile in $profiles) {
+    foreach ($profile in $profiles) {
         $script:report.Profiles[$profile.Name] = @{
             Enabled = $profile.Enabled
             DefaultInboundAction = $profile.DefaultInboundAction
@@ -235,8 +235,8 @@ function Get-FirewallProfiles {
             LogIgnored = $profile.LogIgnored
         }
 
-        $statusText = if($profile.Enabled) { "Enabled" } else { "Disabled" }
-        $statusColor = if($profile.Enabled) { 'Success' } else { 'Warning' }
+        $statusText = if ($profile.Enabled) { "Enabled" } else { "Disabled" }
+        $statusColor = if ($profile.Enabled) { 'Success' } else { 'Warning' }
         Write-ColorOutput "  $($profile.Name): $statusText (In: $($profile.DefaultInboundAction), Out: $($profile.DefaultOutboundAction))" -Level $statusColor
     }
 }
@@ -261,8 +261,8 @@ function Show-Summary {
     Write-Host "  Enabled: $($script:report.Summary.EnabledRules) | Disabled: $($script:report.Summary.DisabledRules)"
 
     Write-Host "`nFirewall Profiles:" -ForegroundColor Cyan
-    foreach($profile in $script:report.Profiles.GetEnumerator()) {
-        $statusText = if($profile.Value.Enabled) { "Enabled" } else { "Disabled" }
+    foreach ($profile in $script:report.Profiles.GetEnumerator()) {
+        $statusText = if ($profile.Value.Enabled) { "Enabled" } else { "Disabled" }
         Write-Host "  $($profile.Key): $statusText"
         Write-Host "    Default Inbound: $($profile.Value.DefaultInboundAction)"
         Write-Host "    Default Outbound: $($profile.Value.DefaultOutboundAction)"
@@ -430,12 +430,12 @@ Get-FirewallProfiles
 Get-FirewallRules
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/network/Get-NetworkConfiguration.ps1
+++ b/scripts/infrastructure/windows/network/Get-NetworkConfiguration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Documents complete network configuration for Windows Server 2016-2022.
 
@@ -45,19 +45,19 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeRouting,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeShares,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeFirewall,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -91,7 +91,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -106,7 +106,7 @@ function Get-NetworkAdapters {
 
     $adapters = Get-NetAdapter | Sort-Object InterfaceIndex
 
-    foreach($adapter in $adapters) {
+    foreach ($adapter in $adapters) {
         $adapterInfo = [PSCustomObject]@{
             Name = $adapter.Name
             InterfaceDescription = $adapter.InterfaceDescription
@@ -122,7 +122,7 @@ function Get-NetworkAdapters {
 
         $script:report.Adapters += $adapterInfo
 
-        $statusColor = if($adapter.Status -eq 'Up') { 'Success' } else { 'Warning' }
+        $statusColor = if ($adapter.Status -eq 'Up') { 'Success' } else { 'Warning' }
         Write-ColorOutput "  $($adapter.Name): $($adapter.Status) - $($adapter.LinkSpeed)" -Level $statusColor
     }
 
@@ -134,7 +134,7 @@ function Get-IPConfiguration {
 
     $ipConfigs = Get-NetIPConfiguration
 
-    foreach($config in $ipConfigs) {
+    foreach ($config in $ipConfigs) {
         # IPv4 addresses
         $ipv4Addresses = $config.IPv4Address.IPAddress -join ', '
         $ipv4DefaultGateway = $config.IPv4DefaultGateway.NextHop -join ', '
@@ -163,13 +163,13 @@ function Get-IPConfiguration {
         $script:report.IPConfig += $ipInfo
 
         Write-Host "  $($config.InterfaceAlias):"
-        if($ipv4Addresses) {
+        if ($ipv4Addresses) {
             Write-Host "    IPv4: $ipv4Addresses" -ForegroundColor Gray
-            if($ipv4DefaultGateway) {
+            if ($ipv4DefaultGateway) {
                 Write-Host "    Gateway: $ipv4DefaultGateway" -ForegroundColor Gray
             }
         }
-        if($dnsServers) {
+        if ($dnsServers) {
             Write-Host "    DNS: $dnsServers" -ForegroundColor Gray
         }
     }
@@ -180,7 +180,7 @@ function Get-DNSConfiguration {
 
     $dnsClientConfig = Get-DnsClient
 
-    foreach($dns in $dnsClientConfig) {
+    foreach ($dns in $dnsClientConfig) {
         $dnsServers = (Get-DnsClientServerAddress -InterfaceIndex $dns.InterfaceIndex -ErrorAction SilentlyContinue).ServerAddresses -join ', '
 
         $dnsInfo = [PSCustomObject]@{
@@ -201,9 +201,9 @@ function Get-DNSConfiguration {
 function Get-RoutingTable {
     Write-Host "`nGathering routing table..." -ForegroundColor Cyan
 
-    $routes = Get-NetRoute | Where-Object {$_.DestinationPrefix -ne '::/0'} | Sort-Object RouteMetric
+    $routes = Get-NetRoute | Where-Object { $_.DestinationPrefix -ne '::/0' } | Sort-Object RouteMetric
 
-    foreach($route in $routes) {
+    foreach ($route in $routes) {
         $routeInfo = [PSCustomObject]@{
             DestinationPrefix = $route.DestinationPrefix
             NextHop = $route.NextHop
@@ -226,7 +226,7 @@ function Get-NetworkShares {
     try {
         $shares = Get-SmbShare -ErrorAction Stop
 
-        foreach($share in $shares) {
+        foreach ($share in $shares) {
             $shareInfo = [PSCustomObject]@{
                 Name = $share.Name
                 Path = $share.Path
@@ -254,7 +254,7 @@ function Get-FirewallStatus {
 
     $profiles = Get-NetFirewallProfile
 
-    foreach($profile in $profiles) {
+    foreach ($profile in $profiles) {
         $script:report.Firewall[$profile.Name] = @{
             Enabled = $profile.Enabled
             DefaultInboundAction = $profile.DefaultInboundAction
@@ -266,8 +266,8 @@ function Get-FirewallStatus {
             LogMaxSizeKilobytes = $profile.LogMaxSizeKilobytes
         }
 
-        $statusText = if($profile.Enabled) { "Enabled" } else { "Disabled" }
-        $statusColor = if($profile.Enabled) { 'Success' } else { 'Warning' }
+        $statusText = if ($profile.Enabled) { "Enabled" } else { "Disabled" }
+        $statusColor = if ($profile.Enabled) { 'Success' } else { 'Warning' }
         Write-ColorOutput "  $($profile.Name): $statusText" -Level $statusColor
     }
 }
@@ -287,12 +287,12 @@ function Show-Summary {
     Write-Host "`nIP Configuration:" -ForegroundColor Cyan
     $script:report.IPConfig | Format-Table InterfaceAlias, IPv4Address, IPv4Gateway, DNSServers -AutoSize
 
-    if($script:report.Routes.Count -gt 0) {
+    if ($script:report.Routes.Count -gt 0) {
         Write-Host "`nTop 10 Routes:" -ForegroundColor Cyan
         $script:report.Routes | Select-Object -First 10 | Format-Table DestinationPrefix, NextHop, InterfaceAlias, RouteMetric -AutoSize
     }
 
-    if($script:report.Shares.Count -gt 0) {
+    if ($script:report.Shares.Count -gt 0) {
         Write-Host "`nNetwork Shares:" -ForegroundColor Cyan
         $script:report.Shares | Format-Table Name, Path, Description, CurrentUsers -AutoSize
     }
@@ -460,26 +460,26 @@ Get-NetworkAdapters
 Get-IPConfiguration
 Get-DNSConfiguration
 
-if($IncludeRouting) {
+if ($IncludeRouting) {
     Get-RoutingTable
 }
 
-if($IncludeShares) {
+if ($IncludeShares) {
     Get-NetworkShares
 }
 
-if($IncludeFirewall) {
+if ($IncludeFirewall) {
     Get-FirewallStatus
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/network/Test-ServerConnectivity.ps1
+++ b/scripts/infrastructure/windows/network/Test-ServerConnectivity.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Tests network connectivity to remote servers including ping, port checks, and DNS resolution.
 
@@ -53,25 +53,25 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
     [string[]]$ComputerName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int[]]$Port = @(80, 443, 3389, 445),
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$PingCount = 4,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Timeout = 3000,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeTraceRoute,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -103,7 +103,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Error' { 'Red' }
         'Warning' { 'Yellow' }
         'Success' { 'Green' }
@@ -136,7 +136,7 @@ function Test-ICMPConnectivity {
         $pingResults.Received = $ping.Count
         $pingResults.Lost = $PingCount - $ping.Count
 
-        if($ping) {
+        if ($ping) {
             $latencies = $ping | ForEach-Object { $_.ResponseTime }
             $pingResults.MinLatency = ($latencies | Measure-Object -Minimum).Minimum
             $pingResults.MaxLatency = ($latencies | Measure-Object -Maximum).Maximum
@@ -170,7 +170,7 @@ function Test-DNSResolution {
 
     try {
         # Skip DNS resolution if target is already an IP address
-        if($Target -match '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$') {
+        if ($Target -match '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$') {
             $dnsResults.Success = $true
             $dnsResults.IPAddresses = @($Target)
             $dnsResults.FQDN = "N/A (IP Address)"
@@ -179,8 +179,8 @@ function Test-DNSResolution {
         else {
             $dns = Resolve-DnsName -Name $Target -ErrorAction Stop
 
-            $ipRecords = $dns | Where-Object {$_.Type -eq 'A'}
-            if($ipRecords) {
+            $ipRecords = $dns | Where-Object { $_.Type -eq 'A' }
+            if ($ipRecords) {
                 $dnsResults.Success = $true
                 $dnsResults.IPAddresses = $ipRecords.IPAddress
                 $dnsResults.FQDN = $ipRecords[0].Name
@@ -222,7 +222,7 @@ function Test-PortConnectivity {
 
         $stopwatch.Stop()
 
-        if($wait) {
+        if ($wait) {
             try {
                 $tcpClient.EndConnect($asyncResult)
                 $portResult.Success = $true
@@ -260,8 +260,8 @@ function Get-TraceRoute {
         $traceRoute = Test-NetConnection -ComputerName $Target -TraceRoute -ErrorAction Stop
 
         $hops = @()
-        if($traceRoute.TraceRoute) {
-            for($i = 0; $i -lt $traceRoute.TraceRoute.Count; $i++) {
+        if ($traceRoute.TraceRoute) {
+            for ($i = 0; $i -lt $traceRoute.TraceRoute.Count; $i++) {
                 $hop = $traceRoute.TraceRoute[$i]
                 $hops += [PSCustomObject]@{
                     Hop = $i + 1
@@ -304,16 +304,16 @@ function Test-TargetConnectivity {
     $result.Ping = Test-ICMPConnectivity -Target $Target
 
     # Port Tests
-    if($Port) {
+    if ($Port) {
         Write-Host "`nPort Connectivity Tests..." -ForegroundColor Cyan
-        foreach($p in $Port) {
+        foreach ($p in $Port) {
             $portResult = Test-PortConnectivity -Target $Target -TestPort $p
             $result.Ports += $portResult
         }
     }
 
     # Trace Route
-    if($IncludeTraceRoute) {
+    if ($IncludeTraceRoute) {
         Write-Host "`nTrace Route..." -ForegroundColor Cyan
         $result.TraceRoute = Get-TraceRoute -Target $Target
     }
@@ -332,7 +332,7 @@ function Show-Summary {
     Write-Host "Successful Pings: $($script:report.Summary.SuccessfulPings)"
     Write-Host "Failed Pings: $($script:report.Summary.FailedPings)"
 
-    if($script:report.Summary.PortTestsRun -gt 0) {
+    if ($script:report.Summary.PortTestsRun -gt 0) {
         $portSuccessRate = [math]::Round(($script:report.Summary.PortTestsSuccessful / $script:report.Summary.PortTestsRun) * 100, 2)
         Write-Host "`nPort Tests: $($script:report.Summary.PortTestsSuccessful)/$($script:report.Summary.PortTestsRun) successful ($portSuccessRate%)"
     }
@@ -456,8 +456,8 @@ function Export-CSVReport {
     $reportPath = "$ReportDir\ConnectivityReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
 
     $csvData = @()
-    foreach($result in $script:report.Results) {
-        foreach($portResult in $result.Ports) {
+    foreach ($result in $script:report.Results) {
+        foreach ($portResult in $result.Ports) {
             $csvData += [PSCustomObject]@{
                 Target = $result.Target
                 DNSResolved = $result.DNS.Success
@@ -489,18 +489,18 @@ Write-Host "Ports: $($Port -join ', ')"
 Write-Host "Ping Count: $PingCount"
 Write-Host "`nStarting tests..." -ForegroundColor Cyan
 
-foreach($target in $ComputerName) {
+foreach ($target in $ComputerName) {
     Test-TargetConnectivity -Target $target
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
+++ b/scripts/infrastructure/windows/security/Get-SecurityEventAudit.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Analyzes Windows Security Event logs for suspicious activities and security incidents.
 
@@ -62,32 +62,32 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Hours = 24,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Days,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('FailedLogins','AccountChanges','PrivilegeUse','PolicyChanges','All')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('FailedLogins', 'AccountChanges', 'PrivilegeUse', 'PolicyChanges', 'All')]
     [string]$EventTypes = 'All',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ComputerName = $env:COMPUTERNAME,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$MaxEvents = 1000,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Threshold = 10,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowSummaryOnly
 )
 
@@ -129,51 +129,51 @@ $summary = @{}
 # Event ID mappings
 $eventMap = @{
     FailedLogins = @(
-        @{ID=4625; Description="Failed Login Attempt"},
-        @{ID=4740; Description="Account Lockout"},
-        @{ID=4767; Description="Account Unlocked"},
-        @{ID=4771; Description="Kerberos Pre-Authentication Failed"}
+        @{ID = 4625; Description = "Failed Login Attempt" },
+        @{ID = 4740; Description = "Account Lockout" },
+        @{ID = 4767; Description = "Account Unlocked" },
+        @{ID = 4771; Description = "Kerberos Pre-Authentication Failed" }
     )
     AccountChanges = @(
-        @{ID=4720; Description="User Account Created"},
-        @{ID=4722; Description="User Account Enabled"},
-        @{ID=4723; Description="Password Change Attempted"},
-        @{ID=4724; Description="Password Reset Attempted"},
-        @{ID=4725; Description="User Account Disabled"},
-        @{ID=4726; Description="User Account Deleted"},
-        @{ID=4738; Description="User Account Changed"},
-        @{ID=4781; Description="Account Name Changed"}
+        @{ID = 4720; Description = "User Account Created" },
+        @{ID = 4722; Description = "User Account Enabled" },
+        @{ID = 4723; Description = "Password Change Attempted" },
+        @{ID = 4724; Description = "Password Reset Attempted" },
+        @{ID = 4725; Description = "User Account Disabled" },
+        @{ID = 4726; Description = "User Account Deleted" },
+        @{ID = 4738; Description = "User Account Changed" },
+        @{ID = 4781; Description = "Account Name Changed" }
     )
     PrivilegeUse = @(
-        @{ID=4672; Description="Special Privileges Assigned to Logon"},
-        @{ID=4673; Description="Privileged Service Called"},
-        @{ID=4674; Description="Operation Attempted on Privileged Object"},
-        @{ID=4985; Description="State of Transaction Changed"}
+        @{ID = 4672; Description = "Special Privileges Assigned to Logon" },
+        @{ID = 4673; Description = "Privileged Service Called" },
+        @{ID = 4674; Description = "Operation Attempted on Privileged Object" },
+        @{ID = 4985; Description = "State of Transaction Changed" }
     )
     PolicyChanges = @(
-        @{ID=4704; Description="User Right Assigned"},
-        @{ID=4705; Description="User Right Removed"},
-        @{ID=4706; Description="Trust to Domain Created"},
-        @{ID=4707; Description="Trust to Domain Removed"},
-        @{ID=4713; Description="Kerberos Policy Changed"},
-        @{ID=4716; Description="Trusted Domain Information Modified"},
-        @{ID=4719; Description="System Audit Policy Changed"},
-        @{ID=4739; Description="Domain Policy Changed"},
-        @{ID=4817; Description="Auditing Settings Changed"}
+        @{ID = 4704; Description = "User Right Assigned" },
+        @{ID = 4705; Description = "User Right Removed" },
+        @{ID = 4706; Description = "Trust to Domain Created" },
+        @{ID = 4707; Description = "Trust to Domain Removed" },
+        @{ID = 4713; Description = "Kerberos Policy Changed" },
+        @{ID = 4716; Description = "Trusted Domain Information Modified" },
+        @{ID = 4719; Description = "System Audit Policy Changed" },
+        @{ID = 4739; Description = "Domain Policy Changed" },
+        @{ID = 4817; Description = "Auditing Settings Changed" }
     )
     GroupChanges = @(
-        @{ID=4727; Description="Security-Enabled Global Group Created"},
-        @{ID=4728; Description="Member Added to Security-Enabled Global Group"},
-        @{ID=4729; Description="Member Removed from Security-Enabled Global Group"},
-        @{ID=4732; Description="Member Added to Security-Enabled Local Group"},
-        @{ID=4733; Description="Member Removed from Security-Enabled Local Group"},
-        @{ID=4756; Description="Member Added to Security-Enabled Universal Group"},
-        @{ID=4757; Description="Member Removed from Security-Enabled Universal Group"}
+        @{ID = 4727; Description = "Security-Enabled Global Group Created" },
+        @{ID = 4728; Description = "Member Added to Security-Enabled Global Group" },
+        @{ID = 4729; Description = "Member Removed from Security-Enabled Global Group" },
+        @{ID = 4732; Description = "Member Added to Security-Enabled Local Group" },
+        @{ID = 4733; Description = "Member Removed from Security-Enabled Local Group" },
+        @{ID = 4756; Description = "Member Added to Security-Enabled Universal Group" },
+        @{ID = 4757; Description = "Member Removed from Security-Enabled Universal Group" }
     )
     ServiceChanges = @(
-        @{ID=4697; Description="Service Installed"},
-        @{ID=7045; Description="Service Installed (System Log)"},
-        @{ID=7040; Description="Service Start Type Changed"}
+        @{ID = 4697; Description = "Service Installed" },
+        @{ID = 7045; Description = "Service Installed (System Log)" },
+        @{ID = 7040; Description = "Service Start Type Changed" }
     )
 }
 

--- a/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
+++ b/scripts/infrastructure/windows/security/Manage-FirewallRules.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Audits and manages Windows Firewall rules with security compliance checks.
 
@@ -64,39 +64,39 @@
     Use with caution when disabling or removing rules
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$true)]
-    [ValidateSet('Audit','Export','Enable','Disable','Remove','ComplianceCheck')]
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Audit', 'Export', 'Enable', 'Disable', 'Remove', 'ComplianceCheck')]
     [string]$Action,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$RuleName = '*',
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Domain','Private','Public','Any')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Domain', 'Private', 'Public', 'Any')]
     [string]$Profile = 'Any',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowDisabled,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ExportPath,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IdentifyRisks,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$RemoteAddress,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('TCP','UDP','ICMPv4','ICMPv6','Any')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('TCP', 'UDP', 'ICMPv4', 'ICMPv6', 'Any')]
     [string]$Protocol,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -142,8 +142,8 @@ if ($Profile -ne 'Any') {
 
 try {
     $rules = @(Get-NetFirewallRule @filterParams -ErrorAction SilentlyContinue | Where-Object {
-        $ShowDisabled -or $_.Enabled -eq $true
-    })
+            $ShowDisabled -or $_.Enabled -eq $true
+        })
 
     Write-Host "[+] Found $($rules.Count) matching rules" -ForegroundColor Green
 
@@ -450,7 +450,8 @@ try {
         Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
     }
 
-} catch {
+}
+catch {
     Write-Host "[-] Error: $($_.Exception.Message)" -ForegroundColor Red
     exit 1
 }

--- a/scripts/infrastructure/windows/security/Test-CertificateExpiration.ps1
+++ b/scripts/infrastructure/windows/security/Test-CertificateExpiration.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Monitors SSL/TLS certificate expiration for local and remote certificates.
 
@@ -56,33 +56,33 @@
     Remote endpoint checks require internet/network connectivity
 #>
 
-[CmdletBinding(DefaultParameterSetName='Local')]
+[CmdletBinding(DefaultParameterSetName = 'Local')]
 param(
-    [Parameter(ParameterSetName='Local')]
+    [Parameter(ParameterSetName = 'Local')]
     [switch]$CheckLocal,
 
-    [Parameter(ParameterSetName='Remote')]
+    [Parameter(ParameterSetName = 'Remote')]
     [switch]$CheckRemote,
 
-    [Parameter(ParameterSetName='Remote', Mandatory=$true)]
+    [Parameter(ParameterSetName = 'Remote', Mandatory = $true)]
     [string[]]$Endpoints,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$WarningDays = 30,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$CriticalDays = 7,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$CertStorePath,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeExpired,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -116,7 +116,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Critical' { 'Red' }
         'Error' { 'Red' }
         'Warning' { 'Yellow' }
@@ -136,21 +136,21 @@ function Get-CertificateStatus {
     $now = Get-Date
     $daysUntilExpiry = ($NotAfter - $now).Days
 
-    if($NotAfter -lt $now) {
+    if ($NotAfter -lt $now) {
         return @{
             Status = 'Expired'
             DaysUntilExpiry = $daysUntilExpiry
             Color = 'Critical'
         }
     }
-    elseif($daysUntilExpiry -le $CriticalDays) {
+    elseif ($daysUntilExpiry -le $CriticalDays) {
         return @{
             Status = 'Critical'
             DaysUntilExpiry = $daysUntilExpiry
             Color = 'Critical'
         }
     }
-    elseif($daysUntilExpiry -le $WarningDays) {
+    elseif ($daysUntilExpiry -le $WarningDays) {
         return @{
             Status = 'Warning'
             DaysUntilExpiry = $daysUntilExpiry
@@ -175,24 +175,24 @@ function Get-LocalCertificates {
         'Cert:\LocalMachine\Remote Desktop'
     )
 
-    if($CertStorePath) {
+    if ($CertStorePath) {
         $storePaths = @($CertStorePath)
     }
 
-    foreach($storePath in $storePaths) {
+    foreach ($storePath in $storePaths) {
         Write-Verbose "Checking store: $storePath"
 
-        if(Test-Path $storePath) {
+        if (Test-Path $storePath) {
             try {
                 $certs = Get-ChildItem -Path $storePath -ErrorAction Stop
 
                 Write-Host "  Found $($certs.Count) certificate(s) in $storePath" -ForegroundColor Gray
 
-                foreach($cert in $certs) {
+                foreach ($cert in $certs) {
                     $status = Get-CertificateStatus -NotAfter $cert.NotAfter -NotBefore $cert.NotBefore
 
                     # Skip expired certs unless IncludeExpired is specified
-                    if($status.Status -eq 'Expired' -and -not $IncludeExpired) {
+                    if ($status.Status -eq 'Expired' -and -not $IncludeExpired) {
                         continue
                     }
 
@@ -215,7 +215,7 @@ function Get-LocalCertificates {
                     $script:report.Certificates += $certInfo
                     $script:report.Summary.TotalCertificates++
 
-                    switch($status.Status) {
+                    switch ($status.Status) {
                         'Expired' { $script:report.Summary.Expired++ }
                         'Critical' { $script:report.Summary.Critical++ }
                         'Warning' { $script:report.Summary.Warning++ }
@@ -223,7 +223,7 @@ function Get-LocalCertificates {
                     }
 
                     # Display cert info
-                    $displayName = if($cert.FriendlyName) { $cert.FriendlyName } else { $cert.Subject }
+                    $displayName = if ($cert.FriendlyName) { $cert.FriendlyName } else { $cert.Subject }
                     $statusText = "[$($status.Status.ToUpper())] $displayName - Expires: $($cert.NotAfter.ToString('yyyy-MM-dd')) ($($status.DaysUntilExpiry) days)"
 
                     Write-ColorOutput "    $statusText" -Level $status.Color
@@ -242,21 +242,21 @@ function Get-LocalCertificates {
 function Get-RemoteCertificates {
     Write-Host "`nChecking remote HTTPS endpoints..." -ForegroundColor Cyan
 
-    foreach($endpoint in $Endpoints) {
+    foreach ($endpoint in $Endpoints) {
         Write-Host "  Testing: $endpoint" -ForegroundColor Gray
 
         try {
             # Parse URL
             $uri = [System.Uri]$endpoint
             $hostname = $uri.Host
-            $port = if($uri.Port -ne -1) { $uri.Port } else { 443 }
+            $port = if ($uri.Port -ne -1) { $uri.Port } else { 443 }
 
             # Create TCP connection
             $tcpClient = New-Object System.Net.Sockets.TcpClient
             $tcpClient.Connect($hostname, $port)
 
             # Create SSL stream
-            $sslStream = New-Object System.Net.Security.SslStream($tcpClient.GetStream(), $false, {$true})
+            $sslStream = New-Object System.Net.Security.SslStream($tcpClient.GetStream(), $false, { $true })
             $sslStream.AuthenticateAsClient($hostname)
 
             # Get certificate
@@ -266,7 +266,7 @@ function Get-RemoteCertificates {
             $status = Get-CertificateStatus -NotAfter $cert2.NotAfter -NotBefore $cert2.NotBefore
 
             # Skip expired certs unless IncludeExpired is specified
-            if($status.Status -eq 'Expired' -and -not $IncludeExpired) {
+            if ($status.Status -eq 'Expired' -and -not $IncludeExpired) {
                 $sslStream.Close()
                 $tcpClient.Close()
                 continue
@@ -291,7 +291,7 @@ function Get-RemoteCertificates {
             $script:report.Certificates += $certInfo
             $script:report.Summary.TotalCertificates++
 
-            switch($status.Status) {
+            switch ($status.Status) {
                 'Expired' { $script:report.Summary.Expired++ }
                 'Critical' { $script:report.Summary.Critical++ }
                 'Warning' { $script:report.Summary.Warning++ }
@@ -318,24 +318,24 @@ function Show-Summary {
     Write-Host "Scan Time: $($script:report.ScanTime)"
     Write-Host "`nTotal Certificates: $($script:report.Summary.TotalCertificates)"
 
-    if($script:report.Summary.Expired -gt 0) {
+    if ($script:report.Summary.Expired -gt 0) {
         Write-ColorOutput "Expired: $($script:report.Summary.Expired)" -Level Critical
     }
-    if($script:report.Summary.Critical -gt 0) {
+    if ($script:report.Summary.Critical -gt 0) {
         Write-ColorOutput "Critical (expires in $CriticalDays days): $($script:report.Summary.Critical)" -Level Critical
     }
-    if($script:report.Summary.Warning -gt 0) {
+    if ($script:report.Summary.Warning -gt 0) {
         Write-ColorOutput "Warning (expires in $WarningDays days): $($script:report.Summary.Warning)" -Level Warning
     }
     Write-ColorOutput "Healthy: $($script:report.Summary.Healthy)" -Level Success
 
     # Show critical certificates
-    $criticalCerts = $script:report.Certificates | Where-Object {$_.Status -in @('Expired', 'Critical')} | Sort-Object DaysUntilExpiry
+    $criticalCerts = $script:report.Certificates | Where-Object { $_.Status -in @('Expired', 'Critical') } | Sort-Object DaysUntilExpiry
 
-    if($criticalCerts) {
+    if ($criticalCerts) {
         Write-Host "`nCertificates Requiring Immediate Attention:" -ForegroundColor Red
-        foreach($cert in $criticalCerts) {
-            $name = if($cert.FriendlyName) { $cert.FriendlyName } else { $cert.Subject }
+        foreach ($cert in $criticalCerts) {
+            $name = if ($cert.FriendlyName) { $cert.FriendlyName } else { $cert.Subject }
             Write-Host "  - $name" -ForegroundColor Red
             Write-Host "    Expires: $($cert.NotAfter.ToString('yyyy-MM-dd')) ($($cert.DaysUntilExpiry) days)" -ForegroundColor Red
             Write-Host "    Location: $($cert.StorePath)" -ForegroundColor Gray
@@ -466,22 +466,22 @@ Write-Host "Server: $($script:report.ServerName)"
 Write-Host "Warning Threshold: $WarningDays days"
 Write-Host "Critical Threshold: $CriticalDays days"
 
-if($CheckLocal -or (-not $CheckRemote -and -not $Endpoints)) {
+if ($CheckLocal -or (-not $CheckRemote -and -not $Endpoints)) {
     Get-LocalCertificates
 }
 
-if($CheckRemote -or $Endpoints) {
+if ($CheckRemote -or $Endpoints) {
     Get-RemoteCertificates
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
+++ b/scripts/infrastructure/windows/security/Test-ServerHardening.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Checks Windows Server security hardening compliance against industry best practices.
 
@@ -48,22 +48,22 @@
     Some checks may require reboot to take effect
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('CIS','STIG','Microsoft')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('CIS', 'STIG', 'Microsoft')]
     [string]$Baseline = 'Microsoft',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeRemediation,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$AutoFix
 )
 

--- a/scripts/infrastructure/windows/storage/Get-DiskReport.ps1
+++ b/scripts/infrastructure/windows/storage/Get-DiskReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Generates comprehensive disk usage report and suggests cleanup targets for Windows Server 2016-2022.
 
@@ -44,17 +44,17 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidatePattern('^[A-Z]$')]
     [string]$DriveLetter,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportReport,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowCleanupOnly,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$MinimumFolderSizeMB = 100
 )
 
@@ -83,7 +83,7 @@ $script:reportData = @{
 function Write-Log {
     param([string]$Message, [string]$Type = "INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
+    $color = switch ($Type) {
         "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }
@@ -108,7 +108,7 @@ function Get-FolderSize {
 
     try {
         $size = (Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
-                 Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
         return [long]$size
     }
     catch {
@@ -262,7 +262,7 @@ function Get-CleanupSuggestions {
     foreach ($logPath in $logPaths) {
         if (Test-Path $logPath) {
             $oldLogs = Get-ChildItem -Path $logPath -Recurse -File -Filter *.log -ErrorAction SilentlyContinue |
-                       Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-90) }
+                Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-90) }
             $oldLogSize = ($oldLogs | Measure-Object -Property Length -Sum).Sum
 
             if ($oldLogSize -gt 100MB) {

--- a/scripts/infrastructure/windows/storage/Get-LargeFilesReport.ps1
+++ b/scripts/infrastructure/windows/storage/Get-LargeFilesReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Identifies and reports large files consuming disk space on Windows Server.
 
@@ -54,25 +54,25 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$Path,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$MinimumSizeMB = 100,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$TopCount = 50,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDuplicates,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string[]]$ExcludePath = @('C:\Windows\WinSxS', 'C:\$Recycle.Bin'),
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -104,7 +104,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -117,8 +117,8 @@ function Write-ColorOutput {
 function Should-ExcludePath {
     param([string]$FilePath)
 
-    foreach($exclude in $ExcludePath) {
-        if($FilePath -like "$exclude*") {
+    foreach ($exclude in $ExcludePath) {
+        if ($FilePath -like "$exclude*") {
             return $true
         }
     }
@@ -142,9 +142,9 @@ function Scan-LargeFiles {
                 -not (Should-ExcludePath -FilePath $_.FullName)
             }
 
-        foreach($file in $files) {
+        foreach ($file in $files) {
             $filesScanned++
-            if($filesScanned % 100 -eq 0) {
+            if ($filesScanned % 100 -eq 0) {
                 Write-Progress -Activity "Scanning files" -Status "Found $($script:report.LargeFiles.Count) large files (scanned $filesScanned)" -PercentComplete -1
             }
 
@@ -167,8 +167,8 @@ function Scan-LargeFiles {
             $script:report.TotalFiles++
 
             # Group by extension
-            $ext = if($file.Extension) { $file.Extension.ToLower() } else { '(no extension)' }
-            if($script:report.FilesByExtension.ContainsKey($ext)) {
+            $ext = if ($file.Extension) { $file.Extension.ToLower() } else { '(no extension)' }
+            if ($script:report.FilesByExtension.ContainsKey($ext)) {
                 $script:report.FilesByExtension[$ext].Count++
                 $script:report.FilesByExtension[$ext].TotalSizeMB += $fileInfo.SizeMB
             }
@@ -194,9 +194,9 @@ function Find-Duplicates {
     Write-Host "This may take significant time for large file sets..." -ForegroundColor Gray
 
     # Group files by size first (faster)
-    $sizeGroups = $script:report.LargeFiles | Group-Object SizeMB | Where-Object {$_.Count -gt 1}
+    $sizeGroups = $script:report.LargeFiles | Group-Object SizeMB | Where-Object { $_.Count -gt 1 }
 
-    if(-not $sizeGroups) {
+    if (-not $sizeGroups) {
         Write-Host "  No potential duplicates found (no files with matching sizes)" -ForegroundColor Gray
         return
     }
@@ -206,10 +206,10 @@ function Find-Duplicates {
 
     $duplicateGroups = @{}
     $filesProcessed = 0
-    $totalFilesToHash = ($sizeGroups | ForEach-Object {$_.Group}).Count
+    $totalFilesToHash = ($sizeGroups | ForEach-Object { $_.Group }).Count
 
-    foreach($group in $sizeGroups) {
-        foreach($file in $group.Group) {
+    foreach ($group in $sizeGroups) {
+        foreach ($file in $group.Group) {
             $filesProcessed++
             Write-Progress -Activity "Computing file hashes" -Status "Processing $filesProcessed of $totalFilesToHash" -PercentComplete (($filesProcessed / $totalFilesToHash) * 100)
 
@@ -217,7 +217,7 @@ function Find-Duplicates {
                 $hash = (Get-FileHash -Path $file.Path -Algorithm MD5 -ErrorAction Stop).Hash
                 $file.Hash = $hash
 
-                if($duplicateGroups.ContainsKey($hash)) {
+                if ($duplicateGroups.ContainsKey($hash)) {
                     $duplicateGroups[$hash] += $file
                 }
                 else {
@@ -233,7 +233,7 @@ function Find-Duplicates {
     Write-Progress -Activity "Computing file hashes" -Completed
 
     # Filter to only groups with multiple files
-    $duplicateGroups.GetEnumerator() | Where-Object {$_.Value.Count -gt 1} | ForEach-Object {
+    $duplicateGroups.GetEnumerator() | Where-Object { $_.Value.Count -gt 1 } | ForEach-Object {
         $dupGroup = $_.Value | Sort-Object Path
         $wastedSpace = ($dupGroup.Count - 1) * $dupGroup[0].SizeMB
 
@@ -247,7 +247,7 @@ function Find-Duplicates {
         }
     }
 
-    if($script:report.DuplicateFiles.Count -gt 0) {
+    if ($script:report.DuplicateFiles.Count -gt 0) {
         $totalWasted = ($script:report.DuplicateFiles | Measure-Object -Property WastedSpaceMB -Sum).Sum
         Write-ColorOutput "  Found $($script:report.DuplicateFiles.Count) sets of duplicate files" -Level Warning
         Write-ColorOutput "  Potential space savings: $([math]::Round($totalWasted / 1024, 2)) GB" -Level Info
@@ -272,13 +272,13 @@ function Show-Summary {
     $script:report.LargeFiles |
         Sort-Object SizeMB -Descending |
         Select-Object -First $TopCount |
-        Select-Object Name, @{Name='Size (GB)';Expression={$_.SizeGB}}, @{Name='Age (Days)';Expression={$_.AgeDays}}, Directory |
+        Select-Object Name, @{Name = 'Size (GB)'; Expression = { $_.SizeGB } }, @{Name = 'Age (Days)'; Expression = { $_.AgeDays } }, Directory |
         Format-Table -AutoSize
 
     # Files by extension
     Write-Host "`nLarge Files by Type:" -ForegroundColor Cyan
     $script:report.FilesByExtension.GetEnumerator() |
-        Sort-Object {$_.Value.TotalSizeMB} -Descending |
+        Sort-Object { $_.Value.TotalSizeMB } -Descending |
         Select-Object -First 10 |
         ForEach-Object {
             [PSCustomObject]@{
@@ -290,12 +290,12 @@ function Show-Summary {
         Format-Table -AutoSize
 
     # Duplicates
-    if($script:report.DuplicateFiles.Count -gt 0) {
+    if ($script:report.DuplicateFiles.Count -gt 0) {
         Write-Host "`nTop Duplicate Files (by wasted space):" -ForegroundColor Yellow
         $script:report.DuplicateFiles |
             Sort-Object WastedSpaceMB -Descending |
             Select-Object -First 10 |
-            Select-Object SampleFile, FileCount, @{Name='Size (MB)';Expression={$_.SizeMB}}, @{Name='Wasted (MB)';Expression={$_.WastedSpaceMB}} |
+            Select-Object SampleFile, FileCount, @{Name = 'Size (MB)'; Expression = { $_.SizeMB } }, @{Name = 'Wasted (MB)'; Expression = { $_.WastedSpaceMB } } |
             Format-Table -AutoSize
     }
 
@@ -420,34 +420,34 @@ Write-Host "Server: $($script:report.ServerName)"
 Write-Host "Minimum Size: $MinimumSizeMB MB"
 
 # Determine scan paths
-if($Path) {
+if ($Path) {
     $scanPaths = @($Path)
 }
 else {
-    $scanPaths = (Get-Volume | Where-Object {$_.DriveLetter -and $_.DriveType -eq 'Fixed'}).DriveLetter | ForEach-Object {"$_`:"}
+    $scanPaths = (Get-Volume | Where-Object { $_.DriveLetter -and $_.DriveType -eq 'Fixed' }).DriveLetter | ForEach-Object { "$_`:" }
 }
 
 Write-Host "Scan Paths: $($scanPaths -join ', ')"
 Write-Host "Excluded Paths: $($ExcludePath -join ', ')"
 
 # Scan each path
-foreach($scanPath in $scanPaths) {
+foreach ($scanPath in $scanPaths) {
     Scan-LargeFiles -ScanPath $scanPath
 }
 
 # Find duplicates if requested
-if($IncludeDuplicates) {
+if ($IncludeDuplicates) {
     Find-Duplicates
 }
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }

--- a/scripts/infrastructure/windows/storage/Optimize-ServerStorage.ps1
+++ b/scripts/infrastructure/windows/storage/Optimize-ServerStorage.ps1
@@ -55,25 +55,25 @@
     Always test with -WhatIf first
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidatePattern('^[A-Z]$')]
     [string]$DriveLetter,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeWindowsUpdate,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeIISLogs,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$IISLogRetentionDays = 30,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDISM,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$Force
 )
 
@@ -93,7 +93,7 @@ $script:report = @{
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
 
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
         'Success' { 'Green' }
@@ -106,8 +106,8 @@ function Write-ColorOutput {
 function Get-DiskSpace {
     param([string]$Drive)
 
-    $volume = Get-Volume | Where-Object {$_.DriveLetter -eq $Drive}
-    if($volume) {
+    $volume = Get-Volume | Where-Object { $_.DriveLetter -eq $Drive }
+    if ($volume) {
         return @{
             TotalGB = [math]::Round($volume.Size / 1GB, 2)
             FreeGB = [math]::Round($volume.SizeRemaining / 1GB, 2)
@@ -120,10 +120,10 @@ function Get-DiskSpace {
 function Get-FolderSize {
     param([string]$Path)
 
-    if(Test-Path $Path) {
+    if (Test-Path $Path) {
         try {
             $size = (Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
-                Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
+                    Measure-Object -Property Length -Sum -ErrorAction SilentlyContinue).Sum
             return [math]::Round($size / 1MB, 2)
         }
         catch {
@@ -134,20 +134,21 @@ function Get-FolderSize {
 }
 
 function Remove-FolderContents {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$Path,
         [string]$Description,
         [int]$OlderThanDays = 0
     )
 
-    if(-not (Test-Path $Path)) {
+    if (-not (Test-Path $Path)) {
         Write-Verbose "$Path does not exist, skipping..."
         return
     }
 
     $beforeSize = Get-FolderSize -Path $Path
 
-    if($WhatIfPreference) {
+    if ($WhatIfPreference) {
         Write-ColorOutput "  [WHATIF] Would clean: $Description ($Path)" -Level Info
         Write-ColorOutput "    Current size: $beforeSize MB" -Level Info
         return
@@ -156,20 +157,22 @@ function Remove-FolderContents {
     Write-Host "  Cleaning: $Description..." -ForegroundColor Cyan
 
     try {
-        if($OlderThanDays -gt 0) {
+        if ($OlderThanDays -gt 0) {
             $cutoffDate = (Get-Date).AddDays(-$OlderThanDays)
             $items = Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue |
-                Where-Object {$_.LastWriteTime -lt $cutoffDate}
+                Where-Object { $_.LastWriteTime -lt $cutoffDate }
         }
         else {
             $items = Get-ChildItem -Path $Path -Recurse -File -ErrorAction SilentlyContinue
         }
 
         $itemCount = 0
-        foreach($item in $items) {
+        foreach ($item in $items) {
             try {
-                Remove-Item -Path $item.FullName -Force -ErrorAction SilentlyContinue
-                $itemCount++
+                if ($PSCmdlet.ShouldProcess($item.FullName, 'Remove file')) {
+                    Remove-Item -Path $item.FullName -Force -ErrorAction SilentlyContinue
+                    $itemCount++
+                }
             }
             catch {
                 Write-Verbose "Could not delete: $($item.FullName)"
@@ -179,7 +182,7 @@ function Remove-FolderContents {
         $afterSize = Get-FolderSize -Path $Path
         $savedMB = $beforeSize - $afterSize
 
-        if($savedMB -gt 0) {
+        if ($savedMB -gt 0) {
             Write-ColorOutput "    Cleaned $itemCount files, saved $savedMB MB" -Level Success
             $script:report.TotalSpaceSavedMB += $savedMB
         }
@@ -214,9 +217,9 @@ function Clean-UserTemp {
 
     $userProfiles = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue
 
-    foreach($profile in $userProfiles) {
+    foreach ($profile in $userProfiles) {
         $tempPath = Join-Path $profile.FullName "AppData\Local\Temp"
-        if(Test-Path $tempPath) {
+        if (Test-Path $tempPath) {
             Remove-FolderContents -Path $tempPath -Description "User temp: $($profile.Name)"
         }
     }
@@ -225,7 +228,7 @@ function Clean-UserTemp {
 function Clean-RecycleBin {
     Write-Host "`nCleaning Recycle Bin..." -ForegroundColor Cyan
 
-    if($WhatIfPreference) {
+    if ($WhatIfPreference) {
         Write-ColorOutput "  [WHATIF] Would empty Recycle Bin on all drives" -Level Info
         return
     }
@@ -256,8 +259,8 @@ function Clean-WindowsErrorReporting {
         "$env:ProgramData\Microsoft\Windows\WER\ReportQueue"
     )
 
-    foreach($path in $werPaths) {
-        if(Test-Path $path) {
+    foreach ($path in $werPaths) {
+        if (Test-Path $path) {
             Remove-FolderContents -Path $path -Description "Windows Error Reporting: $(Split-Path $path -Leaf)" -OlderThanDays 7
         }
     }
@@ -268,9 +271,9 @@ function Clean-ThumbnailCache {
 
     $userProfiles = Get-ChildItem "C:\Users" -Directory -ErrorAction SilentlyContinue
 
-    foreach($profile in $userProfiles) {
+    foreach ($profile in $userProfiles) {
         $thumbPath = Join-Path $profile.FullName "AppData\Local\Microsoft\Windows\Explorer"
-        if(Test-Path $thumbPath) {
+        if (Test-Path $thumbPath) {
             Remove-FolderContents -Path $thumbPath -Description "Thumbnail cache: $($profile.Name)"
         }
     }
@@ -279,7 +282,7 @@ function Clean-ThumbnailCache {
 function Clean-WindowsUpdate {
     Write-Host "`nCleaning Windows Update cache..." -ForegroundColor Cyan
 
-    if($WhatIfPreference) {
+    if ($WhatIfPreference) {
         Write-ColorOutput "  [WHATIF] Would run Windows Update cleanup" -Level Info
         return
     }
@@ -315,7 +318,7 @@ function Clean-IISLogs {
     # Check if IIS is installed
     $iisInstalled = Get-Service -Name W3SVC -ErrorAction SilentlyContinue
 
-    if(-not $iisInstalled) {
+    if (-not $iisInstalled) {
         Write-Host "  IIS not detected, skipping..." -ForegroundColor Gray
         return
     }
@@ -328,9 +331,9 @@ function Clean-IISLogs {
     try {
         Import-Module IISAdministration -ErrorAction SilentlyContinue
         $sites = Get-IISSite -ErrorAction SilentlyContinue
-        foreach($site in $sites) {
+        foreach ($site in $sites) {
             $logPath = $site.logFile.directory
-            if($logPath -and (Test-Path $logPath)) {
+            if ($logPath -and (Test-Path $logPath)) {
                 $iisLogPaths += $logPath
             }
         }
@@ -339,8 +342,8 @@ function Clean-IISLogs {
         Write-Verbose "Could not read IIS configuration"
     }
 
-    foreach($path in ($iisLogPaths | Select-Object -Unique)) {
-        if(Test-Path $path) {
+    foreach ($path in ($iisLogPaths | Select-Object -Unique)) {
+        if (Test-Path $path) {
             Remove-FolderContents -Path $path -Description "IIS logs older than $IISLogRetentionDays days" -OlderThanDays $IISLogRetentionDays
         }
     }
@@ -350,14 +353,14 @@ function Clean-DISMComponentStore {
     Write-Host "`nRunning DISM component store cleanup..." -ForegroundColor Cyan
     Write-ColorOutput "  This operation can take 30+ minutes..." -Level Warning
 
-    if($WhatIfPreference) {
+    if ($WhatIfPreference) {
         Write-ColorOutput "  [WHATIF] Would run DISM component store cleanup" -Level Info
         return
     }
 
-    if(-not $Force) {
+    if (-not $Force) {
         $confirm = Read-Host "DISM cleanup can take significant time. Continue? (y/N)"
-        if($confirm -ne 'y') {
+        if ($confirm -ne 'y') {
             Write-Host "  Skipping DISM cleanup..." -ForegroundColor Gray
             return
         }
@@ -367,7 +370,7 @@ function Clean-DISMComponentStore {
         Write-Host "  Starting DISM cleanup (this will take a while)..." -ForegroundColor Gray
         $result = Dism.exe /Online /Cleanup-Image /StartComponentCleanup /ResetBase
 
-        if($LASTEXITCODE -eq 0) {
+        if ($LASTEXITCODE -eq 0) {
             Write-ColorOutput "  DISM cleanup completed successfully" -Level Success
             $script:report.Operations += [PSCustomObject]@{
                 Operation = "DISM Component Store Cleanup"
@@ -399,7 +402,7 @@ function Show-Summary {
     Write-Host "End Time: $($script:report.EndTime)"
     Write-Host "Duration: $([math]::Round($duration, 2)) seconds"
 
-    if($WhatIfPreference) {
+    if ($WhatIfPreference) {
         Write-ColorOutput "`n[WHATIF MODE - No changes were made]" -Level Warning
     }
     else {
@@ -407,7 +410,7 @@ function Show-Summary {
     }
 
     # Show space changes per drive
-    foreach($drive in $script:report.FinalSpace.Keys) {
+    foreach ($drive in $script:report.FinalSpace.Keys) {
         $initial = $script:report.InitialSpace[$drive]
         $final = $script:report.FinalSpace[$drive]
         $saved = $final.FreeGB - $initial.FreeGB
@@ -415,17 +418,17 @@ function Show-Summary {
         Write-Host "`nDrive $drive`:" -ForegroundColor Cyan
         Write-Host "  Before: $($initial.FreeGB) GB free / $($initial.TotalGB) GB total"
         Write-Host "  After:  $($final.FreeGB) GB free / $($final.TotalGB) GB total"
-        if($saved -gt 0) {
+        if ($saved -gt 0) {
             Write-ColorOutput "  Saved:  $([math]::Round($saved, 2)) GB" -Level Success
         }
     }
 
     # Show operations performed
-    if($script:report.Operations.Count -gt 0) {
+    if ($script:report.Operations.Count -gt 0) {
         Write-Host "`nOperations Performed:" -ForegroundColor Cyan
-        $script:report.Operations | Where-Object {$_.SavedMB -gt 0} |
+        $script:report.Operations | Where-Object { $_.SavedMB -gt 0 } |
             Sort-Object SavedMB -Descending |
-            Format-Table Operation, @{Name='Saved (MB)';Expression={$_.SavedMB}}, FilesRemoved -AutoSize
+            Format-Table Operation, @{Name = 'Saved (MB)'; Expression = { $_.SavedMB } }, FilesRemoved -AutoSize
     }
 
     Write-Host "`n========================================`n" -ForegroundColor Cyan
@@ -437,16 +440,16 @@ Write-Host "  Server Storage Optimization" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "Server: $($script:report.ServerName)"
 
-if($WhatIfPreference) {
+if ($WhatIfPreference) {
     Write-ColorOutput "Running in WhatIf mode - no changes will be made" -Level Warning
 }
 
 # Get initial disk space
-$drives = if($DriveLetter) { @($DriveLetter) } else { (Get-Volume | Where-Object {$_.DriveLetter}).DriveLetter }
+$drives = if ($DriveLetter) { @($DriveLetter) } else { (Get-Volume | Where-Object { $_.DriveLetter }).DriveLetter }
 
-foreach($drive in $drives) {
+foreach ($drive in $drives) {
     $space = Get-DiskSpace -Drive $drive
-    if($space) {
+    if ($space) {
         $script:report.InitialSpace[$drive] = $space
         Write-Host "`nDrive $drive`: $($space.FreeGB) GB free / $($space.TotalGB) GB total"
     }
@@ -459,22 +462,22 @@ Clean-RecycleBin
 Clean-WindowsErrorReporting
 Clean-ThumbnailCache
 
-if($IncludeWindowsUpdate) {
+if ($IncludeWindowsUpdate) {
     Clean-WindowsUpdate
 }
 
-if($IncludeIISLogs) {
+if ($IncludeIISLogs) {
     Clean-IISLogs
 }
 
-if($IncludeDISM) {
+if ($IncludeDISM) {
     Clean-DISMComponentStore
 }
 
 # Get final disk space
-foreach($drive in $drives) {
+foreach ($drive in $drives) {
     $space = Get-DiskSpace -Drive $drive
-    if($space) {
+    if ($space) {
         $script:report.FinalSpace[$drive] = $space
     }
 }

--- a/scripts/infrastructure/windows/system/Check-SystemIntegrity.ps1
+++ b/scripts/infrastructure/windows/system/Check-SystemIntegrity.ps1
@@ -35,13 +35,13 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$QuickScan,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$AutoRepair,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$GenerateReport
 )
 
@@ -61,7 +61,7 @@ $script:results = @{
 function Write-Log {
     param([string]$Message, [string]$Type = "INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
+    $color = switch ($Type) {
         "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }
@@ -171,7 +171,7 @@ function Test-DiskHealth {
     Write-Log "Analyzing disk health..." "INFO"
 
     try {
-        $volumes = Get-Volume | Where-Object {$_.DriveLetter -ne $null -and $_.FileSystem -eq "NTFS"}
+        $volumes = Get-Volume | Where-Object { $_.DriveLetter -ne $null -and $_.FileSystem -eq "NTFS" }
 
         foreach ($volume in $volumes) {
             $driveLetter = $volume.DriveLetter
@@ -212,7 +212,7 @@ function Get-CriticalEventLogErrors {
         foreach ($logName in $logs) {
             $errors = Get-WinEvent -FilterHashtable @{
                 LogName = $logName
-                Level = 1,2  # Critical and Error
+                Level = 1, 2  # Critical and Error
                 StartTime = $startTime
             } -ErrorAction SilentlyContinue | Select-Object -First 10
 
@@ -246,6 +246,8 @@ function Get-CriticalEventLogErrors {
 }
 
 function New-IntegrityReport {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     $RunTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
     $RunId = [Guid]::NewGuid().ToString('N').Substring(0, 8)
 
@@ -260,7 +262,9 @@ function New-IntegrityReport {
     }
     $reportDir = [System.IO.Path]::GetFullPath($reportDir)
     if (-not (Test-Path -LiteralPath $reportDir -PathType Container)) {
-        New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+        if ($PSCmdlet.ShouldProcess($reportDir, 'Create report directory')) {
+            New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+        }
     }
 
     $reportPath = Join-Path $reportDir "SystemIntegrityReport_$($env:COMPUTERNAME)_${RunTimestamp}_${RunId}.html"
@@ -307,7 +311,7 @@ function New-IntegrityReport {
 "@
 
     if ($script:results.EventLogErrors.Count -gt 0) {
-foreach ($err in $script:results.EventLogErrors) {
+        foreach ($err in $script:results.EventLogErrors) {
             $html += "<tr><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Time)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Log)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Source)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.EventID)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($err.Message)"))</td></tr>"
         }
     }
@@ -322,7 +326,9 @@ foreach ($err in $script:results.EventLogErrors) {
 </html>
 "@
 
-    $html | Out-File -FilePath $reportPath -Encoding UTF8
+    if ($PSCmdlet.ShouldProcess($reportPath, 'Write integrity report')) {
+        $html | Out-File -FilePath $reportPath -Encoding UTF8
+    }
     Write-Log "Report generated: $reportPath" "SUCCESS"
     Write-Host "[+] HTML report saved to: $reportPath" -ForegroundColor Green
 }

--- a/scripts/infrastructure/windows/system/New-WeeklyRebootSchedule.ps1
+++ b/scripts/infrastructure/windows/system/New-WeeklyRebootSchedule.ps1
@@ -59,22 +59,22 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")]
     [string]$DayOfWeek,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidatePattern('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$')]
     [string]$Time,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$TaskName = "Weekly Server Reboot",
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateRange(0, 600)]
     [int]$RebootDelay = 60,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$Force
 )
 
@@ -90,20 +90,20 @@ function Write-Log {
         Writes formatted log messages to console with color coding.
     #>
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [ValidateSet("INFO", "SUCCESS", "WARNING", "ERROR")]
         [string]$Type = "INFO"
     )
 
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
-        "ERROR"   { "Red" }
+    $color = switch ($Type) {
+        "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }
-        default   { "White" }
+        default { "White" }
     }
     Write-Host "[$timestamp] [$Type] $Message" -ForegroundColor $color
 }
@@ -175,7 +175,8 @@ function Get-TimeInput {
             $hour = $timeParts[0].PadLeft(2, '0')
             $minute = $timeParts[1]
             return "${hour}:${minute}"
-        } else {
+        }
+        else {
             Write-Host "Invalid time format. Please use 24-hour format (HH:mm), e.g., 02:00 or 23:30" -ForegroundColor Red
         }
     } while ($true)
@@ -187,7 +188,7 @@ function Test-ScheduledTaskExists {
         Checks if a scheduled task exists.
     #>
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Name
     )
 
@@ -205,15 +206,18 @@ function Remove-ExistingTask {
     .SYNOPSIS
         Removes an existing scheduled task.
     #>
+    [CmdletBinding(SupportsShouldProcess)]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Name
     )
 
     try {
-        Unregister-ScheduledTask -TaskName $Name -Confirm:$false -ErrorAction Stop
-        Write-Log "Removed existing scheduled task: $Name" "SUCCESS"
-        return $true
+        if ($PSCmdlet.ShouldProcess($Name, 'Unregister scheduled task')) {
+            Unregister-ScheduledTask -TaskName $Name -Confirm:$false -ErrorAction Stop
+            Write-Log "Removed existing scheduled task: $Name" "SUCCESS"
+            return $true
+        }
     }
     catch {
         Write-Log "Failed to remove existing task: $($_.Exception.Message)" "ERROR"
@@ -226,17 +230,18 @@ function New-RebootScheduledTask {
     .SYNOPSIS
         Creates the scheduled task for weekly reboots.
     #>
+    [CmdletBinding(SupportsShouldProcess)]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$TaskName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Day,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ScheduledTime,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [int]$Delay
     )
 
@@ -269,14 +274,16 @@ function New-RebootScheduledTask {
 
         # Register the scheduled task
         Write-Log "Registering scheduled task..." "INFO"
-        $task = Register-ScheduledTask `
-            -TaskName $TaskName `
-            -Action $action `
-            -Trigger $trigger `
-            -Settings $settings `
-            -Principal $principal `
-            -Description "Automatically reboots the server weekly on $Day at $ScheduledTime. Created by New-WeeklyRebootSchedule.ps1" `
-            -ErrorAction Stop
+        if ($PSCmdlet.ShouldProcess($TaskName, 'Register weekly reboot scheduled task')) {
+            $task = Register-ScheduledTask `
+                -TaskName $TaskName `
+                -Action $action `
+                -Trigger $trigger `
+                -Settings $settings `
+                -Principal $principal `
+                -Description "Automatically reboots the server weekly on $Day at $ScheduledTime. Created by New-WeeklyRebootSchedule.ps1" `
+                -ErrorAction Stop
+        }
 
         return $task
     }
@@ -292,16 +299,16 @@ function Show-TaskSummary {
         Displays a summary of the created scheduled task.
     #>
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [Microsoft.Management.Infrastructure.CimInstance]$Task,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Day,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ScheduledTime,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [int]$Delay
     )
 
@@ -329,7 +336,7 @@ function Get-UserConfirmation {
         Prompts user for confirmation.
     #>
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message
     )
 
@@ -352,7 +359,8 @@ Write-Log "Starting Weekly Reboot Scheduler configuration..." "INFO"
 if ([string]::IsNullOrEmpty($DayOfWeek)) {
     $DayOfWeek = Get-DayOfWeekSelection
     Write-Log "Selected day: $DayOfWeek" "INFO"
-} else {
+}
+else {
     Write-Log "Using day from parameter: $DayOfWeek" "INFO"
 }
 
@@ -360,7 +368,8 @@ if ([string]::IsNullOrEmpty($DayOfWeek)) {
 if ([string]::IsNullOrEmpty($Time)) {
     $Time = Get-TimeInput
     Write-Log "Selected time: $Time" "INFO"
-} else {
+}
+else {
     Write-Log "Using time from parameter: $Time" "INFO"
 }
 
@@ -387,7 +396,8 @@ if ($taskExists) {
             Write-Log "Operation cancelled by user." "INFO"
             exit 0
         }
-    } else {
+    }
+    else {
         Write-Log "Force parameter specified - will overwrite existing task." "INFO"
     }
 

--- a/scripts/infrastructure/windows/system/Optimize-WsusServer.ps1
+++ b/scripts/infrastructure/windows/system/Optimize-WsusServer.ps1
@@ -87,15 +87,15 @@ param (
 
     [Parameter()]
     [ValidateScript({
-        # Validate path format and prevent path traversal
-        if ($_ -match '\.\.[/\\]') {
-            throw "Path traversal detected in ConfigFile parameter"
-        }
-        if ($_ -notmatch '^[A-Za-z]:\\') {
-            throw "ConfigFile must be an absolute Windows path"
-        }
-        return $true
-    })]
+            # Validate path format and prevent path traversal
+            if ($_ -match '\.\.[/\\]') {
+                throw "Path traversal detected in ConfigFile parameter"
+            }
+            if ($_ -notmatch '^[A-Za-z]:\\') {
+                throw "ConfigFile must be an absolute Windows path"
+            }
+            return $true
+        })]
     [string]$ConfigFile = "C:\Scripts\WSUS\wsus-config.json",
 
     [Parameter()]
@@ -286,9 +286,9 @@ function Write-Log {
     # Write to console unless suppressed
     if (-not $NoConsole) {
         switch ($Level) {
-            'Info'    { Write-Host $logMessage -ForegroundColor Cyan }
+            'Info' { Write-Host $logMessage -ForegroundColor Cyan }
             'Warning' { Write-Warning $Message }
-            'Error'   { Write-Host $logMessage -ForegroundColor Red }
+            'Error' { Write-Host $logMessage -ForegroundColor Red }
             'Success' { Write-Host $logMessage -ForegroundColor Green }
         }
     }
@@ -531,13 +531,13 @@ function ConvertTo-Hashtable {
             }
             elseif ($value -is [Array]) {
                 $hash[$_.Name] = @($value | ForEach-Object {
-                    if ($_ -is [PSCustomObject] -or $_ -is [System.Collections.IDictionary]) {
-                        ConvertTo-Hashtable $_
-                    }
-                    else {
-                        $_
-                    }
-                })
+                        if ($_ -is [PSCustomObject] -or $_ -is [System.Collections.IDictionary]) {
+                            ConvertTo-Hashtable $_
+                        }
+                        else {
+                            $_
+                        }
+                    })
             }
             else {
                 $hash[$_.Name] = $value
@@ -567,13 +567,13 @@ function Copy-HashtableDeep {
         elseif ($value -is [Array]) {
             # Clone array elements
             $clone[$key] = @($value | ForEach-Object {
-                if ($_ -is [hashtable]) {
-                    Copy-HashtableDeep $_
-                }
-                else {
-                    $_
-                }
-            })
+                    if ($_ -is [hashtable]) {
+                        Copy-HashtableDeep $_
+                    }
+                    else {
+                        $_
+                    }
+                })
         }
         else {
             # Copy value types and strings
@@ -646,7 +646,7 @@ function Confirm-Choice {
 }
 
 function Start-InteractiveWizard {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param()
 
     Show-Banner
@@ -929,7 +929,7 @@ function Get-WsusIISConfig {
 }
 
 function Test-WsusIISConfig {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [hashtable]$Config
     )
@@ -1387,7 +1387,7 @@ function Invoke-DeepClean {
 }
 
 function Remove-UpdatesByProduct {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true)]
         $WsusServer,
@@ -1425,8 +1425,10 @@ function Remove-UpdatesByProduct {
 
                 foreach ($update in $updates) {
                     if (-not $update.IsDeclined) {
-                        $update.Decline()
-                        $declinedCount++
+                        if ($PSCmdlet.ShouldProcess($update.Title, 'Decline update')) {
+                            $update.Decline()
+                            $declinedCount++
+                        }
                     }
                 }
 
@@ -1445,7 +1447,7 @@ function Remove-UpdatesByProduct {
 }
 
 function Remove-UpdatesByTitle {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true)]
         $WsusServer,
@@ -1486,9 +1488,11 @@ function Remove-UpdatesByTitle {
 
                 foreach ($titlePattern in $UpdateTitles) {
                     if ($update.Title -like "*$titlePattern*" -and -not $update.IsDeclined) {
-                        $update.Decline()
-                        $declinedCount++
-                        Write-Log "  Declined: $($update.Title)" -Level Info -NoConsole
+                        if ($PSCmdlet.ShouldProcess($update.Title, 'Decline update')) {
+                            $update.Decline()
+                            $declinedCount++
+                            Write-Log "  Declined: $($update.Title)" -Level Info -NoConsole
+                        }
                         break
                     }
                 }
@@ -1506,7 +1510,7 @@ function Remove-UpdatesByTitle {
 }
 
 function Remove-DriverUpdates {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory = $true)]
         $WsusServer
@@ -1544,8 +1548,10 @@ function Remove-DriverUpdates {
                 }
 
                 if (-not $update.IsDeclined) {
-                    $update.Decline()
-                    $declinedCount++
+                    if ($PSCmdlet.ShouldProcess($update.Title, 'Decline driver update')) {
+                        $update.Decline()
+                        $declinedCount++
+                    }
                 }
             }
         }
@@ -1685,7 +1691,7 @@ function New-WsusScheduledTasks {
 }
 
 function New-WsusDailyTask {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ScriptPath,
         [hashtable]$Config
@@ -1710,12 +1716,16 @@ function New-WsusDailyTask {
         # Remove existing task if it exists
         $existingTask = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
         if ($existingTask) {
-            Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            if ($PSCmdlet.ShouldProcess($taskName, 'Unregister existing scheduled task')) {
+                Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            }
         }
 
-        Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Daily WSUS server optimization and superseded update cleanup" | Out-Null
+        if ($PSCmdlet.ShouldProcess($taskName, 'Register daily WSUS optimization scheduled task')) {
+            Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Daily WSUS server optimization and superseded update cleanup" | Out-Null
 
-        Write-Log "Daily task created: $taskName at $time" -Level Success
+            Write-Log "Daily task created: $taskName at $time" -Level Success
+        }
     }
     catch {
         Write-Log "Failed to create daily task: $_" -Level Error
@@ -1723,7 +1733,7 @@ function New-WsusDailyTask {
 }
 
 function New-WsusWeeklyTask {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ScriptPath,
         [hashtable]$Config
@@ -1747,12 +1757,16 @@ function New-WsusWeeklyTask {
 
         $existingTask = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
         if ($existingTask) {
-            Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            if ($PSCmdlet.ShouldProcess($taskName, 'Unregister existing scheduled task')) {
+                Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            }
         }
 
-        Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Weekly WSUS database optimization and IIS configuration check" | Out-Null
+        if ($PSCmdlet.ShouldProcess($taskName, 'Register weekly WSUS optimization scheduled task')) {
+            Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Weekly WSUS database optimization and IIS configuration check" | Out-Null
 
-        Write-Log "Weekly task created: $taskName on $dayOfWeek at $time" -Level Success
+            Write-Log "Weekly task created: $taskName on $dayOfWeek at $time" -Level Success
+        }
     }
     catch {
         Write-Log "Failed to create weekly task: $_" -Level Error
@@ -1760,7 +1774,7 @@ function New-WsusWeeklyTask {
 }
 
 function New-WsusMonthlyTask {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$ScriptPath,
         [hashtable]$Config
@@ -1792,11 +1806,15 @@ function New-WsusMonthlyTask {
 
         $existingTask = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
         if ($existingTask) {
-            Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            if ($PSCmdlet.ShouldProcess($taskName, 'Unregister existing scheduled task')) {
+                Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+            }
         }
 
         $task = New-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Monthly WSUS deep clean of obsolete updates"
-        Register-ScheduledTask -TaskName $taskName -InputObject $task | Out-Null
+        if ($PSCmdlet.ShouldProcess($taskName, 'Register monthly WSUS deep clean scheduled task')) {
+            Register-ScheduledTask -TaskName $taskName -InputObject $task | Out-Null
+        }
 
         Write-Log "Monthly task created: $taskName on day $day at $time" -Level Success
     }

--- a/scripts/infrastructure/windows/system/Remove-USLanguagePack.ps1
+++ b/scripts/infrastructure/windows/system/Remove-USLanguagePack.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Removes US English (en-US) language packs from Windows Server 2016-2022.
 
@@ -40,13 +40,13 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$Force,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$KeepKeyboard,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$BackupFirst
 )
 
@@ -55,7 +55,7 @@ param(
 function Write-Log {
     param([string]$Message, [string]$Type = "INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
+    $color = switch ($Type) {
         "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }

--- a/scripts/infrastructure/windows/system/Reset-WindowsUpdate.ps1
+++ b/scripts/infrastructure/windows/system/Reset-WindowsUpdate.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Resets Windows Update components to resolve update issues on Windows Server 2016-2022.
 
@@ -42,13 +42,13 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$FullReset,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$RunDismRepair = $true,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$LegacyReset
 )
 
@@ -58,7 +58,7 @@ param(
 function Write-Log {
     param([string]$Message, [string]$Type = "INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
+    $color = switch ($Type) {
         "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }
@@ -146,48 +146,48 @@ if (-not $LegacyReset -and $RunDismRepair) {
 # Skipped when the DISM repair succeeded, unless -LegacyReset forces them.
 if ($LegacyReset -or -not $dismRepairSucceeded) {
 
-# Re-register Windows Update DLLs
-Write-Log "Re-registering Windows Update DLLs..." "INFO"
-$dlls = @(
-    "atl.dll", "urlmon.dll", "mshtml.dll", "shdocvw.dll", "browseui.dll",
-    "jscript.dll", "vbscript.dll", "scrrun.dll", "msxml.dll", "msxml3.dll",
-    "msxml6.dll", "actxprxy.dll", "softpub.dll", "wintrust.dll", "dssenh.dll",
-    "rsaenh.dll", "gpkcsp.dll", "sccbase.dll", "slbcsp.dll", "cryptdlg.dll",
-    "oleaut32.dll", "ole32.dll", "shell32.dll", "initpki.dll", "wuapi.dll",
-    "wuaueng.dll", "wuaueng1.dll", "wucltui.dll", "wups.dll", "wups2.dll",
-    "wuweb.dll", "qmgr.dll", "qmgrprxy.dll", "wucltux.dll", "muweb.dll", "wuwebv.dll"
-)
+    # Re-register Windows Update DLLs
+    Write-Log "Re-registering Windows Update DLLs..." "INFO"
+    $dlls = @(
+        "atl.dll", "urlmon.dll", "mshtml.dll", "shdocvw.dll", "browseui.dll",
+        "jscript.dll", "vbscript.dll", "scrrun.dll", "msxml.dll", "msxml3.dll",
+        "msxml6.dll", "actxprxy.dll", "softpub.dll", "wintrust.dll", "dssenh.dll",
+        "rsaenh.dll", "gpkcsp.dll", "sccbase.dll", "slbcsp.dll", "cryptdlg.dll",
+        "oleaut32.dll", "ole32.dll", "shell32.dll", "initpki.dll", "wuapi.dll",
+        "wuaueng.dll", "wuaueng1.dll", "wucltui.dll", "wups.dll", "wups2.dll",
+        "wuweb.dll", "qmgr.dll", "qmgrprxy.dll", "wucltux.dll", "muweb.dll", "wuwebv.dll"
+    )
 
-$registeredCount = 0
-foreach ($dll in $dlls) {
-    try {
-        Start-Process "regsvr32.exe" -ArgumentList "/s $dll" -Wait -WindowStyle Hidden -ErrorAction SilentlyContinue
-        $registeredCount++
-    }
-    catch {
-        Write-Log "Failed to register: $dll" "WARNING"
-    }
-}
-Write-Log "Re-registered $registeredCount DLLs" "SUCCESS"
-
-# Reset Windows Update policies
-Write-Log "Resetting Windows Update policies..." "INFO"
-$regPaths = @(
-    "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate",
-    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate"
-)
-
-foreach ($regPath in $regPaths) {
-    if (Test-Path $regPath) {
+    $registeredCount = 0
+    foreach ($dll in $dlls) {
         try {
-            Remove-Item -Path $regPath -Recurse -Force -ErrorAction SilentlyContinue
-            Write-Log "Removed registry path: $regPath" "SUCCESS"
+            Start-Process "regsvr32.exe" -ArgumentList "/s $dll" -Wait -WindowStyle Hidden -ErrorAction SilentlyContinue
+            $registeredCount++
         }
         catch {
-            Write-Log "Failed to remove registry path: $regPath - $($_.Exception.Message)" "WARNING"
+            Write-Log "Failed to register: $dll" "WARNING"
         }
     }
-}
+    Write-Log "Re-registered $registeredCount DLLs" "SUCCESS"
+
+    # Reset Windows Update policies
+    Write-Log "Resetting Windows Update policies..." "INFO"
+    $regPaths = @(
+        "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate",
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate"
+    )
+
+    foreach ($regPath in $regPaths) {
+        if (Test-Path $regPath) {
+            try {
+                Remove-Item -Path $regPath -Recurse -Force -ErrorAction SilentlyContinue
+                Write-Log "Removed registry path: $regPath" "SUCCESS"
+            }
+            catch {
+                Write-Log "Failed to remove registry path: $regPath - $($_.Exception.Message)" "WARNING"
+            }
+        }
+    }
 
 } # end legacy reset steps (skipped when DISM repair succeeded)
 

--- a/scripts/infrastructure/windows/system/Set-EnglishUKRegion.ps1
+++ b/scripts/infrastructure/windows/system/Set-EnglishUKRegion.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Configures Windows Server to use English (UK) regional settings system-wide.
 
@@ -46,16 +46,16 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$TimeZone = "GMT Standard Time",
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ApplyToExistingUsers,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$SkipTimeZone,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$SkipKeyboard
 )
 
@@ -64,7 +64,7 @@ param(
 function Write-Log {
     param([string]$Message, [string]$Type = "INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    $color = switch($Type) {
+    $color = switch ($Type) {
         "ERROR" { "Red" }
         "SUCCESS" { "Green" }
         "WARNING" { "Yellow" }
@@ -101,7 +101,8 @@ function Load-RegistryHive {
         if ($LASTEXITCODE -eq 0) {
             Write-Log "Successfully loaded registry hive: $HiveName" "SUCCESS"
             return $true  # We loaded it
-        } else {
+        }
+        else {
             Write-Log "Failed to load registry hive: $result" "ERROR"
             return $false
         }
@@ -137,7 +138,8 @@ function Unload-RegistryHive {
         $result = & reg unload $HiveName 2>&1
         if ($LASTEXITCODE -eq 0) {
             Write-Log "Successfully unloaded registry hive: $HiveName" "SUCCESS"
-        } else {
+        }
+        else {
             Write-Log "Warning: Could not unload registry hive: $result" "WARNING"
         }
     }
@@ -270,7 +272,8 @@ try {
         $copyResult = & reg copy "HKCU\Control Panel\International" "HKU\DEFAULT_USER\Control Panel\International" /s /f 2>&1
         if ($LASTEXITCODE -eq 0) {
             Write-Log "Settings applied to default user profile" "SUCCESS"
-        } else {
+        }
+        else {
             Write-Log "Warning: Could not copy settings to default user profile: $copyResult" "WARNING"
         }
 
@@ -309,7 +312,8 @@ try {
 
         if ($process.ExitCode -eq 0 -or $null -eq $process.ExitCode) {
             Write-Log "System-wide settings applied via XML" "SUCCESS"
-        } else {
+        }
+        else {
             Write-Log "XML application completed with exit code: $($process.ExitCode)" "WARNING"
         }
 
@@ -351,16 +355,19 @@ if ($ApplyToExistingUsers) {
 
                     if ($LASTEXITCODE -eq 0) {
                         Write-Log "  Profile '$userName' updated" "SUCCESS"
-                    } else {
+                    }
+                    else {
                         Write-Log "  Could not copy settings to '$userName': $copyResult" "WARNING"
                     }
 
                     # Unload hive
                     Unload-RegistryHive -HiveName $userHive -WeLoadedIt $userHiveLoaded
-                } else {
+                }
+                else {
                     Write-Log "  Could not load registry for '$userName' (may be logged in)" "WARNING"
                 }
-            } else {
+            }
+            else {
                 Write-Log "  NTUSER.DAT not found for '$userName'" "WARNING"
             }
         }

--- a/scripts/infrastructure/windows/user-management/Get-InactiveUserReport.ps1
+++ b/scripts/infrastructure/windows/user-management/Get-InactiveUserReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Identifies and reports on inactive Active Directory user accounts.
 
@@ -55,28 +55,28 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$DaysInactive = 90,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeDisabled,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SearchBase,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExcludeServiceAccounts,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$HighlightPrivileged,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$WhatIfDisable
 )
 
@@ -301,7 +301,7 @@ try {
         </tr>
 "@
 
-        foreach ($result in ($results | Sort-Object -Property @{Expression={$_.IsPrivileged}; Descending=$true}, LastLogon)) {
+        foreach ($result in ($results | Sort-Object -Property @{Expression = { $_.IsPrivileged }; Descending = $true }, LastLogon)) {
             $rowClass = if ($result.IsPrivileged) { "privileged" } elseif (-not $result.Enabled) { "disabled" } else { "" }
             $html += @"
         <tr class="$rowClass">
@@ -329,7 +329,8 @@ try {
         Write-Host "[+] CSV export saved to: $csvPath" -ForegroundColor Green
     }
 
-} catch {
+}
+catch {
     Write-Host "[-] Error: $($_.Exception.Message)" -ForegroundColor Red
     exit 1
 }

--- a/scripts/infrastructure/windows/user-management/Get-UserLockoutReport.ps1
+++ b/scripts/infrastructure/windows/user-management/Get-UserLockoutReport.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Reports on user account lockouts and analyzes lockout sources.
 
@@ -52,25 +52,25 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Hours = 24,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Days,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$Username,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeSource,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$DetectBruteForce,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 


### PR DESCRIPTION
Closes #116 #118 #128

PSSA enforcement campaign for #116 (comment-based help), #118 (ShouldProcess), #128 (style rules).
Fixes: formatter-normalized style, manual casing fixes, comment-based help headers, SupportsShouldProcess retrofits with `$PSCmdlet.ShouldProcess()` guards (no -ConfirmImpact; normal runs stay silent, -WhatIf/-Confirm become available).

## Summary by Sourcery

Enforce PowerShell Script Analyzer style conventions and add ShouldProcess support across infrastructure PowerShell tools.

Enhancements:
- Normalize PowerShell formatting and casing across monitoring, networking, storage, security, backup, IIS, Hyper-V, Active Directory, and other infrastructure scripts for PSSA compliance.
- Introduce CmdletBinding SupportsShouldProcess and wrap impactful operations (e.g., progress updates, WSUS update declines, file deletions, scheduled task registration, network resets) in $PSCmdlet.ShouldProcess guards to support -WhatIf/-Confirm workflows.
- Improve robustness of several scripts by tightening parameter validation, refining conditional logic, and correcting minor layout/indentation issues without changing core behavior.