### PR TITLE
fix: enforce PSSA style/ShouldProcess in security/automation/data/utilities

### DIFF
--- a/scripts/automation/cicd/Analyze-BuildPerformance.ps1
+++ b/scripts/automation/cicd/Analyze-BuildPerformance.ps1
@@ -96,7 +96,8 @@ if (-not (Test-Path $DataSource)) {
 
 try {
     $buildData = Get-Content $DataSource -Raw | ConvertFrom-Json
-} catch {
+}
+catch {
     Write-Error "Failed to parse build data: $($_.Exception.Message)"
     exit 1
 }

--- a/scripts/automation/cicd/Monitor-AzureDevOpsPipelines.ps1
+++ b/scripts/automation/cicd/Monitor-AzureDevOpsPipelines.ps1
@@ -138,7 +138,8 @@ $OutputPath = [System.IO.Path]::GetFullPath($OutputPath)
 if (-not (Test-Path -LiteralPath $OutputPath -PathType Container)) {
     try {
         New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
-    } catch {
+    }
+    catch {
         Write-Error "Failed to create output directory '$OutputPath': $($_.Exception.Message)"
         exit 1
     }
@@ -152,10 +153,12 @@ try {
         $projectsUrl = "$baseUrl/_apis/projects?api-version=7.0"
         $projectsResponse = Invoke-RestMethod -Uri $projectsUrl -Headers $headers -Method Get
         $projects = $projectsResponse.value
-    } else {
+    }
+    else {
         $projects = @(@{ name = $Project })
     }
-} catch {
+}
+catch {
     Write-Error "Failed to retrieve projects: $($_.Exception.Message)"
     exit 1
 }
@@ -198,7 +201,8 @@ foreach ($proj in $projects) {
                     ([datetime]$_.finishedDate - [datetime]$_.createdDate).TotalMinutes
                 }
                 [math]::Round(($durations | Measure-Object -Average).Average, 2)
-            } else {
+            }
+            else {
                 0
             }
 
@@ -229,7 +233,8 @@ foreach ($proj in $projects) {
                 Status = if ($successRate -ge 90) { 'Healthy' } elseif ($successRate -ge 70) { 'Warning' } else { 'Critical' }
             }
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to analyze pipelines for $projectName : $($_.Exception.Message)"
     }
 
@@ -256,7 +261,8 @@ foreach ($proj in $projects) {
                     HealthStatus = if ($onlineAgents -eq 0) { 'Critical' } elseif ($offlineAgents -gt 0) { 'Warning' } else { 'Healthy' }
                 }
             }
-        } catch {
+        }
+        catch {
             Write-Warning "Failed to analyze agent pools: $($_.Exception.Message)"
         }
     }
@@ -285,7 +291,8 @@ foreach ($proj in $projects) {
                     Environments = $deploymentStatus
                 }
             }
-        } catch {
+        }
+        catch {
             Write-Warning "Failed to analyze releases for $projectName : $($_.Exception.Message)"
         }
     }

--- a/scripts/automation/cicd/Monitor-GitHubActions.ps1
+++ b/scripts/automation/cicd/Monitor-GitHubActions.ps1
@@ -128,10 +128,12 @@ try {
         $reposUrl = "$baseUrl/orgs/$Owner/repos?per_page=100"
         $reposResponse = Invoke-RestMethod -Uri $reposUrl -Headers $headers -Method Get
         $repositories = $reposResponse | Select-Object -ExpandProperty name
-    } else {
+    }
+    else {
         $repositories = @($Repository)
     }
-} catch {
+}
+catch {
     Write-Error "Failed to retrieve repositories: $($_.Exception.Message)"
     exit 1
 }
@@ -167,7 +169,8 @@ foreach ($repo in $repositories) {
 
             $successRate = if ($totalRuns -gt 0) {
                 [math]::Round((($successfulRuns + $skippedRuns) / $totalRuns) * 100, 2)
-            } else { 0 }
+            }
+            else { 0 }
 
             # Calculate average duration
             $completedRuns = $recentRuns | Where-Object { $_.conclusion -and $_.updated_at }
@@ -176,7 +179,8 @@ foreach ($repo in $repositories) {
                     ([datetime]$_.updated_at - [datetime]$_.created_at).TotalMinutes
                 }
                 [math]::Round(($durations | Measure-Object -Average).Average, 2)
-            } else {
+            }
+            else {
                 0
             }
 
@@ -210,7 +214,8 @@ foreach ($repo in $repositories) {
                 Status = if ($successRate -ge 90) { 'Healthy' } elseif ($successRate -ge 70) { 'Warning' } else { 'Critical' }
             }
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to analyze workflows for $repo : $($_.Exception.Message)"
     }
 }
@@ -232,7 +237,8 @@ if ($IncludeRunners) {
                 Labels = ($runner.labels | Select-Object -ExpandProperty name) -join ', '
             }
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to analyze runners: $($_.Exception.Message)"
     }
 }
@@ -250,7 +256,8 @@ if ($IncludeBilling) {
             IncludedMinutes = $billingResponse.included_minutes
             MinutesUsedBreakdown = $billingResponse.minutes_used_breakdown
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to retrieve billing information (requires admin access): $($_.Exception.Message)"
     }
 }
@@ -262,7 +269,8 @@ $warningWorkflows = ($results.Workflows | Where-Object { $_.Status -eq 'Warning'
 $criticalWorkflows = ($results.Workflows | Where-Object { $_.Status -eq 'Critical' }).Count
 $avgSuccessRate = if ($totalWorkflows -gt 0) {
     [math]::Round(($results.Workflows.SuccessRate | Measure-Object -Average).Average, 2)
-} else { 0 }
+}
+else { 0 }
 
 $results.Summary = @{
     TotalWorkflows = $totalWorkflows

--- a/scripts/automation/cicd/Monitor-GitLabCI.ps1
+++ b/scripts/automation/cicd/Monitor-GitLabCI.ps1
@@ -125,13 +125,15 @@ try {
         $projectsUrl = "$apiUrl/projects?membership=true&per_page=100"
         $projectsResponse = Invoke-RestMethod -Uri $projectsUrl -Headers $headers -Method Get
         $projects = $projectsResponse | Select-Object id, name, path_with_namespace
-    } else {
+    }
+    else {
         $encodedProject = [uri]::EscapeDataString($ProjectId)
         $projectUrl = "$apiUrl/projects/$encodedProject"
         $project = Invoke-RestMethod -Uri $projectUrl -Headers $headers -Method Get
         $projects = @($project | Select-Object id, name, path_with_namespace)
     }
-} catch {
+}
+catch {
     Write-Error "Failed to retrieve projects: $($_.Exception.Message)"
     exit 1
 }
@@ -167,13 +169,15 @@ foreach ($project in $projects) {
 
             $successRate = if ($totalRuns -gt 0) {
                 [math]::Round((($successfulRuns + $skippedRuns) / $totalRuns) * 100, 2)
-            } else { 0 }
+            }
+            else { 0 }
 
             # Calculate average duration for completed pipelines
             $completedPipelines = $refPipelines | Where-Object { $_.duration }
             $avgDuration = if ($completedPipelines.Count -gt 0) {
                 [math]::Round(($completedPipelines.duration | Measure-Object -Average).Average / 60, 2)
-            } else { 0 }
+            }
+            else { 0 }
 
             # Get failed pipeline details
             $failedDetails = $refPipelines | Where-Object { $_.status -eq 'failed' } |
@@ -202,7 +206,8 @@ foreach ($project in $projects) {
                 Status = if ($successRate -ge 90) { 'Healthy' } elseif ($successRate -ge 70) { 'Warning' } else { 'Critical' }
             }
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to analyze pipelines for $($project.path_with_namespace): $($_.Exception.Message)"
     }
 
@@ -223,7 +228,8 @@ foreach ($project in $projects) {
                     UpdatedAt = $deployment.updated_at
                 }
             }
-        } catch {
+        }
+        catch {
             Write-Warning "Failed to retrieve deployments for $($project.path_with_namespace): $($_.Exception.Message)"
         }
     }
@@ -248,7 +254,8 @@ if ($IncludeRunners) {
                 Architecture = $runner.architecture
             }
         }
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to retrieve runners (requires admin access): $($_.Exception.Message)"
     }
 }
@@ -260,7 +267,8 @@ $warningPipelines = ($results.Pipelines | Where-Object { $_.Status -eq 'Warning'
 $criticalPipelines = ($results.Pipelines | Where-Object { $_.Status -eq 'Critical' }).Count
 $avgSuccessRate = if ($totalPipelines -gt 0) {
     [math]::Round(($results.Pipelines.SuccessRate | Measure-Object -Average).Average, 2)
-} else { 0 }
+}
+else { 0 }
 
 $results.Summary = @{
     TotalPipelines = $totalPipelines

--- a/scripts/automation/iac/Test-BicepTemplates.ps1
+++ b/scripts/automation/iac/Test-BicepTemplates.ps1
@@ -102,7 +102,8 @@ Write-Host "Validating Bicep templates..." -ForegroundColor Cyan
 try {
     $bicepVersion = bicep --version
     Write-Host "Bicep CLI version: $bicepVersion" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Error "Bicep CLI not found. Install from: https://aka.ms/bicep-install"
     exit 1
 }
@@ -111,9 +112,11 @@ try {
 $templates = @()
 if (Test-Path $TemplatePath -PathType Container) {
     $templates = Get-ChildItem -Path $TemplatePath -Filter "*.bicep" -Recurse
-} elseif (Test-Path $TemplatePath -PathType Leaf) {
+}
+elseif (Test-Path $TemplatePath -PathType Leaf) {
     $templates = @(Get-Item $TemplatePath)
-} else {
+}
+else {
     Write-Error "Template path not found: $TemplatePath"
     exit 1
 }
@@ -139,11 +142,13 @@ foreach ($template in $templates) {
         if ($LASTEXITCODE -eq 0) {
             $templateResult.SyntaxValid = $true
             Write-Host "  ✓ Syntax validation passed" -ForegroundColor Green
-        } else {
+        }
+        else {
             $templateResult.Errors += "Syntax validation failed: $buildOutput"
             Write-Host "  ✗ Syntax validation failed" -ForegroundColor Red
         }
-    } catch {
+    }
+    catch {
         $templateResult.Errors += "Build error: $($_.Exception.Message)"
     }
 
@@ -152,11 +157,13 @@ foreach ($template in $templates) {
         $lintOutput = bicep lint $template.FullName 2>&1
         if ($LASTEXITCODE -eq 0 -and -not $lintOutput) {
             Write-Host "  ✓ Lint analysis passed" -ForegroundColor Green
-        } else {
+        }
+        else {
             $templateResult.BestPracticeIssues += [string]$lintOutput
             Write-Host "  ⚠ Lint: $lintOutput" -ForegroundColor Yellow
         }
-    } catch {
+    }
+    catch {
         $templateResult.BestPracticeIssues += "Lint error: $($_.Exception.Message)"
     }
 
@@ -199,10 +206,12 @@ foreach ($template in $templates) {
                 $whatIfResult = Invoke-Expression $whatIfCmd 2>&1
                 $templateResult.WhatIfResult = $whatIfResult
                 Write-Host "  ✓ What-if analysis completed" -ForegroundColor Green
-            } catch {
+            }
+            catch {
                 $templateResult.Warnings += "What-if analysis failed: $($_.Exception.Message)"
             }
-        } else {
+        }
+        else {
             $templateResult.Warnings += "SubscriptionId and ResourceGroupName required for what-if analysis"
         }
     }

--- a/scripts/automation/iac/Test-TerraformConfiguration.ps1
+++ b/scripts/automation/iac/Test-TerraformConfiguration.ps1
@@ -92,7 +92,8 @@ Write-Host "Validating Terraform configuration: $ConfigPath" -ForegroundColor Cy
 try {
     $tfVersion = terraform version
     Write-Host "Terraform version: $($tfVersion[0])" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Error "Terraform CLI not found. Install from: https://www.terraform.io/downloads"
     exit 1
 }
@@ -112,7 +113,8 @@ try {
     if ($LASTEXITCODE -eq 0) {
         $results.ValidationResults.Init = @{ Success = $true; Output = $initOutput }
         Write-Host "  ✓ Initialization successful" -ForegroundColor Green
-    } else {
+    }
+    else {
         $results.ValidationResults.Init = @{ Success = $false; Output = $initOutput }
         Write-Host "  ✗ Initialization failed" -ForegroundColor Red
     }
@@ -123,7 +125,8 @@ try {
     if ($LASTEXITCODE -eq 0) {
         $results.ValidationResults.Format = @{ Success = $true; Message = "All files properly formatted" }
         Write-Host "  ✓ Formatting check passed" -ForegroundColor Green
-    } else {
+    }
+    else {
         $results.ValidationResults.Format = @{ Success = $false; FilesNeedingFormat = $fmtOutput }
         Write-Host "  ⚠ Some files need formatting" -ForegroundColor Yellow
     }
@@ -134,7 +137,8 @@ try {
     if ($validateOutput.valid) {
         $results.ValidationResults.Validate = @{ Success = $true; Message = "Configuration valid" }
         Write-Host "  ✓ Validation passed" -ForegroundColor Green
-    } else {
+    }
+    else {
         $results.ValidationResults.Validate = @{
             Success = $false
             Errors = $validateOutput.diagnostics
@@ -164,7 +168,8 @@ try {
             }
             Write-Host "  ✓ Plan generated: $($planShow.resource_changes.Count) resource changes" -ForegroundColor Green
             Remove-Item tfplan -Force -ErrorAction SilentlyContinue
-        } else {
+        }
+        else {
             $results.ValidationResults.Plan = @{ Success = $false; Output = $planOutput }
             Write-Host "  ✗ Plan generation failed" -ForegroundColor Red
         }
@@ -185,12 +190,14 @@ try {
                 }
             }
             Write-Host "  ✓ Security scan complete: $($results.SecurityIssues.Count) issues found" -ForegroundColor $(if ($results.SecurityIssues.Count -eq 0) { 'Green' } else { 'Yellow' })
-        } catch {
+        }
+        catch {
             Write-Host "  ⚠ tfsec not found. Install from: https://github.com/aquasecurity/tfsec" -ForegroundColor Yellow
         }
     }
 
-} finally {
+}
+finally {
     Pop-Location
 }
 

--- a/scripts/data/api/Monitor-AzureAPIManagement.ps1
+++ b/scripts/data/api/Monitor-AzureAPIManagement.ps1
@@ -137,7 +137,8 @@ try {
         exit 1
     }
     Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
-} catch {
+}
+catch {
     Write-Error "Failed to set Azure context: $($_.Exception.Message)"
     exit 1
 }
@@ -160,7 +161,8 @@ try {
     }
 
     Write-Host "Service Status: $($apim.ProvisioningState)" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Error "Failed to retrieve API Management service: $($_.Exception.Message)"
     exit 1
 }
@@ -219,11 +221,13 @@ try {
 
     $successRate = if ($totalRequests -gt 0) {
         [math]::Round(($successfulRequests / $totalRequests) * 100, 2)
-    } else { 0 }
+    }
+    else { 0 }
 
     $avgCapacity = if ($capacityMetric.Data.Count -gt 0) {
         [math]::Round(($capacityMetric.Data.Average | Measure-Object -Average).Average, 2)
-    } else { 0 }
+    }
+    else { 0 }
 
     $results.Metrics = @{
         TotalRequests = $totalRequests
@@ -236,7 +240,8 @@ try {
 
     Write-Host "Total Requests: $totalRequests | Success Rate: $successRate%" -ForegroundColor White
     Write-Host "Average Capacity: $avgCapacity%" -ForegroundColor White
-} catch {
+}
+catch {
     Write-Warning "Failed to retrieve metrics: $($_.Exception.Message)"
 }
 
@@ -264,7 +269,8 @@ if ($IncludeAPIDetails) {
         }
 
         Write-Host "Found $($apis.Count) APIs with $($results.APIs.OperationCount | Measure-Object -Sum).Sum operations" -ForegroundColor White
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to retrieve API details: $($_.Exception.Message)"
     }
 }
@@ -287,20 +293,21 @@ if ($IncludeBackendHealth) {
         }
 
         Write-Host "Found $($backends.Count) backend services" -ForegroundColor White
-    } catch {
+    }
+    catch {
         Write-Warning "Failed to retrieve backend details: $($_.Exception.Message)"
     }
 }
 
 # Calculate summary
 $healthStatus = if ($successRate -ge 99) { 'Excellent' }
-    elseif ($successRate -ge 95) { 'Good' }
-    elseif ($successRate -ge 90) { 'Fair' }
-    else { 'Poor' }
+elseif ($successRate -ge 95) { 'Good' }
+elseif ($successRate -ge 90) { 'Fair' }
+else { 'Poor' }
 
 $capacityStatus = if ($avgCapacity -lt 70) { 'Healthy' }
-    elseif ($avgCapacity -lt 85) { 'Warning' }
-    else { 'Critical' }
+elseif ($avgCapacity -lt 85) { 'Warning' }
+else { 'Critical' }
 
 $results.Summary = @{
     ServiceName = $ServiceName

--- a/scripts/data/api/Test-APIHealth.ps1
+++ b/scripts/data/api/Test-APIHealth.ps1
@@ -170,7 +170,8 @@ function Test-Endpoint {
         try {
             $response = Invoke-WebRequest @requestParams
             $statusCode = $response.StatusCode
-        } catch {
+        }
+        catch {
             $statusCode = $_.Exception.Response.StatusCode.value__
             if (-not $statusCode) { $statusCode = 0 }
             $response = $null
@@ -185,7 +186,8 @@ function Test-Endpoint {
         # Validate status code
         if ($statusCode -eq $Endpoint.ExpectedStatusCode) {
             $result.Success = $true
-        } else {
+        }
+        else {
             $result.Errors += "Status code mismatch: Expected $($Endpoint.ExpectedStatusCode), Got $statusCode"
         }
 
@@ -214,14 +216,16 @@ function Test-Endpoint {
                         if ($daysUntilExpiration -lt 30) {
                             $result.Warnings += "SSL certificate expires in $daysUntilExpiration days"
                         }
-                    } else {
+                    }
+                    else {
                         $result.Errors += "SSL certificate expired on $($expirationDate.ToString('yyyy-MM-dd'))"
                     }
                 }
 
                 $sslStream.Close()
                 $tcpClient.Close()
-            } catch {
+            }
+            catch {
                 $result.Errors += "SSL validation failed: $($_.Exception.Message)"
             }
         }
@@ -240,7 +244,8 @@ function Test-Endpoint {
             }
         }
 
-    } catch {
+    }
+    catch {
         $result.Errors += "Request failed: $($_.Exception.Message)"
     }
 
@@ -270,11 +275,13 @@ if ($EndpointsFile) {
                 ContentType = $ep.ContentType
             }
         }
-    } catch {
+    }
+    catch {
         Write-Error "Failed to parse endpoints file: $($_.Exception.Message)"
         exit 1
     }
-} elseif ($SingleEndpoint) {
+}
+elseif ($SingleEndpoint) {
     $endpoints += @{
         Name = "Single Endpoint Test"
         Url = $SingleEndpoint
@@ -282,7 +289,8 @@ if ($EndpointsFile) {
         ExpectedStatusCode = $ExpectedStatusCode
         MaxResponseTime = $MaxResponseTime
     }
-} else {
+}
+else {
     Write-Error "Either -EndpointsFile or -SingleEndpoint must be specified"
     exit 1
 }
@@ -305,7 +313,8 @@ function Run-Tests {
 
         if ($result.Success) {
             Write-Host "    ✓ Passed ($($result.ResponseTime) ms)" -ForegroundColor Green
-        } else {
+        }
+        else {
             Write-Host "    ✗ Failed: $($result.Errors -join ', ')" -ForegroundColor Red
         }
 

--- a/scripts/data/databases/Get-MySQLHealth.ps1
+++ b/scripts/data/databases/Get-MySQLHealth.ps1
@@ -28,7 +28,7 @@ if (-not $mysqlCmd) {
     exit 1
 }
 
-$cred = if ($Password) {"-p$Password"} else {""}
+$cred = if ($Password) { "-p$Password" } else { "" }
 $results = @{}
 
 # Get version
@@ -58,7 +58,8 @@ if ($CheckReplication) {
     $replica = mysql -h $Server -u $Username $cred -P $Port -e "SHOW REPLICA STATUS\G" 2>$null
     if ($replica) {
         Write-Host "[+] Replication configured" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "[!] Replication not configured or not a replica" -ForegroundColor Yellow
     }
 }

--- a/scripts/data/databases/Get-SQLServerHealth.ps1
+++ b/scripts/data/databases/Get-SQLServerHealth.ps1
@@ -53,22 +53,22 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ServerInstance = "localhost",
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$Database,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludePerformance,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckBackups,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -209,8 +209,8 @@ ORDER BY DaysSinceFullBackup DESC
             $daysSince = if ($backup.DaysSinceFullBackup -is [DBNull]) { 999 } else { $backup.DaysSinceFullBackup }
 
             $status = if ($daysSince -le 1) { "Pass" }
-                     elseif ($daysSince -le 7) { "Warning" }
-                     else { "Fail" }
+            elseif ($daysSince -le 7) { "Warning" }
+            else { "Fail" }
 
             if ($status -eq "Fail") { $issueCount++ }
 
@@ -249,8 +249,8 @@ if ($logSpace) {
         $logUsed = [math]::Round($log.'Log Space Used (%)', 2)
 
         $status = if ($logUsed -lt 70) { "Pass" }
-                 elseif ($logUsed -lt 90) { "Warning" }
-                 else { "Fail" }
+        elseif ($logUsed -lt 90) { "Warning" }
+        else { "Fail" }
 
         if ($status -eq "Fail") { $issueCount++ }
 

--- a/scripts/data/databases/Monitor-MongoDBHealth.ps1
+++ b/scripts/data/databases/Monitor-MongoDBHealth.ps1
@@ -127,7 +127,8 @@ if ($Credential) {
     finally {
         [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstrPtr)
     }
-} elseif ($Username -and $Password) {
+}
+elseif ($Username -and $Password) {
     $bstrPtr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)
     try {
         $password = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstrPtr)

--- a/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
+++ b/scripts/security/compliance/defender-endpoint/Get-MDEDeviceHealth.ps1
@@ -178,7 +178,8 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     Write-Error "Error accessing Defender for Endpoint: $($_.Exception.Message)"
 }
 

--- a/scripts/security/compliance/frameworks/Get-AntivirusStatus.ps1
+++ b/scripts/security/compliance/frameworks/Get-AntivirusStatus.ps1
@@ -118,14 +118,17 @@ try {
                     ActionSuccess = $_.ActionSuccess
                 }
             }
-        } catch {
+        }
+        catch {
             $avStatus.WindowsDefender.RecentThreats = 0
         }
-    } else {
+    }
+    else {
         $avStatus.WindowsDefender.Enabled = $false
         $avStatus.Issues += "Could not retrieve Windows Defender status"
     }
-} catch {
+}
+catch {
     $avStatus.WindowsDefender.Error = $_.Exception.Message
     $avStatus.Issues += "Error checking Windows Defender: $($_.Exception.Message)"
 }
@@ -170,7 +173,8 @@ if ($CheckThirdParty) {
                 }
             }
         }
-    } catch {
+    }
+    catch {
         Write-Verbose "Could not query Security Center: $($_.Exception.Message)"
     }
 
@@ -200,9 +204,9 @@ try {
     $firewallProfiles = Get-NetFirewallProfile -ErrorAction SilentlyContinue
 
     $avStatus.Firewall = @{
-        Domain = ($firewallProfiles | Where-Object {$_.Name -eq 'Domain'}).Enabled
-        Private = ($firewallProfiles | Where-Object {$_.Name -eq 'Private'}).Enabled
-        Public = ($firewallProfiles | Where-Object {$_.Name -eq 'Public'}).Enabled
+        Domain = ($firewallProfiles | Where-Object { $_.Name -eq 'Domain' }).Enabled
+        Private = ($firewallProfiles | Where-Object { $_.Name -eq 'Private' }).Enabled
+        Public = ($firewallProfiles | Where-Object { $_.Name -eq 'Public' }).Enabled
     }
 
     foreach ($profile in $firewallProfiles) {
@@ -210,7 +214,8 @@ try {
             $avStatus.Issues += "Windows Firewall is DISABLED for $($profile.Name) profile"
         }
     }
-} catch {
+}
+catch {
     $avStatus.Firewall.Error = $_.Exception.Message
     $avStatus.Issues += "Error checking firewall status"
 }
@@ -220,10 +225,12 @@ try {
 if ($avStatus.Issues.Count -eq 0) {
     $avStatus.OverallStatus = "Protected"
     $statusColor = "Green"
-} elseif ($avStatus.Issues.Count -le 2) {
+}
+elseif ($avStatus.Issues.Count -le 2) {
     $avStatus.OverallStatus = "Warning"
     $statusColor = "Yellow"
-} else {
+}
+else {
     $avStatus.OverallStatus = "At Risk"
     $statusColor = "Red"
 }
@@ -232,10 +239,10 @@ if ($avStatus.Issues.Count -eq 0) {
 Write-Host "`n=== Antivirus Status Summary ===" -ForegroundColor Cyan
 Write-Host "Overall Status: $($avStatus.OverallStatus)" -ForegroundColor $statusColor
 Write-Host "`nWindows Defender:" -ForegroundColor Cyan
-Write-Host "  Enabled: $($avStatus.WindowsDefender.Enabled)" -ForegroundColor $(if ($avStatus.WindowsDefender.Enabled) {'Green'} else {'Red'})
-Write-Host "  Real-Time Protection: $($avStatus.WindowsDefender.RealTimeProtectionEnabled)" -ForegroundColor $(if ($avStatus.WindowsDefender.RealTimeProtectionEnabled) {'Green'} else {'Red'})
+Write-Host "  Enabled: $($avStatus.WindowsDefender.Enabled)" -ForegroundColor $(if ($avStatus.WindowsDefender.Enabled) { 'Green' } else { 'Red' })
+Write-Host "  Real-Time Protection: $($avStatus.WindowsDefender.RealTimeProtectionEnabled)" -ForegroundColor $(if ($avStatus.WindowsDefender.RealTimeProtectionEnabled) { 'Green' } else { 'Red' })
 Write-Host "  Signature Version: $($avStatus.WindowsDefender.AntivirusSignatureVersion)"
-Write-Host "  Signature Age: $($avStatus.WindowsDefender.AntivirusSignatureAge) days" -ForegroundColor $(if ($avStatus.WindowsDefender.AntivirusSignatureAge -le 7) {'Green'} else {'Yellow'})
+Write-Host "  Signature Age: $($avStatus.WindowsDefender.AntivirusSignatureAge) days" -ForegroundColor $(if ($avStatus.WindowsDefender.AntivirusSignatureAge -le 7) { 'Green' } else { 'Yellow' })
 Write-Host "  Last Quick Scan: $($avStatus.WindowsDefender.QuickScanEndTime)"
 Write-Host "  Last Full Scan: $($avStatus.WindowsDefender.FullScanEndTime)"
 
@@ -247,14 +254,15 @@ if ($avStatus.ThirdPartyAV.Count -gt 0) {
 }
 
 Write-Host "`nWindows Firewall:" -ForegroundColor Cyan
-Write-Host "  Domain Profile: $($avStatus.Firewall.Domain)" -ForegroundColor $(if ($avStatus.Firewall.Domain) {'Green'} else {'Red'})
-Write-Host "  Private Profile: $($avStatus.Firewall.Private)" -ForegroundColor $(if ($avStatus.Firewall.Private) {'Green'} else {'Red'})
-Write-Host "  Public Profile: $($avStatus.Firewall.Public)" -ForegroundColor $(if ($avStatus.Firewall.Public) {'Green'} else {'Red'})
+Write-Host "  Domain Profile: $($avStatus.Firewall.Domain)" -ForegroundColor $(if ($avStatus.Firewall.Domain) { 'Green' } else { 'Red' })
+Write-Host "  Private Profile: $($avStatus.Firewall.Private)" -ForegroundColor $(if ($avStatus.Firewall.Private) { 'Green' } else { 'Red' })
+Write-Host "  Public Profile: $($avStatus.Firewall.Public)" -ForegroundColor $(if ($avStatus.Firewall.Public) { 'Green' } else { 'Red' })
 
 if ($avStatus.Issues.Count -gt 0) {
     Write-Host "`n=== Issues Found ===" -ForegroundColor Red
     $avStatus.Issues | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
-} else {
+}
+else {
     Write-Host "`nNo issues found. System is properly protected." -ForegroundColor Green
 }
 #endregion
@@ -273,7 +281,8 @@ if ($OutputFormat -eq 'HTML' -or $OutputFormat -eq 'All') {
 
     $issuesHtml = if ($avStatus.Issues.Count -gt 0) {
         "<ul>" + ($avStatus.Issues | ForEach-Object { "<li style='color: red;'>$_</li>" }) + "</ul>"
-    } else {
+    }
+    else {
         "<p style='color: green;'>No issues found.</p>"
     }
 

--- a/scripts/security/compliance/frameworks/Get-ExpiredCertificates.ps1
+++ b/scripts/security/compliance/frameworks/Get-ExpiredCertificates.ps1
@@ -134,7 +134,8 @@ foreach ($Location in $StoreLocations) {
                 $Results += $CertInfo
             }
 
-        } catch {
+        }
+        catch {
             Write-Verbose "Error scanning $Location\$StoreName : $($_.Exception.Message)"
         }
     }
@@ -156,7 +157,8 @@ Write-Host "`n[3/3] Certificate Details..." -ForegroundColor Yellow
 
 if ($Results.Count -eq 0) {
     Write-Host "`n  ✓ No expired or expiring certificates found!" -ForegroundColor Green
-} else {
+}
+else {
     # Sort by days until expiry (expired first)
     $Results = $Results | Sort-Object DaysUntilExpiry
 
@@ -332,7 +334,8 @@ if ($ExportReport) {
         }
 
         $HTML += "</table>"
-    } else {
+    }
+    else {
         $HTML += "<p style='color: #27ae60; font-size: 18px; font-weight: bold;'>✓ No expired or expiring certificates found!</p>"
     }
 
@@ -359,7 +362,8 @@ Write-Host ""
 if ($IssuesFound) {
     Write-Host "⚠ Certificate scan completed with issues found.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "✓ Certificate scan completed. No issues found.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
+++ b/scripts/security/compliance/frameworks/Get-FailedLoginReport.ps1
@@ -84,11 +84,13 @@ try {
 
     Write-Host "    Found: $($FailedLoginEvents.Count) failed login events" -ForegroundColor Green
 
-} catch {
+}
+catch {
     if ($_.Exception.Message -like "*No events were found*") {
         Write-Host "    Found: 0 failed login events" -ForegroundColor Green
         $FailedLoginEvents = @()
-    } else {
+    }
+    else {
         Write-Host "    ERROR: Unable to query event log - $($_.Exception.Message)" -ForegroundColor Red
         Write-Host "    Make sure you're running as Administrator and audit policy is enabled." -ForegroundColor Yellow
         exit 1
@@ -106,11 +108,13 @@ try {
 
     Write-Host "    Found: $($LockoutEvents.Count) lockout events" -ForegroundColor $(if ($LockoutEvents.Count -gt 0) { 'Red' } else { 'Green' })
 
-} catch {
+}
+catch {
     if ($_.Exception.Message -like "*No events were found*") {
         Write-Host "    Found: 0 lockout events" -ForegroundColor Green
         $LockoutEvents = @()
-    } else {
+    }
+    else {
         Write-Verbose "Error querying lockout events: $($_.Exception.Message)"
         $LockoutEvents = @()
     }
@@ -137,12 +141,12 @@ foreach ($Event in $FailedLoginEvents) {
 
         # Map logon type to friendly name
         $LogonTypeDescription = switch ($LogonType) {
-            '2'  { 'Interactive (Console)' }
-            '3'  { 'Network (SMB/File Share)' }
-            '4'  { 'Batch' }
-            '5'  { 'Service' }
-            '7'  { 'Unlock' }
-            '8'  { 'NetworkCleartext' }
+            '2' { 'Interactive (Console)' }
+            '3' { 'Network (SMB/File Share)' }
+            '4' { 'Batch' }
+            '5' { 'Service' }
+            '7' { 'Unlock' }
+            '8' { 'NetworkCleartext' }
             '10' { 'Remote Desktop (RDP)' }
             '11' { 'Cached Credentials' }
             default { "Unknown ($LogonType)" }
@@ -178,7 +182,8 @@ foreach ($Event in $FailedLoginEvents) {
 
         $FailedLogins += $FailedLogin
 
-    } catch {
+    }
+    catch {
         Write-Verbose "Error parsing event: $($_.Exception.Message)"
     }
 }
@@ -203,7 +208,8 @@ if ($LockoutEvents.Count -gt 0) {
 
             $Lockouts += $Lockout
 
-        } catch {
+        }
+        catch {
             Write-Verbose "Error parsing lockout event: $($_.Exception.Message)"
         }
     }
@@ -217,7 +223,7 @@ $UserFailureCounts = $FailedLogins | Group-Object UserName | Sort-Object Count -
 
 # Group by source IP
 $IPFailureCounts = $FailedLogins | Where-Object { $_.SourceIP -and $_.SourceIP -ne '-' } |
-                    Group-Object SourceIP | Sort-Object Count -Descending
+    Group-Object SourceIP | Sort-Object Count -Descending
 
 # Identify potential brute force (more than 5 failures)
 $BruteForceAccounts = $UserFailureCounts | Where-Object { $_.Count -ge 5 }
@@ -454,7 +460,8 @@ Write-Host ""
 if ($FailedLogins.Count -gt 0 -or $Lockouts.Count -gt 0) {
     Write-Host "⚠ Failed login activity detected. Review the report above.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "✓ No failed login attempts found in the specified time period.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Get-LocalAdminAudit.ps1
+++ b/scripts/security/compliance/frameworks/Get-LocalAdminAudit.ps1
@@ -61,7 +61,8 @@ try {
     $AdminMembers = Get-LocalGroupMember -Name "Administrators" -ErrorAction Stop
 
     Write-Host "  Found $($AdminMembers.Count) member(s) in Administrators group`n" -ForegroundColor Green
-} catch {
+}
+catch {
     Write-Host "  ERROR: Failed to retrieve Administrators group: $($_.Exception.Message)" -ForegroundColor Red
     exit 1
 }
@@ -110,7 +111,8 @@ foreach ($Member in $AdminMembers) {
                 $AccountInfo.PasswordExpires = "Never"
                 $AccountInfo.Notes += "Password never expires"
                 $AccountInfo.Risk = "Medium"
-            } else {
+            }
+            else {
                 $AccountInfo.PasswordExpires = "Yes"
             }
 
@@ -123,7 +125,8 @@ foreach ($Member in $AdminMembers) {
                         $AccountInfo.Notes += "No logon in $($DaysSinceLogon.Days) days"
                         $AccountInfo.Risk = "Medium"
                     }
-                } else {
+                }
+                else {
                     $AccountInfo.Notes += "Account never used"
                     $AccountInfo.Risk = "High"
                 }
@@ -134,30 +137,36 @@ foreach ($Member in $AdminMembers) {
                     $AccountInfo.Risk = "High"
                     $IssuesFound = $true
                 }
-            } else {
+            }
+            else {
                 $AccountInfo.Notes += "Account disabled"
             }
 
-        } catch {
+        }
+        catch {
             $AccountInfo.Notes += "Could not retrieve account details"
         }
 
-    } elseif ($Member.PrincipalSource -eq "ActiveDirectory") {
+    }
+    elseif ($Member.PrincipalSource -eq "ActiveDirectory") {
         $AccountInfo.AccountType = "Domain Account"
         $AccountInfo.Notes += "Domain-based administrator"
 
         # Check if it's a user or group
         if ($Member.ObjectClass -eq "Group") {
             $AccountInfo.Notes += "Domain Group"
-        } else {
+        }
+        else {
             $AccountInfo.Notes += "Domain User"
         }
 
-    } elseif ($Member.PrincipalSource -eq "AzureAD") {
+    }
+    elseif ($Member.PrincipalSource -eq "AzureAD") {
         $AccountInfo.AccountType = "Azure AD Account"
         $AccountInfo.Notes += "Azure AD-based administrator"
 
-    } else {
+    }
+    else {
         $AccountInfo.AccountType = "Unknown"
         $AccountInfo.Notes += "Unknown account source"
         $AccountInfo.Risk = "High"
@@ -373,7 +382,8 @@ Write-Host ""
 if ($IssuesFound) {
     Write-Host "⚠ Audit completed with issues found. Review high-risk accounts.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "✓ Audit completed. No critical issues found.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Get-OpenPortScan.ps1
+++ b/scripts/security/compliance/frameworks/Get-OpenPortScan.ps1
@@ -60,19 +60,19 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 
 # Define high-risk ports
 $HighRiskPorts = @{
-    21   = @{ Service = "FTP"; Risk = "High"; Reason = "Unencrypted file transfer" }
-    22   = @{ Service = "SSH"; Risk = "Medium"; Reason = "Remote access (ensure strong auth)" }
-    23   = @{ Service = "Telnet"; Risk = "Critical"; Reason = "Unencrypted remote access" }
-    25   = @{ Service = "SMTP"; Risk = "Medium"; Reason = "Email relay (ensure secured)" }
-    53   = @{ Service = "DNS"; Risk = "Low"; Reason = "Domain resolution" }
-    80   = @{ Service = "HTTP"; Risk = "Medium"; Reason = "Unencrypted web traffic" }
-    110  = @{ Service = "POP3"; Risk = "Medium"; Reason = "Unencrypted email" }
-    135  = @{ Service = "RPC"; Risk = "High"; Reason = "Windows RPC - attack vector" }
-    139  = @{ Service = "NetBIOS"; Risk = "High"; Reason = "SMB over NetBIOS" }
-    143  = @{ Service = "IMAP"; Risk = "Medium"; Reason = "Unencrypted email" }
-    389  = @{ Service = "LDAP"; Risk = "Medium"; Reason = "Directory services (use LDAPS)" }
-    443  = @{ Service = "HTTPS"; Risk = "Low"; Reason = "Encrypted web traffic" }
-    445  = @{ Service = "SMB"; Risk = "High"; Reason = "File sharing - common attack target" }
+    21 = @{ Service = "FTP"; Risk = "High"; Reason = "Unencrypted file transfer" }
+    22 = @{ Service = "SSH"; Risk = "Medium"; Reason = "Remote access (ensure strong auth)" }
+    23 = @{ Service = "Telnet"; Risk = "Critical"; Reason = "Unencrypted remote access" }
+    25 = @{ Service = "SMTP"; Risk = "Medium"; Reason = "Email relay (ensure secured)" }
+    53 = @{ Service = "DNS"; Risk = "Low"; Reason = "Domain resolution" }
+    80 = @{ Service = "HTTP"; Risk = "Medium"; Reason = "Unencrypted web traffic" }
+    110 = @{ Service = "POP3"; Risk = "Medium"; Reason = "Unencrypted email" }
+    135 = @{ Service = "RPC"; Risk = "High"; Reason = "Windows RPC - attack vector" }
+    139 = @{ Service = "NetBIOS"; Risk = "High"; Reason = "SMB over NetBIOS" }
+    143 = @{ Service = "IMAP"; Risk = "Medium"; Reason = "Unencrypted email" }
+    389 = @{ Service = "LDAP"; Risk = "Medium"; Reason = "Directory services (use LDAPS)" }
+    443 = @{ Service = "HTTPS"; Risk = "Low"; Reason = "Encrypted web traffic" }
+    445 = @{ Service = "SMB"; Risk = "High"; Reason = "File sharing - common attack target" }
     1433 = @{ Service = "SQL Server"; Risk = "High"; Reason = "Database exposure" }
     3306 = @{ Service = "MySQL"; Risk = "High"; Reason = "Database exposure" }
     3389 = @{ Service = "RDP"; Risk = "High"; Reason = "Remote Desktop - secure properly" }
@@ -97,7 +97,8 @@ if ($IncludeUDP) {
     $UDPEndpoints = Get-NetUDPEndpoint -ErrorAction SilentlyContinue |
         Select-Object LocalAddress, LocalPort, OwningProcess
     Write-Host "  Found $($UDPEndpoints.Count) UDP endpoints`n" -ForegroundColor Green
-} else {
+}
+else {
     Write-Host "[2/3] Skipping UDP scan (use -IncludeUDP to include)" -ForegroundColor Gray
 }
 
@@ -124,7 +125,8 @@ foreach ($Connection in $TCPConnections) {
         if ($Connection.LocalAddress -eq "0.0.0.0" -or $Connection.LocalAddress -eq "::") {
             $AllInterfaces = $true
             if ($RiskLevel -eq "Low") { $RiskLevel = "Medium" }
-        } else {
+        }
+        else {
             $AllInterfaces = $false
         }
 
@@ -151,7 +153,8 @@ foreach ($Connection in $TCPConnections) {
             $Results += $PortInfo
         }
 
-    } catch {
+    }
+    catch {
         Write-Verbose "Error processing port $($Connection.LocalPort): $($_.Exception.Message)"
     }
 }
@@ -172,7 +175,8 @@ if ($IncludeUDP) {
             if ($Endpoint.LocalAddress -eq "0.0.0.0" -or $Endpoint.LocalAddress -eq "::") {
                 $AllInterfaces = $true
                 if ($RiskLevel -eq "Low") { $RiskLevel = "Medium" }
-            } else {
+            }
+            else {
                 $AllInterfaces = $false
             }
 
@@ -197,22 +201,24 @@ if ($IncludeUDP) {
                 $Results += $PortInfo
             }
 
-        } catch {
+        }
+        catch {
             Write-Verbose "Error processing UDP port $($Endpoint.LocalPort): $($_.Exception.Message)"
         }
     }
 }
 
 # Sort by risk level, then port number
-$Results = $Results | Sort-Object @{Expression={
-    switch ($_.RiskLevel) {
-        "Critical" { 0 }
-        "High" { 1 }
-        "Medium" { 2 }
-        "Low" { 3 }
-        default { 4 }
+$Results = $Results | Sort-Object @{Expression = {
+        switch ($_.RiskLevel) {
+            "Critical" { 0 }
+            "High" { 1 }
+            "Medium" { 2 }
+            "Low" { 3 }
+            default { 4 }
+        }
     }
-}}, Port
+}, Port
 
 # Display results
 Write-Host "`n========================================" -ForegroundColor Cyan
@@ -242,7 +248,8 @@ foreach ($Result in $Results) {
     if ($Result.AllInterfaces) {
         Write-Host "$($Result.Address) " -ForegroundColor Yellow -NoNewline
         Write-Host "(All Interfaces - Higher Risk)" -ForegroundColor Yellow
-    } else {
+    }
+    else {
         Write-Host $Result.Address -ForegroundColor White
     }
 
@@ -281,17 +288,23 @@ if ($CriticalCount -gt 0 -or $HighCount -gt 0) {
 
         # Specific recommendations
         switch ($Port.Port) {
-            3389 { Write-Host "  → Enable Network Level Authentication (NLA)" -ForegroundColor Cyan
-                   Write-Host "  → Use VPN or restrict by IP address" -ForegroundColor Cyan
-                   Write-Host "  → Consider changing default port" -ForegroundColor Cyan }
-            445  { Write-Host "  → Ensure SMB signing is enabled" -ForegroundColor Cyan
-                   Write-Host "  → Disable SMBv1 protocol" -ForegroundColor Cyan
-                   Write-Host "  → Use firewall to restrict access" -ForegroundColor Cyan }
-            135  { Write-Host "  → Restrict RPC access via firewall" -ForegroundColor Cyan
-                   Write-Host "  → Disable if not required" -ForegroundColor Cyan }
-            139  { Write-Host "  → Disable NetBIOS over TCP/IP if not needed" -ForegroundColor Cyan }
-            23   { Write-Host "  → CRITICAL: Replace Telnet with SSH immediately" -ForegroundColor Red }
-            21   { Write-Host "  → Replace FTP with SFTP or FTPS" -ForegroundColor Cyan }
+            3389 {
+                Write-Host "  → Enable Network Level Authentication (NLA)" -ForegroundColor Cyan
+                Write-Host "  → Use VPN or restrict by IP address" -ForegroundColor Cyan
+                Write-Host "  → Consider changing default port" -ForegroundColor Cyan 
+            }
+            445 {
+                Write-Host "  → Ensure SMB signing is enabled" -ForegroundColor Cyan
+                Write-Host "  → Disable SMBv1 protocol" -ForegroundColor Cyan
+                Write-Host "  → Use firewall to restrict access" -ForegroundColor Cyan 
+            }
+            135 {
+                Write-Host "  → Restrict RPC access via firewall" -ForegroundColor Cyan
+                Write-Host "  → Disable if not required" -ForegroundColor Cyan 
+            }
+            139 { Write-Host "  → Disable NetBIOS over TCP/IP if not needed" -ForegroundColor Cyan }
+            23 { Write-Host "  → CRITICAL: Replace Telnet with SSH immediately" -ForegroundColor Red }
+            21 { Write-Host "  → Replace FTP with SFTP or FTPS" -ForegroundColor Cyan }
         }
     }
 
@@ -382,7 +395,8 @@ if ($ExportReport) {
         $RiskClass = $Result.RiskLevel.ToLower()
         $AddressDisplay = if ($Result.AllInterfaces) {
             "$($Result.Address) <span class='all-interfaces'>(All Interfaces)</span>"
-        } else {
+        }
+        else {
             $Result.Address
         }
 
@@ -415,7 +429,8 @@ Write-Host ""
 if ($HighRiskFound) {
     Write-Host "⚠ Scan completed. High-risk ports detected - review recommendations.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "✓ Scan completed. No critical issues found.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
+++ b/scripts/security/compliance/frameworks/Get-SecurityBaseline.ps1
@@ -109,7 +109,8 @@ try {
     if ([int]$MinPasswordLength -ge 14) {
         Write-CheckResult "Minimum password length: $MinPasswordLength characters" "PASS"
         Add-Result "Password Policy" "Minimum Length" "14+" $MinPasswordLength "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Minimum password length: $MinPasswordLength characters (should be 14+)" "FAIL"
         Add-Result "Password Policy" "Minimum Length" "14+" $MinPasswordLength "FAIL"
     }
@@ -118,7 +119,8 @@ try {
     if ($PasswordComplexity -eq '1') {
         Write-CheckResult "Password complexity: Enabled" "PASS"
         Add-Result "Password Policy" "Complexity" "Enabled" "Enabled" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Password complexity: Disabled" "FAIL"
         Add-Result "Password Policy" "Complexity" "Enabled" "Disabled" "FAIL"
     }
@@ -127,7 +129,8 @@ try {
     if ([int]$MaxPasswordAge -le 60 -and [int]$MaxPasswordAge -gt 0) {
         Write-CheckResult "Maximum password age: $MaxPasswordAge days" "PASS"
         Add-Result "Password Policy" "Maximum Age" "≤60 days" "$MaxPasswordAge days" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Maximum password age: $MaxPasswordAge days (should be ≤60)" "FAIL"
         Add-Result "Password Policy" "Maximum Age" "≤60 days" "$MaxPasswordAge days" "FAIL"
     }
@@ -136,14 +139,17 @@ try {
     if ([int]$PasswordHistorySize -ge 24) {
         Write-CheckResult "Password history: $PasswordHistorySize passwords remembered" "PASS"
         Add-Result "Password Policy" "History Size" "24+" "$PasswordHistorySize" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Password history: $PasswordHistorySize passwords (should be 24+)" "FAIL"
         Add-Result "Password Policy" "History Size" "24+" "$PasswordHistorySize" "FAIL"
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check password policy: $($_.Exception.Message)" "FAIL"
     Add-Result "Password Policy" "Check" "Success" "Failed" "FAIL"
-} finally {
+}
+finally {
     # Always clean up the exported policy file, even on parse failure
     if (Test-Path -LiteralPath $secpolFile) {
         Remove-Item -LiteralPath $secpolFile -Force -ErrorAction SilentlyContinue
@@ -164,7 +170,8 @@ try {
         if ($ThresholdValue -ge 5 -and $ThresholdValue -le 10) {
             Write-CheckResult "Account lockout threshold: $LockoutThreshold" "PASS"
             Add-Result "Account Lockout" "Threshold" "5-10 attempts" $LockoutThreshold "PASS"
-        } else {
+        }
+        else {
             Write-CheckResult "Account lockout threshold: $LockoutThreshold (should be 5-10)" "FAIL"
             Add-Result "Account Lockout" "Threshold" "5-10 attempts" $LockoutThreshold "FAIL"
         }
@@ -172,7 +179,8 @@ try {
 
     Write-CheckResult "Lockout duration: $LockoutDuration" "INFO"
     Add-Result "Account Lockout" "Duration" "30+ minutes" $LockoutDuration "INFO"
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check account lockout policy: $($_.Exception.Message)" "FAIL"
     Add-Result "Account Lockout" "Check" "Success" "Failed" "FAIL"
 }
@@ -186,12 +194,14 @@ try {
         if ($Profile.Enabled) {
             Write-CheckResult "$($Profile.Name) profile: Enabled" "PASS"
             Add-Result "Windows Firewall" "$($Profile.Name) Profile" "Enabled" "Enabled" "PASS"
-        } else {
+        }
+        else {
             Write-CheckResult "$($Profile.Name) profile: Disabled" "FAIL"
             Add-Result "Windows Firewall" "$($Profile.Name) Profile" "Enabled" "Disabled" "FAIL"
         }
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check firewall status: $($_.Exception.Message)" "FAIL"
     Add-Result "Windows Firewall" "Check" "Success" "Failed" "FAIL"
 }
@@ -206,7 +216,8 @@ try {
     if ($EnableLUA.EnableLUA -eq 1) {
         Write-CheckResult "UAC: Enabled" "PASS"
         Add-Result "UAC" "Enabled" "Yes" "Yes" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "UAC: Disabled" "FAIL"
         Add-Result "UAC" "Enabled" "Yes" "No" "FAIL"
     }
@@ -214,11 +225,13 @@ try {
     if ($ConsentPromptBehaviorAdmin.ConsentPromptBehaviorAdmin -ge 2) {
         Write-CheckResult "UAC prompt for administrators: Configured" "PASS"
         Add-Result "UAC" "Prompt Behavior" "Prompt" "Configured" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "UAC prompt for administrators: Not configured properly" "FAIL"
         Add-Result "UAC" "Prompt Behavior" "Prompt" "Not Configured" "FAIL"
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check UAC settings: $($_.Exception.Message)" "FAIL"
     Add-Result "UAC" "Check" "Success" "Failed" "FAIL"
 }
@@ -231,7 +244,8 @@ try {
     if ($DefenderStatus.AntivirusEnabled) {
         Write-CheckResult "Antivirus: Enabled" "PASS"
         Add-Result "Windows Defender" "Antivirus" "Enabled" "Enabled" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Antivirus: Disabled" "FAIL"
         Add-Result "Windows Defender" "Antivirus" "Enabled" "Disabled" "FAIL"
     }
@@ -239,7 +253,8 @@ try {
     if ($DefenderStatus.RealTimeProtectionEnabled) {
         Write-CheckResult "Real-time protection: Enabled" "PASS"
         Add-Result "Windows Defender" "Real-Time Protection" "Enabled" "Enabled" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Real-time protection: Disabled" "FAIL"
         Add-Result "Windows Defender" "Real-Time Protection" "Enabled" "Disabled" "FAIL"
     }
@@ -249,11 +264,13 @@ try {
     if ($DefAge.Days -le 7) {
         Write-CheckResult "Antivirus definitions: $($DefenderStatus.AntivirusSignatureLastUpdated.ToString('yyyy-MM-dd')) (Up to date)" "PASS"
         Add-Result "Windows Defender" "Definitions" "≤7 days old" "$($DefAge.Days) days old" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Antivirus definitions: $($DefenderStatus.AntivirusSignatureLastUpdated.ToString('yyyy-MM-dd')) (Outdated)" "FAIL"
         Add-Result "Windows Defender" "Definitions" "≤7 days old" "$($DefAge.Days) days old" "FAIL"
     }
-} catch {
+}
+catch {
     Write-CheckResult "Windows Defender not available or error checking: $($_.Exception.Message)" "WARN"
     Add-Result "Windows Defender" "Check" "Success" "Not Available" "WARN"
 }
@@ -278,18 +295,21 @@ try {
             if ($AuditPol -match "$Audit.*Success and Failure") {
                 Write-CheckResult "$Audit events: Success and Failure" "PASS"
                 Add-Result "Audit Policy" $Audit "Success and Failure" "Configured" "PASS"
-            } elseif ($AuditPol -match "$Audit.*Success") {
+            }
+            elseif ($AuditPol -match "$Audit.*Success") {
                 Write-CheckResult "$Audit events: Success only (should include Failure)" "WARN"
                 Add-Result "Audit Policy" $Audit "Success and Failure" "Success only" "WARN"
                 $AuditCompliant = $false
-            } else {
+            }
+            else {
                 Write-CheckResult "$Audit events: Not configured" "FAIL"
                 Add-Result "Audit Policy" $Audit "Success and Failure" "Not configured" "FAIL"
                 $AuditCompliant = $false
             }
         }
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check audit policy: $($_.Exception.Message)" "FAIL"
     Add-Result "Audit Policy" "Check" "Success" "Failed" "FAIL"
 }
@@ -304,11 +324,14 @@ try {
     # state when Get-SmbServerConfiguration is unavailable.
     if ($null -ne $SMBServerConfig) {
         $SMB1Enabled = $SMBServerConfig.EnableSMB1Protocol
-    } elseif ($SMB1.State -eq 'Enabled') {
+    }
+    elseif ($SMB1.State -eq 'Enabled') {
         $SMB1Enabled = $true
-    } elseif ($SMB1.State -eq 'Disabled') {
+    }
+    elseif ($SMB1.State -eq 'Disabled') {
         $SMB1Enabled = $false
-    } else {
+    }
+    else {
         # Feature absent and no server configuration: SMBv1 is not active
         $SMB1Enabled = $false
     }
@@ -316,10 +339,12 @@ try {
     if ($SMB1Enabled -eq $false) {
         Write-CheckResult "SMBv1: Disabled (Secure)" "PASS"
         Add-Result "SMB Security" "SMBv1" "Disabled" "Disabled" "PASS"
-    } elseif ($SMB1Enabled -eq $true) {
+    }
+    elseif ($SMB1Enabled -eq $true) {
         Write-CheckResult "SMBv1: Enabled (Security Risk)" "FAIL"
         Add-Result "SMB Security" "SMBv1" "Disabled" "Enabled" "FAIL"
-    } else {
+    }
+    else {
         Write-CheckResult "SMBv1: Status unknown" "WARN"
         Add-Result "SMB Security" "SMBv1" "Disabled" "Unknown" "WARN"
     }
@@ -328,11 +353,13 @@ try {
     if ($SMBServerConfig -and $SMBServerConfig.EncryptData) {
         Write-CheckResult "SMB encryption: Enabled" "PASS"
         Add-Result "SMB Security" "Encryption" "Enabled" "Enabled" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "SMB encryption: Disabled (Consider enabling)" "WARN"
         Add-Result "SMB Security" "Encryption" "Enabled" "Disabled" "WARN"
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check SMB security: $($_.Exception.Message)" "WARN"
     Add-Result "SMB Security" "Check" "Success" "Failed" "WARN"
 }
@@ -346,7 +373,8 @@ try {
     if ($RDPEnabled.fDenyTSConnections -eq 1) {
         Write-CheckResult "Remote Desktop: Disabled" "INFO"
         Add-Result "Remote Desktop" "Enabled" "Disabled (Recommended)" "Disabled" "INFO"
-    } else {
+    }
+    else {
         Write-CheckResult "Remote Desktop: Enabled (Ensure NLA is required)" "WARN"
         Add-Result "Remote Desktop" "Enabled" "Disabled (Recommended)" "Enabled" "WARN"
 
@@ -357,12 +385,14 @@ try {
         if ($NLA.UserAuthentication -eq 1) {
             Write-CheckResult "  Network Level Authentication: Required" "PASS"
             Add-Result "Remote Desktop" "NLA" "Required" "Required" "PASS"
-        } else {
+        }
+        else {
             Write-CheckResult "  Network Level Authentication: Not required" "FAIL"
             Add-Result "Remote Desktop" "NLA" "Required" "Not Required" "FAIL"
         }
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check Remote Desktop security: $($_.Exception.Message)" "WARN"
     Add-Result "Remote Desktop" "Check" "Success" "Failed" "WARN"
 }
@@ -375,7 +405,8 @@ try {
     if ($AdminAccount.Enabled -eq $false) {
         Write-CheckResult "Built-in Administrator account: Disabled" "PASS"
         Add-Result "Security Options" "Built-in Admin" "Disabled" "Disabled" "PASS"
-    } else {
+    }
+    else {
         Write-CheckResult "Built-in Administrator account: Enabled (Should be disabled)" "FAIL"
         Add-Result "Security Options" "Built-in Admin" "Disabled" "Enabled" "FAIL"
     }
@@ -385,14 +416,17 @@ try {
     if ($GuestAccount -and $GuestAccount.Enabled -eq $false) {
         Write-CheckResult "Guest account: Disabled" "PASS"
         Add-Result "Security Options" "Guest Account" "Disabled" "Disabled" "PASS"
-    } elseif ($GuestAccount -and $GuestAccount.Enabled -eq $true) {
+    }
+    elseif ($GuestAccount -and $GuestAccount.Enabled -eq $true) {
         Write-CheckResult "Guest account: Enabled (Should be disabled)" "FAIL"
         Add-Result "Security Options" "Guest Account" "Disabled" "Enabled" "FAIL"
-    } else {
+    }
+    else {
         Write-CheckResult "Guest account: Not found" "INFO"
         Add-Result "Security Options" "Guest Account" "Disabled" "Not Found" "INFO"
     }
-} catch {
+}
+catch {
     Write-CheckResult "Failed to check security options: $($_.Exception.Message)" "WARN"
     Add-Result "Security Options" "Check" "Success" "Failed" "WARN"
 }
@@ -415,7 +449,8 @@ Write-Host "Warnings: $WarningChecks" -ForegroundColor Yellow
 if ($TotalChecks -eq 0) {
     Write-Warning "No checks were performed; compliance score cannot be computed."
     $CompliancePercent = 0
-} else {
+}
+else {
     $CompliancePercent = [math]::Round(($PassedChecks / $TotalChecks) * 100, 2)
 }
 Write-Host "`nCompliance Score: $CompliancePercent%" -ForegroundColor $(if ($CompliancePercent -ge 80) { 'Green' } elseif ($CompliancePercent -ge 60) { 'Yellow' } else { 'Red' })
@@ -543,7 +578,8 @@ if ($ExportReport) {
 if ($IssuesFound) {
     Write-Host "`n⚠ Security baseline check completed with issues found.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "`n✓ Security baseline check completed successfully.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Get-SoftwareLicenseCompliance.ps1
+++ b/scripts/security/compliance/frameworks/Get-SoftwareLicenseCompliance.ps1
@@ -90,10 +90,12 @@ foreach ($path in $registryPaths) {
                         if ($officeLicense) {
                             $licenseKey = $officeLicense.ProductKeyID
                             $licenseStatus = "Licensed"
-                        } else {
+                        }
+                        else {
                             $licenseStatus = "Unlicensed"
                         }
-                    } catch {
+                    }
+                    catch {
                         $licenseStatus = "Unknown"
                     }
                 }
@@ -105,10 +107,12 @@ foreach ($path in $registryPaths) {
                         if ($windowsLicense) {
                             $licenseKey = $windowsLicense.ProductKeyID
                             $licenseStatus = "Licensed"
-                        } else {
+                        }
+                        else {
                             $licenseStatus = "Unlicensed"
                         }
-                    } catch {
+                    }
+                    catch {
                         $licenseStatus = "Unknown"
                     }
                 }
@@ -138,7 +142,8 @@ foreach ($path in $registryPaths) {
                                     break
                                 }
                             }
-                        } catch {
+                        }
+                        catch {
                             # Continue to next path
                         }
                     }
@@ -149,10 +154,12 @@ foreach ($path in $registryPaths) {
             $installDate = if ($app.InstallDate) {
                 try {
                     [datetime]::ParseExact($app.InstallDate, "yyyyMMdd", $null).ToString("yyyy-MM-dd")
-                } catch {
+                }
+                catch {
                     $app.InstallDate
                 }
-            } else {
+            }
+            else {
                 "Unknown"
             }
 
@@ -166,7 +173,8 @@ foreach ($path in $registryPaths) {
                 LicenseStatus = $licenseStatus
             }
         }
-    } catch {
+    }
+    catch {
         Write-Verbose "Could not access registry path: $path"
     }
 }
@@ -178,9 +186,9 @@ Write-Host "`n=== Software Inventory Results ===" -ForegroundColor Cyan
 Write-Host "Total applications found: $($softwareInventory.Count)" -ForegroundColor Green
 
 if ($CheckLicenseKeys) {
-    $licensed = ($softwareInventory | Where-Object {$_.LicenseStatus -eq 'Licensed'}).Count
-    $unlicensed = ($softwareInventory | Where-Object {$_.LicenseStatus -eq 'Unlicensed'}).Count
-    $unknown = ($softwareInventory | Where-Object {$_.LicenseStatus -eq 'Unknown'}).Count
+    $licensed = ($softwareInventory | Where-Object { $_.LicenseStatus -eq 'Licensed' }).Count
+    $unlicensed = ($softwareInventory | Where-Object { $_.LicenseStatus -eq 'Unlicensed' }).Count
+    $unknown = ($softwareInventory | Where-Object { $_.LicenseStatus -eq 'Unknown' }).Count
 
     Write-Host "Licensed software: $licensed" -ForegroundColor Green
     Write-Host "Unlicensed software: $unlicensed" -ForegroundColor $(if ($unlicensed -gt 0) { 'Red' } else { 'Green' })
@@ -204,7 +212,7 @@ if ($HighlightUnlicensed) {
 }
 
 # Detect duplicate installations
-$duplicates = $softwareInventory | Group-Object Name | Where-Object {$_.Count -gt 1}
+$duplicates = $softwareInventory | Group-Object Name | Where-Object { $_.Count -gt 1 }
 if ($duplicates) {
     Write-Host "`n=== Duplicate Software Installations Detected ===" -ForegroundColor Yellow
     foreach ($dup in $duplicates) {

--- a/scripts/security/compliance/frameworks/Get-USBDeviceAudit.ps1
+++ b/scripts/security/compliance/frameworks/Get-USBDeviceAudit.ps1
@@ -75,22 +75,26 @@ foreach ($device in $connectedDevices) {
     # Parse USB device information
     $deviceID = $device.DeviceID
     $vidPid = if ($deviceID -match "VID_([0-9A-F]{4}).*PID_([0-9A-F]{4})") {
-        @{VID = $matches[1]; PID = $matches[2]}
-    } else {
-        @{VID = "Unknown"; PID = "Unknown"}
+        @{VID = $matches[1]; PID = $matches[2] }
+    }
+    else {
+        @{VID = "Unknown"; PID = "Unknown" }
     }
 
     $serialNumber = if ($deviceID -match "\\([^\\]+)$") {
         $matches[1]
-    } else {
+    }
+    else {
         "N/A"
     }
 
     $isAuthorized = if ($AuthorizedVendors.Count -eq 0) {
         "N/A"
-    } elseif ($AuthorizedVendors -contains $vidPid.VID) {
+    }
+    elseif ($AuthorizedVendors -contains $vidPid.VID) {
         "Yes"
-    } else {
+    }
+    else {
         "No"
     }
 
@@ -132,7 +136,8 @@ if ($IncludeHistory) {
                     $deviceName = $deviceKey.PSChildName
                     $manufacturer = if ($deviceName -match "^([^&]+)&") {
                         $matches[1]
-                    } else {
+                    }
+                    else {
                         "Unknown"
                     }
 
@@ -154,13 +159,15 @@ if ($IncludeHistory) {
                             CurrentlyConnected = "No"
                             FirstSeen = if ($props.PSObject.Properties['InstallDate']) {
                                 $props.InstallDate
-                            } else {
+                            }
+                            else {
                                 "Unknown"
                             }
                             Source = "Registry"
                         }
                     }
-                } catch {
+                }
+                catch {
                     Write-Verbose "Could not process device instance: $($instance.PSChildName)"
                 }
             }
@@ -176,7 +183,7 @@ if ($IncludeHistory) {
     Write-Host "Historical devices: $(($results | Where-Object {$_.CurrentlyConnected -eq 'No'}).Count)" -ForegroundColor Yellow
 }
 if ($HighlightUnauthorized -and $AuthorizedVendors.Count -gt 0) {
-    $unauthorized = ($results | Where-Object {$_.IsAuthorized -eq 'No'}).Count
+    $unauthorized = ($results | Where-Object { $_.IsAuthorized -eq 'No' }).Count
     Write-Host "Unauthorized devices: $unauthorized" -ForegroundColor $(if ($unauthorized -gt 0) { 'Red' } else { 'Green' })
 }
 

--- a/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
+++ b/scripts/security/compliance/frameworks/Test-CISBenchmark.ps1
@@ -197,44 +197,44 @@ Write-Host "[*] Testing Password Policies..." -ForegroundColor Cyan
 # 1.1.1 Enforce password history
 $testResults += Test-CISControl -ControlID "1.1.1" -Description "Enforce password history" `
     -TestScript {
-        $value = $secPolicy['System Access']['PasswordHistorySize']
-        [int]$value -ge 24
-    } -Recommendation "Set to 24 or more passwords remembered"
+    $value = $secPolicy['System Access']['PasswordHistorySize']
+    [int]$value -ge 24
+} -Recommendation "Set to 24 or more passwords remembered"
 
 # 1.1.2 Maximum password age
 $testResults += Test-CISControl -ControlID "1.1.2" -Description "Maximum password age" `
     -TestScript {
-        $value = $secPolicy['System Access']['MaximumPasswordAge']
-        [int]$value -le 365 -and [int]$value -gt 0
-    } -Recommendation "Set to 365 or fewer days (but not 0)"
+    $value = $secPolicy['System Access']['MaximumPasswordAge']
+    [int]$value -le 365 -and [int]$value -gt 0
+} -Recommendation "Set to 365 or fewer days (but not 0)"
 
 # 1.1.3 Minimum password age
 $testResults += Test-CISControl -ControlID "1.1.3" -Description "Minimum password age" `
     -TestScript {
-        $value = $secPolicy['System Access']['MinimumPasswordAge']
-        [int]$value -ge 1
-    } -Recommendation "Set to 1 or more days"
+    $value = $secPolicy['System Access']['MinimumPasswordAge']
+    [int]$value -ge 1
+} -Recommendation "Set to 1 or more days"
 
 # 1.1.4 Minimum password length
 $testResults += Test-CISControl -ControlID "1.1.4" -Description "Minimum password length" `
     -TestScript {
-        $value = $secPolicy['System Access']['MinimumPasswordLength']
-        [int]$value -ge 14
-    } -Recommendation "Set to 14 or more characters"
+    $value = $secPolicy['System Access']['MinimumPasswordLength']
+    [int]$value -ge 14
+} -Recommendation "Set to 14 or more characters"
 
 # 1.1.5 Password complexity
 $testResults += Test-CISControl -ControlID "1.1.5" -Description "Password must meet complexity requirements" `
     -TestScript {
-        $value = $secPolicy['System Access']['PasswordComplexity']
-        [int]$value -eq 1
-    } -Recommendation "Set to Enabled"
+    $value = $secPolicy['System Access']['PasswordComplexity']
+    [int]$value -eq 1
+} -Recommendation "Set to Enabled"
 
 # 1.1.6 Reversible encryption
 $testResults += Test-CISControl -ControlID "1.1.6" -Description "Store passwords using reversible encryption" `
     -TestScript {
-        $value = $secPolicy['System Access']['ClearTextPassword']
-        [int]$value -eq 0
-    } -Recommendation "Set to Disabled"
+    $value = $secPolicy['System Access']['ClearTextPassword']
+    [int]$value -eq 0
+} -Recommendation "Set to Disabled"
 
 # ==================================================================
 # ACCOUNT LOCKOUT POLICY (CIS Section 1.2)
@@ -244,23 +244,23 @@ Write-Host "[*] Testing Account Lockout Policies..." -ForegroundColor Cyan
 # 1.2.1 Account lockout duration
 $testResults += Test-CISControl -ControlID "1.2.1" -Description "Account lockout duration" `
     -TestScript {
-        $value = $secPolicy['System Access']['LockoutDuration']
-        [int]$value -ge 15
-    } -Recommendation "Set to 15 or more minutes"
+    $value = $secPolicy['System Access']['LockoutDuration']
+    [int]$value -ge 15
+} -Recommendation "Set to 15 or more minutes"
 
 # 1.2.2 Account lockout threshold
 $testResults += Test-CISControl -ControlID "1.2.2" -Description "Account lockout threshold" `
     -TestScript {
-        $value = $secPolicy['System Access']['LockoutBadCount']
-        [int]$value -le 5 -and [int]$value -gt 0
-    } -Recommendation "Set to 5 or fewer invalid logon attempts (but not 0)"
+    $value = $secPolicy['System Access']['LockoutBadCount']
+    [int]$value -le 5 -and [int]$value -gt 0
+} -Recommendation "Set to 5 or fewer invalid logon attempts (but not 0)"
 
 # 1.2.3 Reset account lockout counter
 $testResults += Test-CISControl -ControlID "1.2.3" -Description "Reset account lockout counter after" `
     -TestScript {
-        $value = $secPolicy['System Access']['ResetLockoutCount']
-        [int]$value -ge 15
-    } -Recommendation "Set to 15 or more minutes"
+    $value = $secPolicy['System Access']['ResetLockoutCount']
+    [int]$value -ge 15
+} -Recommendation "Set to 15 or more minutes"
 
 # ==================================================================
 # AUDIT POLICIES (CIS Section 17.1-17.9)
@@ -283,50 +283,50 @@ function Test-AuditPolicy {
 # 17.1.1 Audit Credential Validation
 $testResults += Test-CISControl -ControlID "17.1.1" -Description "Audit Credential Validation" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Credential Validation" -Expected "Success and Failure"
-    } -Recommendation "Set to 'Success and Failure'"
+    Test-AuditPolicy -Subcategory "Credential Validation" -Expected "Success and Failure"
+} -Recommendation "Set to 'Success and Failure'"
 
 # 17.2.1 Audit Application Group Management
 $testResults += Test-CISControl -ControlID "17.2.1" -Description "Audit Application Group Management" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Application Group Management" -Expected "Success and Failure"
-    } -Recommendation "Set to 'Success and Failure'" -RequiredLevel 2
+    Test-AuditPolicy -Subcategory "Application Group Management" -Expected "Success and Failure"
+} -Recommendation "Set to 'Success and Failure'" -RequiredLevel 2
 
 # 17.3.1 Audit Process Creation
 $testResults += Test-CISControl -ControlID "17.3.1" -Description "Audit Process Creation" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Process Creation" -Expected "Success"
-    } -Recommendation "Set to 'Success'"
+    Test-AuditPolicy -Subcategory "Process Creation" -Expected "Success"
+} -Recommendation "Set to 'Success'"
 
 # 17.5.1 Audit Account Lockout
 $testResults += Test-CISControl -ControlID "17.5.1" -Description "Audit Account Lockout" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Account Lockout" -Expected "Failure"
-    } -Recommendation "Set to 'Failure'"
+    Test-AuditPolicy -Subcategory "Account Lockout" -Expected "Failure"
+} -Recommendation "Set to 'Failure'"
 
 # 17.5.2 Audit Logoff
 $testResults += Test-CISControl -ControlID "17.5.2" -Description "Audit Logoff" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Logoff" -Expected "Success"
-    } -Recommendation "Set to 'Success'"
+    Test-AuditPolicy -Subcategory "Logoff" -Expected "Success"
+} -Recommendation "Set to 'Success'"
 
 # 17.5.3 Audit Logon
 $testResults += Test-CISControl -ControlID "17.5.3" -Description "Audit Logon" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Logon" -Expected "Success and Failure"
-    } -Recommendation "Set to 'Success and Failure'"
+    Test-AuditPolicy -Subcategory "Logon" -Expected "Success and Failure"
+} -Recommendation "Set to 'Success and Failure'"
 
 # 17.6.1 Audit Sensitive Privilege Use
 $testResults += Test-CISControl -ControlID "17.6.1" -Description "Audit Sensitive Privilege Use" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Sensitive Privilege Use" -Expected "Success and Failure"
-    } -Recommendation "Set to 'Success and Failure'" -RequiredLevel 2
+    Test-AuditPolicy -Subcategory "Sensitive Privilege Use" -Expected "Success and Failure"
+} -Recommendation "Set to 'Success and Failure'" -RequiredLevel 2
 
 # 17.9.1 Audit Security System Extension
 $testResults += Test-CISControl -ControlID "17.9.1" -Description "Audit Security System Extension" `
     -TestScript {
-        Test-AuditPolicy -Subcategory "Security System Extension" -Expected "Success"
-    } -Recommendation "Set to 'Success'"
+    Test-AuditPolicy -Subcategory "Security System Extension" -Expected "Success"
+} -Recommendation "Set to 'Success'"
 
 # Filter out null results (controls not applicable to current level)
 $testResults = $testResults | Where-Object { $null -ne $_ }
@@ -375,7 +375,7 @@ Write-Host "Total Controls:      $total" -ForegroundColor White
 Write-Host "Passed:              $passed" -ForegroundColor Green
 Write-Host "Failed:              $failed" -ForegroundColor Red
 Write-Host "Errors:              $errors" -ForegroundColor Yellow
-Write-Host "Compliance Rate:     $compliancePercent%" -ForegroundColor $(if ($compliancePercent -ge 80) {"Green"} elseif ($compliancePercent -ge 60) {"Yellow"} else {"Red"})
+Write-Host "Compliance Rate:     $compliancePercent%" -ForegroundColor $(if ($compliancePercent -ge 80) { "Green" } elseif ($compliancePercent -ge 60) { "Yellow" } else { "Red" })
 Write-Host "==================================================================`n" -ForegroundColor Cyan
 
 # Export HTML report if requested
@@ -486,6 +486,7 @@ Write-Host "Compliance test complete!`n" -ForegroundColor Green
 # Exit with appropriate code
 if ($failed -gt 0) {
     exit 1
-} else {
+}
+else {
     exit 0
 }

--- a/scripts/security/compliance/frameworks/Test-SecurityFeatures.ps1
+++ b/scripts/security/compliance/frameworks/Test-SecurityFeatures.ps1
@@ -83,15 +83,18 @@ try {
             $TPMVersion = $TPM.ManufacturerVersion
             Write-Host "  [✓] TPM Present and Ready (Version: $TPMVersion)" -ForegroundColor Green
             Add-Result "TPM (Trusted Platform Module)" "Enabled" "Present and ready, Version: $TPMVersion" ""
-        } else {
+        }
+        else {
             Write-Host "  [!] TPM Present but Not Ready" -ForegroundColor Yellow
             Add-Result "TPM (Trusted Platform Module)" "Disabled" "Present but not ready" "Initialize TPM in BIOS/UEFI settings"
         }
-    } else {
+    }
+    else {
         Write-Host "  [✗] TPM Not Present" -ForegroundColor Red
         Add-Result "TPM (Trusted Platform Module)" "Not Available" "No TPM detected" "Enable TPM in BIOS/UEFI or upgrade hardware"
     }
-} catch {
+}
+catch {
     Write-Host "  [✗] Unable to check TPM: $($_.Exception.Message)" -ForegroundColor Red
     Add-Result "TPM (Trusted Platform Module)" "Failed" "Unable to check TPM status" "Verify TPM is enabled in BIOS/UEFI"
 }
@@ -104,11 +107,13 @@ try {
     if ($SecureBoot) {
         Write-Host "  [✓] Secure Boot Enabled" -ForegroundColor Green
         Add-Result "Secure Boot" "Enabled" "UEFI Secure Boot is active" ""
-    } else {
+    }
+    else {
         Write-Host "  [✗] Secure Boot Disabled" -ForegroundColor Red
         Add-Result "Secure Boot" "Disabled" "Secure Boot is not enabled" "Enable Secure Boot in UEFI firmware settings"
     }
-} catch {
+}
+catch {
     Write-Host "  [!] Secure Boot Not Supported (Legacy BIOS)" -ForegroundColor Yellow
     Add-Result "Secure Boot" "Not Available" "System using Legacy BIOS" "Convert to UEFI and enable Secure Boot"
 }
@@ -121,14 +126,17 @@ try {
     if ($DevGuard.VirtualizationBasedSecurityStatus -eq 2) {
         Write-Host "  [✓] VBS Running" -ForegroundColor Green
         Add-Result "Virtualization-Based Security (VBS)" "Enabled" "VBS is running" ""
-    } elseif ($DevGuard.VirtualizationBasedSecurityStatus -eq 1) {
+    }
+    elseif ($DevGuard.VirtualizationBasedSecurityStatus -eq 1) {
         Write-Host "  [!] VBS Enabled but Not Running" -ForegroundColor Yellow
         Add-Result "Virtualization-Based Security (VBS)" "Disabled" "VBS enabled but not running" "Reboot system or check hardware virtualization"
-    } else {
+    }
+    else {
         Write-Host "  [✗] VBS Not Enabled" -ForegroundColor Red
         Add-Result "Virtualization-Based Security (VBS)" "Disabled" "VBS is not enabled" "Enable via Group Policy or Intune"
     }
-} catch {
+}
+catch {
     Write-Host "  [✗] Unable to check VBS status" -ForegroundColor Red
     Add-Result "Virtualization-Based Security (VBS)" "Not Available" "Cannot determine VBS status" "Ensure Windows 10/11 Pro/Enterprise"
 }
@@ -141,14 +149,17 @@ try {
     if ($DevGuard.SecurityServicesRunning -contains 1) {
         Write-Host "  [✓] Credential Guard Running" -ForegroundColor Green
         Add-Result "Credential Guard" "Enabled" "Credential Guard is running" ""
-    } elseif ($DevGuard.SecurityServicesConfigured -contains 1) {
+    }
+    elseif ($DevGuard.SecurityServicesConfigured -contains 1) {
         Write-Host "  [!] Credential Guard Configured but Not Running" -ForegroundColor Yellow
         Add-Result "Credential Guard" "Disabled" "Configured but not running" "Reboot system or check VBS prerequisites"
-    } else {
+    }
+    else {
         Write-Host "  [✗] Credential Guard Not Configured" -ForegroundColor Red
         Add-Result "Credential Guard" "Disabled" "Not configured" "Enable via Group Policy: Computer Config > Admin Templates > System > Device Guard"
     }
-} catch {
+}
+catch {
     Write-Host "  [✗] Unable to check Credential Guard" -ForegroundColor Red
     Add-Result "Credential Guard" "Not Available" "Cannot determine status" "Requires Windows 10/11 Enterprise and compatible hardware"
 }
@@ -163,7 +174,8 @@ try {
         if ($OSVolume.ProtectionStatus -eq 'On') {
             Write-Host "  [✓] BitLocker Enabled on OS Drive ($($OSVolume.MountPoint))" -ForegroundColor Green
             Add-Result "BitLocker Drive Encryption" "Enabled" "OS drive encrypted: $($OSVolume.MountPoint) - $($OSVolume.EncryptionPercentage)%" ""
-        } else {
+        }
+        else {
             Write-Host "  [✗] BitLocker Not Enabled on OS Drive" -ForegroundColor Red
             Add-Result "BitLocker Drive Encryption" "Disabled" "OS drive not encrypted" "Enable BitLocker via Control Panel or Intune policy"
         }
@@ -172,11 +184,13 @@ try {
         if ($OSVolume.EncryptionMethod) {
             Write-Host "      Encryption Method: $($OSVolume.EncryptionMethod)" -ForegroundColor Gray
         }
-    } else {
+    }
+    else {
         Write-Host "  [!] No OS Volume Found for BitLocker Check" -ForegroundColor Yellow
         Add-Result "BitLocker Drive Encryption" "Not Available" "Cannot detect OS volume" "Verify BitLocker support"
     }
-} catch {
+}
+catch {
     Write-Host "  [✗] BitLocker Not Available: $($_.Exception.Message)" -ForegroundColor Red
     Add-Result "BitLocker Drive Encryption" "Not Available" "BitLocker not available on this system" "Requires Windows 10/11 Pro or Enterprise"
 }
@@ -189,7 +203,8 @@ try {
     if ($Defender.AntivirusEnabled) {
         Write-Host "  [✓] Windows Defender Antivirus Enabled" -ForegroundColor Green
         Add-Result "Windows Defender Antivirus" "Enabled" "Antivirus protection active" ""
-    } else {
+    }
+    else {
         Write-Host "  [✗] Windows Defender Antivirus Disabled" -ForegroundColor Red
         Add-Result "Windows Defender Antivirus" "Disabled" "Antivirus protection disabled" "Enable Windows Defender or ensure third-party AV is active"
     }
@@ -197,24 +212,28 @@ try {
     if ($Defender.RealTimeProtectionEnabled) {
         Write-Host "  [✓] Real-Time Protection Enabled" -ForegroundColor Green
         Add-Result "Windows Defender Real-Time Protection" "Enabled" "Real-time scanning active" ""
-    } else {
+    }
+    else {
         Write-Host "  [✗] Real-Time Protection Disabled" -ForegroundColor Red
         Add-Result "Windows Defender Real-Time Protection" "Disabled" "Real-time scanning disabled" "Enable real-time protection in Windows Security"
     }
 
     if ($Defender.BehaviorMonitorEnabled) {
         Write-Host "  [✓] Behavior Monitoring Enabled" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "  [!] Behavior Monitoring Disabled" -ForegroundColor Yellow
     }
 
     if ($Defender.IoavProtectionEnabled) {
         Write-Host "  [✓] Cloud-Delivered Protection Enabled" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "  [!] Cloud-Delivered Protection Disabled" -ForegroundColor Yellow
     }
 
-} catch {
+}
+catch {
     Write-Host "  [!] Windows Defender Status Unknown (Third-party AV may be active)" -ForegroundColor Yellow
     Add-Result "Windows Defender" "Not Available" "Cannot determine status - third-party AV may be in use" ""
 }
@@ -228,7 +247,8 @@ try {
     foreach ($Profile in $Firewall) {
         if ($Profile.Enabled) {
             Write-Host "  [✓] $($Profile.Name) Profile: Enabled" -ForegroundColor Green
-        } else {
+        }
+        else {
             Write-Host "  [✗] $($Profile.Name) Profile: Disabled" -ForegroundColor Red
             $AllEnabled = $false
         }
@@ -236,10 +256,12 @@ try {
 
     if ($AllEnabled) {
         Add-Result "Windows Firewall" "Enabled" "All firewall profiles enabled" ""
-    } else {
+    }
+    else {
         Add-Result "Windows Firewall" "Disabled" "One or more firewall profiles disabled" "Enable all firewall profiles in Windows Security"
     }
-} catch {
+}
+catch {
     Write-Host "  [✗] Unable to check Windows Firewall" -ForegroundColor Red
     Add-Result "Windows Firewall" "Failed" "Cannot determine firewall status" "Check Windows Security settings"
 }
@@ -256,11 +278,13 @@ try {
     if ($BootMode -eq "UEFI" -or $BootMode -eq 2) {
         Write-Host "  [✓] UEFI Boot Mode" -ForegroundColor Green
         Add-Result "Boot Mode" "Enabled" "System using UEFI firmware" ""
-    } else {
+    }
+    else {
         Write-Host "  [!] Legacy BIOS Mode" -ForegroundColor Yellow
         Add-Result "Boot Mode" "Disabled" "System using Legacy BIOS" "Convert to UEFI for enhanced security features"
     }
-} catch {
+}
+catch {
     Write-Host "  [!] Unable to determine boot mode" -ForegroundColor Yellow
     Add-Result "Boot Mode" "Not Available" "Cannot determine boot mode" ""
 }
@@ -274,10 +298,12 @@ try {
     if ($DEP -eq 3) {
         Write-Host "  [✓] DEP (Data Execution Prevention): Enabled for all programs" -ForegroundColor Green
         Add-Result "DEP (Data Execution Prevention)" "Enabled" "Enabled for all programs and services" ""
-    } elseif ($DEP -eq 2) {
+    }
+    elseif ($DEP -eq 2) {
         Write-Host "  [!] DEP: Enabled for essential Windows programs only" -ForegroundColor Yellow
         Add-Result "DEP (Data Execution Prevention)" "Enabled" "Enabled for essential programs only" "Enable for all programs in System Properties"
-    } else {
+    }
+    else {
         Write-Host "  [✗] DEP: Not properly configured" -ForegroundColor Red
         Add-Result "DEP (Data Execution Prevention)" "Disabled" "Not properly configured" "Enable DEP for all programs"
     }
@@ -286,11 +312,13 @@ try {
     $ExploitGuard = Get-ProcessMitigation -System -ErrorAction SilentlyContinue
     if ($ExploitGuard) {
         Write-Host "  [✓] Windows Defender Exploit Guard: Available" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "  [!] Windows Defender Exploit Guard: Status unknown" -ForegroundColor Yellow
     }
 
-} catch {
+}
+catch {
     Write-Host "  [!] Unable to fully check exploit protection" -ForegroundColor Yellow
     Add-Result "Exploit Protection" "Not Available" "Cannot determine full exploit protection status" ""
 }
@@ -304,12 +332,14 @@ try {
     if ($WUService.Status -eq 'Running') {
         Write-Host "  [✓] Windows Update Service: Running" -ForegroundColor Green
         Add-Result "Windows Update Service" "Enabled" "Service is running" ""
-    } else {
+    }
+    else {
         Write-Host "  [!] Windows Update Service: $($WUService.Status)" -ForegroundColor Yellow
         Add-Result "Windows Update Service" "Disabled" "Service is $($WUService.Status)" "Ensure Windows Update service is running"
     }
 
-} catch {
+}
+catch {
     Write-Host "  [✗] Unable to check Windows Update service" -ForegroundColor Red
     Add-Result "Windows Update Service" "Failed" "Cannot determine service status" "Check Services.msc"
 }
@@ -344,7 +374,8 @@ if ($ShowRecommendations -or $DisabledFeatures -gt 0) {
             Write-Host "  Status: $($Item.Status)" -ForegroundColor $(if ($Item.Status -eq 'Disabled') { 'Red' } else { 'Yellow' })
             Write-Host "  → $($Item.Recommendation)" -ForegroundColor Cyan
         }
-    } else {
+    }
+    else {
         Write-Host "`n✓ All critical security features are enabled!" -ForegroundColor Green
     }
 }
@@ -456,7 +487,8 @@ Write-Host ""
 if ($IssuesFound) {
     Write-Host "⚠ Security assessment completed with missing features.`n" -ForegroundColor Yellow
     exit 1
-} else {
+}
+else {
     Write-Host "✓ Security assessment completed. All features enabled.`n" -ForegroundColor Green
     exit 0
 }

--- a/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
+++ b/scripts/security/hardening/Invoke-SecurityComplianceScan.ps1
@@ -383,7 +383,8 @@ $results.Summary = @{
     LowFindings = $lowCount
     ComplianceScore = if ($results.Findings.Count -gt 0) {
         [math]::Round((1 - ($criticalCount * 4 + $highCount * 3 + $mediumCount * 2 + $lowCount) / ($results.Findings.Count * 4)) * 100, 2)
-    } else { 100 }
+    }
+    else { 100 }
 }
 
 # Output results
@@ -399,7 +400,7 @@ switch ($OutputFormat) {
 
         if ($results.Findings.Count -gt 0) {
             Write-Host "`n=== Top Findings ===" -ForegroundColor Cyan
-            foreach ($finding in ($results.Findings | Sort-Object { @('Critical','High','Medium','Low').IndexOf($_.Severity) } | Select-Object -First 10)) {
+            foreach ($finding in ($results.Findings | Sort-Object { @('Critical', 'High', 'Medium', 'Low').IndexOf($_.Severity) } | Select-Object -First 10)) {
                 $color = switch ($finding.Severity) {
                     'Critical' { 'Red' }
                     'High' { 'DarkRed' }
@@ -451,7 +452,7 @@ switch ($OutputFormat) {
     <table>
         <tr><th>Control ID</th><th>Title</th><th>Severity</th><th>Status</th><th>Current Value</th><th>Expected Value</th>$(if ($RemediationGuidance) { '<th>Remediation</th>' })</tr>
 "@
-        foreach ($finding in ($results.Findings | Sort-Object { @('Critical','High','Medium','Low').IndexOf($_.Severity) })) {
+        foreach ($finding in ($results.Findings | Sort-Object { @('Critical', 'High', 'Medium', 'Low').IndexOf($_.Severity) })) {
             $severityClass = $finding.Severity.ToLower()
             $html += "<tr class='$severityClass'><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.ControlID)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Title)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Severity)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.Status)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.CurrentValue)"))</td><td>$([System.Net.WebUtility]::HtmlEncode("$($finding.ExpectedValue)"))</td>"
             if ($RemediationGuidance) {

--- a/scripts/security/monitoring/Get-PerformanceTrends.ps1
+++ b/scripts/security/monitoring/Get-PerformanceTrends.ps1
@@ -119,14 +119,16 @@ try {
         $diskCounters = Get-Counter '\PhysicalDisk(_Total)\% Disk Time' -ErrorAction SilentlyContinue
         $diskUsage = if ($diskCounters) {
             [math]::Round($diskCounters.CounterSamples.CookedValue, 2)
-        } else { 0 }
+        }
+        else { 0 }
 
         # Collect network usage
         $networkCounters = Get-Counter '\Network Interface(*)\Bytes Total/sec' -ErrorAction SilentlyContinue
         $networkUsage = if ($networkCounters) {
             ($networkCounters.CounterSamples | Measure-Object -Property CookedValue -Sum).Sum
             [math]::Round($networkUsage / 1MB, 2)  # Convert to MB/s
-        } else { 0 }
+        }
+        else { 0 }
 
         # Create performance record
         $record = [PSCustomObject]@{

--- a/scripts/security/monitoring/Get-SystemHealthCheck.ps1
+++ b/scripts/security/monitoring/Get-SystemHealthCheck.ps1
@@ -88,8 +88,8 @@ Write-Host "`nChecking CPU usage..." -ForegroundColor Yellow
 try {
     $cpu = Get-CimInstance -ClassName Win32_Processor
     $cpuLoad = (Get-Counter '\Processor(_Total)\% Processor Time' -SampleInterval 2 -MaxSamples 3 |
-        Select-Object -ExpandProperty CounterSamples |
-        Measure-Object -Property CookedValue -Average).Average
+            Select-Object -ExpandProperty CounterSamples |
+            Measure-Object -Property CookedValue -Average).Average
 
     $healthCheck.CPU = @{
         Name = $cpu.Name
@@ -102,13 +102,15 @@ try {
     if ($cpuLoad -gt 90) {
         $healthCheck.Issues += "CPU usage is very high: $([math]::Round($cpuLoad, 2))%"
         $healthCheck.HealthScore -= 15
-    } elseif ($cpuLoad -gt 75) {
+    }
+    elseif ($cpuLoad -gt 75) {
         $healthCheck.Warnings += "CPU usage is elevated: $([math]::Round($cpuLoad, 2))%"
         $healthCheck.HealthScore -= 5
     }
 
-    Write-Host "CPU: $($cpu.Name) - Load: $([math]::Round($cpuLoad, 2))%" -ForegroundColor $(if ($cpuLoad -gt 75) {'Yellow'} else {'Green'})
-} catch {
+    Write-Host "CPU: $($cpu.Name) - Load: $([math]::Round($cpuLoad, 2))%" -ForegroundColor $(if ($cpuLoad -gt 75) { 'Yellow' } else { 'Green' })
+}
+catch {
     $healthCheck.Issues += "Could not check CPU status"
     $healthCheck.HealthScore -= 10
 }
@@ -133,13 +135,15 @@ try {
     if ($memoryUsagePercent -gt $MemoryThresholdPercent) {
         $healthCheck.Issues += "Memory usage is very high: $memoryUsagePercent%"
         $healthCheck.HealthScore -= 15
-    } elseif ($memoryUsagePercent -gt ($MemoryThresholdPercent - 10)) {
+    }
+    elseif ($memoryUsagePercent -gt ($MemoryThresholdPercent - 10)) {
         $healthCheck.Warnings += "Memory usage is elevated: $memoryUsagePercent%"
         $healthCheck.HealthScore -= 5
     }
 
-    Write-Host "Memory: $usedMemoryGB GB / $totalMemoryGB GB ($memoryUsagePercent%)" -ForegroundColor $(if ($memoryUsagePercent -gt $MemoryThresholdPercent) {'Red'} elseif ($memoryUsagePercent -gt 80) {'Yellow'} else {'Green'})
-} catch {
+    Write-Host "Memory: $usedMemoryGB GB / $totalMemoryGB GB ($memoryUsagePercent%)" -ForegroundColor $(if ($memoryUsagePercent -gt $MemoryThresholdPercent) { 'Red' } elseif ($memoryUsagePercent -gt 80) { 'Yellow' } else { 'Green' })
+}
+catch {
     $healthCheck.Issues += "Could not check memory status"
     $healthCheck.HealthScore -= 10
 }
@@ -170,15 +174,17 @@ try {
         if ($diskUsagePercent -gt $DiskThresholdPercent + 10) {
             $healthCheck.Issues += "Disk $($disk.DeviceID) usage is critical: $diskUsagePercent%"
             $healthCheck.HealthScore -= 15
-        } elseif ($diskUsagePercent -gt $DiskThresholdPercent) {
+        }
+        elseif ($diskUsagePercent -gt $DiskThresholdPercent) {
             $healthCheck.Warnings += "Disk $($disk.DeviceID) usage is high: $diskUsagePercent%"
             $healthCheck.HealthScore -= 5
         }
 
-        $diskColor = if ($diskUsagePercent -gt 90) {'Red'} elseif ($diskUsagePercent -gt $DiskThresholdPercent) {'Yellow'} else {'Green'}
+        $diskColor = if ($diskUsagePercent -gt 90) { 'Red' } elseif ($diskUsagePercent -gt $DiskThresholdPercent) { 'Yellow' } else { 'Green' }
         Write-Host "Disk $($disk.DeviceID): $diskUsedGB GB / $diskSizeGB GB ($diskUsagePercent%)" -ForegroundColor $diskColor
     }
-} catch {
+}
+catch {
     $healthCheck.Issues += "Could not check disk status"
     $healthCheck.HealthScore -= 10
 }
@@ -205,13 +211,15 @@ try {
                 $healthCheck.HealthScore -= 10
             }
 
-            $serviceColor = if ($service.Status -eq 'Running') {'Green'} else {'Red'}
+            $serviceColor = if ($service.Status -eq 'Running') { 'Green' } else { 'Red' }
             Write-Host "  $($service.DisplayName): $($service.Status)" -ForegroundColor $serviceColor
-        } else {
+        }
+        else {
             Write-Host "  ${serviceName}: Not Found" -ForegroundColor Yellow
         }
     }
-} catch {
+}
+catch {
     $healthCheck.Warnings += "Could not check all services"
 }
 #endregion
@@ -234,8 +242,9 @@ try {
         $healthCheck.HealthScore -= 5
     }
 
-    Write-Host "Uptime: $([math]::Round($uptime.TotalDays, 2)) days (Last boot: $($lastBootTime.ToString('yyyy-MM-dd HH:mm')))" -ForegroundColor $(if ($uptime.TotalDays -gt 30) {'Yellow'} else {'Green'})
-} catch {
+    Write-Host "Uptime: $([math]::Round($uptime.TotalDays, 2)) days (Last boot: $($lastBootTime.ToString('yyyy-MM-dd HH:mm')))" -ForegroundColor $(if ($uptime.TotalDays -gt 30) { 'Yellow' } else { 'Green' })
+}
+catch {
     $healthCheck.Warnings += "Could not check uptime"
 }
 #endregion
@@ -256,8 +265,9 @@ try {
         $healthCheck.HealthScore -= 5
     }
 
-    Write-Host "Pending Windows Updates: $pendingUpdates" -ForegroundColor $(if ($pendingUpdates -gt 10) {'Yellow'} else {'Green'})
-} catch {
+    Write-Host "Pending Windows Updates: $pendingUpdates" -ForegroundColor $(if ($pendingUpdates -gt 10) { 'Yellow' } else { 'Green' })
+}
+catch {
     Write-Host "Could not check Windows Update status" -ForegroundColor Yellow
 }
 #endregion
@@ -266,7 +276,7 @@ try {
 Write-Host "`nChecking recent event log errors..." -ForegroundColor Yellow
 try {
     $startTime = (Get-Date).AddDays(-1)
-    $criticalErrors = Get-WinEvent -FilterHashtable @{LogName='System'; Level=2; StartTime=$startTime} -MaxEvents 100 -ErrorAction SilentlyContinue
+    $criticalErrors = Get-WinEvent -FilterHashtable @{LogName = 'System'; Level = 2; StartTime = $startTime } -MaxEvents 100 -ErrorAction SilentlyContinue
     $errorCount = ($criticalErrors | Measure-Object).Count
 
     $healthCheck.EventLogErrors = @{
@@ -283,13 +293,15 @@ try {
     if ($errorCount -gt 50) {
         $healthCheck.Issues += "High number of system errors in last 24 hours: $errorCount"
         $healthCheck.HealthScore -= 10
-    } elseif ($errorCount -gt 20) {
+    }
+    elseif ($errorCount -gt 20) {
         $healthCheck.Warnings += "Elevated system errors in last 24 hours: $errorCount"
         $healthCheck.HealthScore -= 5
     }
 
-    Write-Host "System errors (24h): $errorCount" -ForegroundColor $(if ($errorCount -gt 50) {'Red'} elseif ($errorCount -gt 20) {'Yellow'} else {'Green'})
-} catch {
+    Write-Host "System errors (24h): $errorCount" -ForegroundColor $(if ($errorCount -gt 50) { 'Red' } elseif ($errorCount -gt 20) { 'Yellow' } else { 'Green' })
+}
+catch {
     Write-Host "Could not check event logs" -ForegroundColor Yellow
 }
 #endregion
@@ -298,10 +310,12 @@ try {
 if ($healthCheck.HealthScore -ge 90) {
     $healthCheck.OverallHealth = "Healthy"
     $healthColor = "Green"
-} elseif ($healthCheck.HealthScore -ge 70) {
+}
+elseif ($healthCheck.HealthScore -ge 70) {
     $healthCheck.OverallHealth = "Warning"
     $healthColor = "Yellow"
-} else {
+}
+else {
     $healthCheck.OverallHealth = "Critical"
     $healthColor = "Red"
 }

--- a/scripts/utilities/Get-SoftwareInventory.ps1
+++ b/scripts/utilities/Get-SoftwareInventory.ps1
@@ -53,25 +53,25 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeUpdates,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeFeatures,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeStoreApps,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeWinget,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportJSON
 )
 

--- a/scripts/utilities/Optimize-WindowsServices.ps1
+++ b/scripts/utilities/Optimize-WindowsServices.ps1
@@ -48,26 +48,26 @@
     Use with caution on production servers
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$true)]
-    [ValidateSet('Analyze','Optimize','Restore')]
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Analyze', 'Optimize', 'Restore')]
     [string]$Mode,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('Minimal','Balanced','Performance')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Minimal', 'Balanced', 'Performance')]
     [string]$Profile = 'Balanced',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$BackupPath,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ApplyChanges,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 

--- a/scripts/utilities/Sync-UserGroupToPrimaryDeviceGroup.ps1
+++ b/scripts/utilities/Sync-UserGroupToPrimaryDeviceGroup.ps1
@@ -85,7 +85,8 @@ function Get-UserPrimaryDevice {
 
         return $selectedDevice
 
-    } catch {
+    }
+    catch {
         Write-ColorOutput "  └─ Error getting devices: $($_.Exception.Message)" "Red"
         return $null
     }
@@ -177,7 +178,8 @@ try {
                 if ($azureAdDevice) {
                     $deviceIdMap[$azureAdDevice.Id] = $device
                 }
-            } catch {
+            }
+            catch {
                 Write-ColorOutput "Warning: Could not find Azure AD device for $($device.DeviceName)" "Yellow"
             }
         }
@@ -196,7 +198,8 @@ try {
 
     if ($devicesToAddToGroup.Count -eq 0 -and $devicesToRemoveFromGroup.Count -eq 0) {
         Write-ColorOutput "`nNo changes needed. Target group is already in sync!" "Green"
-    } else {
+    }
+    else {
         $confirm = Read-Host "`nProceed with sync? (Y/N)"
 
         if ($confirm -eq 'Y' -or $confirm -eq 'y') {
@@ -208,7 +211,8 @@ try {
                     try {
                         New-MgGroupMember -GroupId $targetGroup.Id -DirectoryObjectId $deviceId -ErrorAction Stop
                         Write-ColorOutput "  ✓ Added: $($deviceInfo.DeviceName) (User: $($deviceInfo.UserName))" "Green"
-                    } catch {
+                    }
+                    catch {
                         Write-ColorOutput "  ✗ Failed to add $($deviceInfo.DeviceName): $($_.Exception.Message)" "Red"
                     }
                 }
@@ -221,22 +225,26 @@ try {
                     try {
                         Remove-MgGroupMemberByRef -GroupId $targetGroup.Id -DirectoryObjectId $deviceId -ErrorAction Stop
                         Write-ColorOutput "  ✓ Removed device ID: $deviceId" "Green"
-                    } catch {
+                    }
+                    catch {
                         Write-ColorOutput "  ✗ Failed to remove device ${deviceId}: $($_.Exception.Message)" "Red"
                     }
                 }
             }
 
             Write-ColorOutput "`nSync completed successfully!" "Green"
-        } else {
+        }
+        else {
             Write-ColorOutput "`nSync cancelled by user." "Yellow"
         }
     }
 
-} catch {
+}
+catch {
     Write-ColorOutput "`nError: $($_.Exception.Message)" "Red"
     Write-ColorOutput $_.ScriptStackTrace "Red"
-} finally {
+}
+finally {
     Write-ColorOutput "`nDisconnecting from Microsoft Graph..." "Yellow"
     Disconnect-MgGraph | Out-Null
     Write-ColorOutput "Done!`n" "Green"

--- a/scripts/utilities/Update-AllAppsWinget.ps1
+++ b/scripts/utilities/Update-AllAppsWinget.ps1
@@ -54,16 +54,16 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$LogPath = "C:\ProgramData\WingetUpdates\update-all-apps.log",
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$MaxRetries = 3,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$SkipDependencyCheck,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('winget', 'msstore')]
     [string]$UpdateSource = 'winget'
 )
@@ -94,9 +94,9 @@ function Write-Log {
 
     # Write to console with color
     $color = switch ($Level) {
-        'Info'    { 'Cyan' }
+        'Info' { 'Cyan' }
         'Warning' { 'Yellow' }
-        'Error'   { 'Red' }
+        'Error' { 'Red' }
         'Success' { 'Green' }
     }
     Write-Host $logMessage -ForegroundColor $color
@@ -121,13 +121,15 @@ function Get-WingetPath {
             if ($wingetPaths.Count -gt 1) {
                 # Return the latest version
                 return ($wingetPaths | Sort-Object -Descending)[0].Path
-            } else {
+            }
+            else {
                 return $wingetPaths.Path
             }
         }
 
         return $null
-    } catch {
+    }
+    catch {
         return $null
     }
 }
@@ -158,7 +160,8 @@ function Install-WingetDependency {
         Remove-Item -Path $tempPath -Force -ErrorAction SilentlyContinue
 
         return $true
-    } catch {
+    }
+    catch {
         Write-Log "Failed to install ${Description}: $($_.Exception.Message)" -Level Error
         Remove-Item -Path $tempPath -Force -ErrorAction SilentlyContinue
         return $false
@@ -210,7 +213,8 @@ function Install-WingetForSystem {
         Start-Sleep -Seconds 5
 
         return $true
-    } catch {
+    }
+    catch {
         Write-Log "Failed to install winget: $($_.Exception.Message)" -Level Error
         Remove-Item -Path $tempWinget -Force -ErrorAction SilentlyContinue
         return $false
@@ -232,7 +236,8 @@ function Test-WingetConfiguration {
             Write-Log "Winget version: $testResult" -Level Info
             return $true
         }
-    } catch {
+    }
+    catch {
         return $false
     }
 
@@ -255,18 +260,22 @@ function Split-CommandLine {
         if ($inQuotes) {
             if ($c -eq $quoteChar) {
                 $inQuotes = $false
-            } else {
+            }
+            else {
                 [void]$current.Append($c)
             }
-        } elseif ($c -eq '"' -or $c -eq "'") {
+        }
+        elseif ($c -eq '"' -or $c -eq "'") {
             $inQuotes = $true
             $quoteChar = $c
-        } elseif ($c -eq ' ') {
+        }
+        elseif ($c -eq ' ') {
             if ($current.Length -gt 0) {
                 $tokens.Add($current.ToString())
                 [void]$current.Clear()
             }
-        } else {
+        }
+        else {
             [void]$current.Append($c)
         }
     }
@@ -298,10 +307,12 @@ function Invoke-WingetWithRetry {
 
             if ($LASTEXITCODE -eq 0) {
                 return $result
-            } else {
+            }
+            else {
                 Write-Log "Winget command failed with exit code $LASTEXITCODE" -Level Warning
             }
-        } catch {
+        }
+        catch {
             Write-Log "Exception during winget execution: $($_.Exception.Message)" -Level Warning
         }
 
@@ -378,13 +389,15 @@ function Update-AllApplications {
 
         if ($remainingUpdates -eq 0) {
             Write-Log "All applications updated successfully!" -Level Success
-        } else {
+        }
+        else {
             Write-Log "$remainingUpdates application(s) still have pending updates (may require manual intervention)" -Level Warning
         }
 
         return $true
 
-    } catch {
+    }
+    catch {
         Write-Log "Error during application update: $($_.Exception.Message)" -Level Error
         return $false
     }
@@ -408,7 +421,8 @@ try {
     $isSystem = Test-RunningAsSystem
     if ($isSystem) {
         Write-Log "Running as SYSTEM" -Level Info
-    } else {
+    }
+    else {
         Write-Log "Running as Administrator" -Level Info
     }
 
@@ -438,7 +452,8 @@ try {
         }
 
         Write-Log "Winget configured successfully" -Level Success
-    } else {
+    }
+    else {
         Write-Log "Winget is already configured and ready" -Level Success
     }
 
@@ -450,12 +465,14 @@ try {
         Write-Log "Update process completed successfully" -Level Success
         Write-Log "========================================" -Level Success
         exit 0
-    } else {
+    }
+    else {
         Write-Log "Update process completed with errors" -Level Warning
         exit 1
     }
 
-} catch {
+}
+catch {
     Write-Log "Critical error: $($_.Exception.Message)" -Level Error
     Write-Log "Stack trace: $($_.ScriptStackTrace)" -Level Error
     exit 1

--- a/scripts/utilities/Update-AllAppsWinget.ps1
+++ b/scripts/utilities/Update-AllAppsWinget.ps1
@@ -329,6 +329,8 @@ function Invoke-WingetWithRetry {
 }
 
 function Update-AllApplications {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     Write-Log "Starting application update process..." -Level Info
 
     try {
@@ -365,14 +367,16 @@ function Update-AllApplications {
         # Update all applications
         Write-Log "Starting update of all applications..." -Level Info
 
-        $updateOutput = Invoke-WingetWithRetry -Arguments "upgrade --all --silent --accept-package-agreements --accept-source-agreements --source $UpdateSource"
+        if ($PSCmdlet.ShouldProcess("all applications (source: $UpdateSource)", "Run winget upgrade --all")) {
+            $updateOutput = Invoke-WingetWithRetry -Arguments "upgrade --all --silent --accept-package-agreements --accept-source-agreements --source $UpdateSource"
 
-        # Log the output
-        foreach ($line in $updateOutput) {
-            Write-Log $line -Level Info
+            # Log the output
+            foreach ($line in $updateOutput) {
+                Write-Log $line -Level Info
+            }
+
+            Write-Log "Application update process completed" -Level Success
         }
-
-        Write-Log "Application update process completed" -Level Success
 
         # Verify updates
         Write-Log "Verifying updates..." -Level Info

--- a/scripts/utilities/Update-DotNetRuntimes.ps1
+++ b/scripts/utilities/Update-DotNetRuntimes.ps1
@@ -364,19 +364,29 @@ function Initialize-NetworkDefaults {
 }
 
 function Start-TypedTranscript {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$Path)
     if ([string]::IsNullOrWhiteSpace($Path)) { return }
     try {
         $dir = Split-Path -Path $Path -Parent
         if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-        Start-Transcript -Path $Path -Append -ErrorAction Stop | Out-Null
+        if ($PSCmdlet.ShouldProcess($Path, 'Start transcript')) {
+            Start-Transcript -Path $Path -Append -ErrorAction Stop | Out-Null
+        }
         Write-Log -Level Debug -Message "Transcript started" -Context @{ Path = $Path }
     }
     catch { Write-Log -Level Warn -Message "Transcript start failed" -Context @{ Path = $Path; Error = $_.Exception.Message } }
 }
 
 function Stop-TypedTranscript {
-    try { Stop-Transcript | Out-Null } catch { Write-Log -Level Debug -Message "Transcript stop failed" -Context @{ Error = $_.Exception.Message } }
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+    try {
+        if ($PSCmdlet.ShouldProcess('Transcript', 'Stop transcript')) {
+            Stop-Transcript | Out-Null
+        }
+    }
+    catch { Write-Log -Level Debug -Message "Transcript stop failed" -Context @{ Error = $_.Exception.Message } }
 }
 
 function Test-Admin {
@@ -691,6 +701,7 @@ function Get-LatestUninstallToolUrl {
 }
 
 function Install-DotnetUninstallTool {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$UrlOverride)
     $existing = Get-DotnetUninstallToolPath
     if ($existing) { Write-Log -Level Ok -Message "Uninstall tool present" -Context @{ Path = $existing }; return $true }
@@ -764,6 +775,7 @@ function Install-DotnetUninstallTool {
 # ========================= REMOVAL ========================= #
 
 function Remove-AspNetCoreChannel {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$MajorMinor, [ValidateSet('x64', 'x86')][string]$ArchLimit)
     $tool = Get-DotnetUninstallToolPath
     if (-not $tool) { Write-Log -Level Warn -Message "Uninstall tool not found"; return $false }
@@ -883,6 +895,7 @@ function Summarize-DiskUsage {
 }
 
 function Invoke-PostPatchCleanup {
+    [CmdletBinding(SupportsShouldProcess)]
     param([ValidateSet('x64', 'x86')][string]$ArchToClean)
     $tool = Get-DotnetUninstallToolPath
     if (-not $tool) { Write-Log -Level Warn -Message "Uninstall tool not found"; return @() }
@@ -1013,7 +1026,8 @@ function Invoke-RuntimeUpdatePlan {
 }
 
 function Invoke-ExecutionPlan {
-    param([Parameter(Mandatory)][object[]]$Plan, [switch]$WhatIf)
+    [CmdletBinding(SupportsShouldProcess)]
+    param([Parameter(Mandatory)][object[]]$Plan)
     $results = @()
 
     foreach ($item in $Plan) {
@@ -1026,7 +1040,7 @@ function Invoke-ExecutionPlan {
 
                     # Download
                     Write-Log -Level Info -Message "Downloading $($item.FileName)..."
-                    if (-not $WhatIf) {
+                    if ($PSCmdlet.ShouldProcess($item.DownloadUrl, "Download $($item.FileName)")) {
                         Save-FileWithRetry -Url $item.DownloadUrl -Destination $tempFile
 
                         # Hash verification (mandatory with fallback)
@@ -1048,14 +1062,11 @@ function Invoke-ExecutionPlan {
 
                     # Install
                     Write-Log -Level Info -Message "Installing $($item.TargetVersion)..."
-                    if (-not $WhatIf) {
+                    if ($PSCmdlet.ShouldProcess($item.TargetVersion, "Install $($item.Product) $($item.Channel)")) {
                         $installResult = Install-Exe -Path $tempFile -Arguments "/quiet /norestart"
                         # FIX: Check if $installResult exists before accessing properties
                         if ($installResult -and $installResult.RebootRequired) { $script:RebootRequired = $true }
                         Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
-                    }
-                    else {
-                        Write-Log -Level Info -Message "[WhatIf] Would install $($item.TargetVersion)"
                     }
 
                     $results += [PSCustomObject]@{
@@ -1073,7 +1084,7 @@ function Invoke-ExecutionPlan {
                 }
 
                 'Remove' {
-                    if (-not $WhatIf) {
+                    if ($PSCmdlet.ShouldProcess($item.Channel, "Remove $($item.Product) channel")) {
                         Remove-AspNetCoreChannel -MajorMinor $item.Channel -ArchLimit $item.Architecture
                     }
                     $results += [PSCustomObject]@{
@@ -1176,6 +1187,7 @@ function Get-SystemStatus {
 # ========================= ROLLBACK SUPPORT ========================= #
 
 function New-SystemSnapshot {
+    [CmdletBinding(SupportsShouldProcess)]
     param([string]$SnapshotLabel = "DotNetMaintainer")
 
     # Checkpoint-Computer (System Restore) is only available on client operating systems
@@ -1190,9 +1202,11 @@ function New-SystemSnapshot {
     if ($IsWindows -and $isClientOS -and (Get-Command "Checkpoint-Computer" -ErrorAction SilentlyContinue)) {
         try {
             Write-Log -Level Info -Message "Creating system restore point"
-            Checkpoint-Computer -Description $SnapshotLabel -RestorePointType MODIFY_SETTINGS -ErrorAction Stop
-            Write-Log -Level Ok -Message "System restore point created"
-            return $true
+            if ($PSCmdlet.ShouldProcess($SnapshotLabel, 'Create system restore point')) {
+                Checkpoint-Computer -Description $SnapshotLabel -RestorePointType MODIFY_SETTINGS -ErrorAction Stop
+                Write-Log -Level Ok -Message "System restore point created"
+                return $true
+            }
         }
         catch {
             Write-Log -Level Warn -Message "Restore point creation failed" -Context @{ Error = $_.Exception.Message }

--- a/scripts/utilities/Update-DotNetRuntimes.ps1
+++ b/scripts/utilities/Update-DotNetRuntimes.ps1
@@ -142,57 +142,57 @@
 
 [CmdletBinding(SupportsShouldProcess)]
 param(
-    [Parameter(Mandatory=$false)][switch]$OneShotCleanup,
-    [Parameter(Mandatory=$false)][switch]$NonInteractive,
-    [Parameter(Mandatory=$false)][switch]$Approve,
-    [Parameter(Mandatory=$false)][switch]$RemoveEol,
-    [Parameter(Mandatory=$false)][switch]$CleanupLowerPatches,
-    [Parameter(Mandatory=$false)][switch]$AutoInstallUninstallTool,
-    [Parameter(Mandatory=$false)][switch]$ForceFileCleanup = $true,
-    [Parameter(Mandatory=$false)][switch]$IncludeHostingBundle,
-    [Parameter(Mandatory=$false)][ValidateSet('Warn','Block','Off')][string]$DependencyCheck = 'Warn',
-    [Parameter(Mandatory=$false)][switch]$ForceEolRemoval,
-    [Parameter(Mandatory=$false)][string[]]$ProtectChannels,
-    [Parameter(Mandatory=$false)][switch]$PreferOldestLts,
-    [Parameter(Mandatory=$false)][switch]$PlanOnly,
-    [Parameter(Mandatory=$false)][switch]$Quiet,
-    [Parameter(Mandatory=$false)][switch]$DryRun,
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)][switch]$OneShotCleanup,
+    [Parameter(Mandatory = $false)][switch]$NonInteractive,
+    [Parameter(Mandatory = $false)][switch]$Approve,
+    [Parameter(Mandatory = $false)][switch]$RemoveEol,
+    [Parameter(Mandatory = $false)][switch]$CleanupLowerPatches,
+    [Parameter(Mandatory = $false)][switch]$AutoInstallUninstallTool,
+    [Parameter(Mandatory = $false)][switch]$ForceFileCleanup = $true,
+    [Parameter(Mandatory = $false)][switch]$IncludeHostingBundle,
+    [Parameter(Mandatory = $false)][ValidateSet('Warn', 'Block', 'Off')][string]$DependencyCheck = 'Warn',
+    [Parameter(Mandatory = $false)][switch]$ForceEolRemoval,
+    [Parameter(Mandatory = $false)][string[]]$ProtectChannels,
+    [Parameter(Mandatory = $false)][switch]$PreferOldestLts,
+    [Parameter(Mandatory = $false)][switch]$PlanOnly,
+    [Parameter(Mandatory = $false)][switch]$Quiet,
+    [Parameter(Mandatory = $false)][switch]$DryRun,
+    [Parameter(Mandatory = $false)]
     [ValidateScript({
-        if ([string]::IsNullOrWhiteSpace($_)) { return $true }
-        $uri = [uri]$_
-        if ($uri.Scheme -ne 'https') { throw "URL must use HTTPS protocol" }
-        # FIX: Use regex for subdomain protection (e.g., prevents evil-github.com)
-        $allowedDomainPatterns = @(
-            '^github\.com$',
-            '^.*\.github\.com$',
-            '^githubusercontent\.com$',
-            '^.*\.githubusercontent\.com$',
-            '^microsoft\.com$',
-            '^.*\.microsoft\.com$',
-            '^download\.microsoft\.com$'
-        )
-        $isAllowed = $false
-        foreach ($pattern in $allowedDomainPatterns) {
-            if ($uri.Host -match $pattern) {
-                $isAllowed = $true
-                break
+            if ([string]::IsNullOrWhiteSpace($_)) { return $true }
+            $uri = [uri]$_
+            if ($uri.Scheme -ne 'https') { throw "URL must use HTTPS protocol" }
+            # FIX: Use regex for subdomain protection (e.g., prevents evil-github.com)
+            $allowedDomainPatterns = @(
+                '^github\.com$',
+                '^.*\.github\.com$',
+                '^githubusercontent\.com$',
+                '^.*\.githubusercontent\.com$',
+                '^microsoft\.com$',
+                '^.*\.microsoft\.com$',
+                '^download\.microsoft\.com$'
+            )
+            $isAllowed = $false
+            foreach ($pattern in $allowedDomainPatterns) {
+                if ($uri.Host -match $pattern) {
+                    $isAllowed = $true
+                    break
+                }
             }
-        }
-        if (-not $isAllowed) {
-            throw "URL must be from trusted domain: *.github.com, *.githubusercontent.com, *.microsoft.com, or download.microsoft.com"
-        }
-        return $true
-    })]
+            if (-not $isAllowed) {
+                throw "URL must be from trusted domain: *.github.com, *.githubusercontent.com, *.microsoft.com, or download.microsoft.com"
+            }
+            return $true
+        })]
     [string]$UninstallToolMsiUrl,
-    [Parameter(Mandatory=$false)][ValidateSet('x64','x86')][string]$Arch,
-    [Parameter(Mandatory=$false)][switch]$LtsOnly,
-    [Parameter(Mandatory=$false)][string[]]$IncludeChannels,
-    [Parameter(Mandatory=$false)][version]$MinVersion,
-    [Parameter(Mandatory=$false)][string]$LogPath,
-    [Parameter(Mandatory=$false)][string]$ReportPath,
-    [Parameter(Mandatory=$false)][string]$JsonSummaryPath,
-    [Parameter(Mandatory=$false)][switch]$EnableRollback
+    [Parameter(Mandatory = $false)][ValidateSet('x64', 'x86')][string]$Arch,
+    [Parameter(Mandatory = $false)][switch]$LtsOnly,
+    [Parameter(Mandatory = $false)][string[]]$IncludeChannels,
+    [Parameter(Mandatory = $false)][version]$MinVersion,
+    [Parameter(Mandatory = $false)][string]$LogPath,
+    [Parameter(Mandatory = $false)][string]$ReportPath,
+    [Parameter(Mandatory = $false)][string]$JsonSummaryPath,
+    [Parameter(Mandatory = $false)][switch]$EnableRollback
 )
 
 # ========================= SCRIPT GLOBALS ========================= #
@@ -214,7 +214,7 @@ $script:UseEmoji = $false
 
 function Write-Log {
     param(
-        [Parameter(Mandatory)][ValidateSet('Info','Ok','Warn','Error','Debug')][string]$Level,
+        [Parameter(Mandatory)][ValidateSet('Info', 'Ok', 'Warn', 'Error', 'Debug')][string]$Level,
         [Parameter(Mandatory)][string]$Message,
         [hashtable]$Context,
         [switch]$NoConsole
@@ -223,9 +223,9 @@ function Write-Log {
     $ts = (Get-Date).ToString('s')
     $entry = [PSCustomObject]@{
         Timestamp = $ts
-        Level     = $Level
-        Message   = $Message
-        Context   = $Context
+        Level = $Level
+        Message = $Message
+        Context = $Context
     }
     $script:LogEntries += $entry
 
@@ -233,31 +233,32 @@ function Write-Log {
     $fullMessage = if ($Context -and $Context.Count -gt 0) {
         $ctx = ($Context.Keys | Sort-Object | ForEach-Object { "$_=$($Context[$_])" }) -join ' '
         "$Message ($ctx)"
-    } else { $Message }
+    }
+    else { $Message }
 
     switch ($Level) {
-        'Warn'  { Write-Warning $fullMessage }
+        'Warn' { Write-Warning $fullMessage }
         'Error' { Write-Error $fullMessage -ErrorAction Continue }
         'Debug' { Write-Verbose $fullMessage }
-        'Info'  { Write-Information $fullMessage -InformationAction Continue }
-        'Ok'    { Write-Information $fullMessage -InformationAction Continue }
+        'Info' { Write-Information $fullMessage -InformationAction Continue }
+        'Ok' { Write-Information $fullMessage -InformationAction Continue }
     }
 
     # Console output for interactive
     if ($NoConsole) { return }
-    if ($Quiet -and $Level -notin @('Warn','Error')) { return }
+    if ($Quiet -and $Level -notin @('Warn', 'Error')) { return }
 
     $prefix = switch ($Level) {
-        'Ok'    { '[OK]  ' }
-        'Warn'  { '[WARN]' }
+        'Ok' { '[OK]  ' }
+        'Warn' { '[WARN]' }
         'Error' { '[FAIL]' }
         'Debug' { '[DBG] ' }
         default { '[INFO]' }
     }
 
     $color = switch ($Level) {
-        'Ok'    { 'Green' }
-        'Warn'  { 'Yellow' }
+        'Ok' { 'Green' }
+        'Warn' { 'Yellow' }
         'Error' { 'Red' }
         'Debug' { 'DarkGray' }
         default { 'Cyan' }
@@ -268,10 +269,10 @@ function Write-Log {
 
 function Add-Action {
     param([string]$Type, [string]$Product, [string]$Channel, [string]$Arch,
-          [string]$Detail, [int]$ExitCode = -1, [string]$Method)
+        [string]$Detail, [int]$ExitCode = -1, [string]$Method)
     $script:ActionLog += [PSCustomObject]@{
-        Type=$Type; Product=$Product; Channel=$Channel; Arch=$Arch;
-        Detail=$Detail; ExitCode=$ExitCode; Method=$Method
+        Type = $Type; Product = $Product; Channel = $Channel; Arch = $Arch;
+        Detail = $Detail; ExitCode = $ExitCode; Method = $Method
     }
 }
 
@@ -307,7 +308,7 @@ function Read-YesNoDefault {
         if ([string]::IsNullOrWhiteSpace($resp)) { return $Default }
         switch -regex ($resp.Trim()) {
             '^(y|yes)$' { return $true }
-            '^(n|no)$'  { return $false }
+            '^(n|no)$' { return $false }
             default { Write-Host "Please answer Y or N" -ForegroundColor Yellow }
         }
     }
@@ -321,7 +322,8 @@ function Read-MenuChoice {
         if ($ValidChoices) {
             if ($choice -in $ValidChoices) { return $choice }
             Write-Host "Invalid. Choose from: $($ValidChoices -join ', ')" -ForegroundColor Yellow
-        } else {
+        }
+        else {
             if ($choice -match '^\d+$' -and [int]$choice -ge $Min -and [int]$choice -le $Max) {
                 return [int]$choice
             }
@@ -341,7 +343,8 @@ function Initialize-NetworkDefaults {
         $tls13 = $null
         try {
             $tls13 = [System.Net.SecurityProtocolType]::Tls13
-        } catch {
+        }
+        catch {
             # TLS 1.3 not available, will use TLS 1.2 only
         }
 
@@ -349,12 +352,14 @@ function Initialize-NetworkDefaults {
         if ($tls13) {
             [System.Net.ServicePointManager]::SecurityProtocol = $tls12 -bor $tls13
             Write-Log -Level Info -Message "Enforced TLS 1.2 and TLS 1.3 (weak protocols disabled)"
-        } else {
+        }
+        else {
             [System.Net.ServicePointManager]::SecurityProtocol = $tls12
             Write-Log -Level Info -Message "Enforced TLS 1.2 only (weak protocols disabled)"
         }
-    } catch {
-        Write-Log -Level Warn -Message "TLS configuration failed" -Context @{ Error=$_.Exception.Message }
+    }
+    catch {
+        Write-Log -Level Warn -Message "TLS configuration failed" -Context @{ Error = $_.Exception.Message }
     }
 }
 
@@ -365,12 +370,13 @@ function Start-TypedTranscript {
         $dir = Split-Path -Path $Path -Parent
         if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
         Start-Transcript -Path $Path -Append -ErrorAction Stop | Out-Null
-        Write-Log -Level Debug -Message "Transcript started" -Context @{ Path=$Path }
-    } catch { Write-Log -Level Warn -Message "Transcript start failed" -Context @{ Path=$Path; Error=$_.Exception.Message } }
+        Write-Log -Level Debug -Message "Transcript started" -Context @{ Path = $Path }
+    }
+    catch { Write-Log -Level Warn -Message "Transcript start failed" -Context @{ Path = $Path; Error = $_.Exception.Message } }
 }
 
 function Stop-TypedTranscript {
-    try { Stop-Transcript | Out-Null } catch { Write-Log -Level Debug -Message "Transcript stop failed" -Context @{ Error=$_.Exception.Message } }
+    try { Stop-Transcript | Out-Null } catch { Write-Log -Level Debug -Message "Transcript stop failed" -Context @{ Error = $_.Exception.Message } }
 }
 
 function Test-Admin {
@@ -387,9 +393,9 @@ function Convert-ToSafeVersion {
 }
 
 function Invoke-WithRetry {
-    param([Parameter(Mandatory)][scriptblock]$ScriptBlock, [int]$Attempts=3, [int]$DelaySeconds=2)
+    param([Parameter(Mandatory)][scriptblock]$ScriptBlock, [int]$Attempts = 3, [int]$DelaySeconds = 2)
     $last = $null
-    for ($i=1; $i -le $Attempts; $i++) {
+    for ($i = 1; $i -le $Attempts; $i++) {
         try { return & $ScriptBlock }
         catch {
             $last = $_
@@ -402,9 +408,9 @@ function Invoke-WithRetry {
 function Format-Bytes {
     param([long]$Bytes)
     if ($Bytes -lt 1KB) { return "$Bytes B" }
-    elseif ($Bytes -lt 1MB) { return ("{0:N2} KB" -f ($Bytes/1KB)) }
-    elseif ($Bytes -lt 1GB) { return ("{0:N2} MB" -f ($Bytes/1MB)) }
-    else { return ("{0:N2} GB" -f ($Bytes/1GB)) }
+    elseif ($Bytes -lt 1MB) { return ("{0:N2} KB" -f ($Bytes / 1KB)) }
+    elseif ($Bytes -lt 1GB) { return ("{0:N2} MB" -f ($Bytes / 1MB)) }
+    else { return ("{0:N2} GB" -f ($Bytes / 1GB)) }
 }
 
 # ========================= DEPENDENCY DETECTION ========================= #
@@ -431,7 +437,8 @@ function Get-IisSiteCount {
         $out = & $appcmd list site 2>$null
         if (-not $out) { return 0 }
         return ($out | Measure-Object).Count
-    } catch { return 0 }
+    }
+    catch { return 0 }
 }
 
 function Test-DotnetServiceDependencies {
@@ -441,7 +448,7 @@ function Test-DotnetServiceDependencies {
         # Windows Services
         $services = Get-WmiObject Win32_Service -ErrorAction SilentlyContinue | Where-Object { $_.PathName -match 'dotnet' }
         foreach ($svc in $services) {
-            $dependencies += [PSCustomObject]@{ Type='Service'; Name=$svc.Name; Path=$svc.PathName; State=$svc.State }
+            $dependencies += [PSCustomObject]@{ Type = 'Service'; Name = $svc.Name; Path = $svc.PathName; State = $svc.State }
         }
 
         # Scheduled Tasks
@@ -450,17 +457,18 @@ function Test-DotnetServiceDependencies {
                 $_.Actions.Execute -match 'dotnet' -or $_.Actions.WorkingDirectory -match 'dotnet'
             }
             foreach ($task in $tasks) {
-                $dependencies += [PSCustomObject]@{ Type='ScheduledTask'; Name=$task.TaskName; Path=$task.TaskPath; State=$task.State }
+                $dependencies += [PSCustomObject]@{ Type = 'ScheduledTask'; Name = $task.TaskName; Path = $task.TaskPath; State = $task.State }
             }
         }
 
         # Running processes
         $procs = Get-WmiObject Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction SilentlyContinue
         foreach ($proc in $procs) {
-            $dependencies += [PSCustomObject]@{ Type='Process'; Name="dotnet.exe (PID $($proc.ProcessId))"; Path=$proc.ExecutablePath; CommandLine=$proc.CommandLine }
+            $dependencies += [PSCustomObject]@{ Type = 'Process'; Name = "dotnet.exe (PID $($proc.ProcessId))"; Path = $proc.ExecutablePath; CommandLine = $proc.CommandLine }
         }
-    } catch {
-        Write-Log -Level Debug -Message "Dependency scan failed" -Context @{ Error=$_.Exception.Message; Function=$MyInvocation.MyCommand.Name }
+    }
+    catch {
+        Write-Log -Level Debug -Message "Dependency scan failed" -Context @{ Error = $_.Exception.Message; Function = $MyInvocation.MyCommand.Name }
     }
     return $dependencies
 }
@@ -481,7 +489,7 @@ function Test-EolRemovalRisk {
 
     [PSCustomObject]@{
         Channel = $Channel; Arch = $ArchLabel; RiskLevel = $risk
-        Reasons = $reasons.ToArray(); Dependencies = $deps; BlockRecommended = ($risk -in @('Medium','High'))
+        Reasons = $reasons.ToArray(); Dependencies = $deps; BlockRecommended = ($risk -in @('Medium', 'High'))
     }
 }
 
@@ -491,7 +499,7 @@ function Get-InstalledProductByArch {
     param([string]$DotnetPath, [string]$ProductRegex, [string]$ArchLabel)
     if (-not (Test-Path $DotnetPath)) { return @() }
     try { $list = & $DotnetPath --list-runtimes 2>$null }
-    catch { Write-Log -Level Warn -Message "List runtimes failed" -Context @{ Dotnet=$DotnetPath; Error=$_.Exception.Message }; return @() }
+    catch { Write-Log -Level Warn -Message "List runtimes failed" -Context @{ Dotnet = $DotnetPath; Error = $_.Exception.Message }; return @() }
     if (-not $list) { return @() }
 
     $lines = $list | Where-Object { $_ -match $ProductRegex }
@@ -500,12 +508,12 @@ function Get-InstalledProductByArch {
         if ($parts.Count -lt 2) { continue }
         $v = Convert-ToSafeVersion -VersionString $parts[1]
         if (-not $v) { continue }
-        [PSCustomObject]@{ MajorMinor="$($v.Major).$($v.Minor)"; Patch=[int]$v.Build; FullVersion=$v; RawVersion=$parts[1]; Architecture=$ArchLabel }
+        [PSCustomObject]@{ MajorMinor = "$($v.Major).$($v.Minor)"; Patch = [int]$v.Build; FullVersion = $v; RawVersion = $parts[1]; Architecture = $ArchLabel }
     }
 
     $groups = @()
     foreach ($g in ($objs | Group-Object MajorMinor)) {
-        $groups += [PSCustomObject]@{ Name=$g.Name; Group=$g.Group; Architecture=$ArchLabel }
+        $groups += [PSCustomObject]@{ Name = $g.Name; Group = $g.Group; Architecture = $ArchLabel }
     }
     return $groups
 }
@@ -562,7 +570,7 @@ function Get-LatestAspNetCoreVersion {
     if (-not $latest) { return $null }
     $release = $ReleaseData.releases | Where-Object { $_.'release-version' -eq $latest } | Select-Object -First 1
     $verObj = Convert-ToSafeVersion -VersionString $latest
-    if ($release -and $verObj) { [PSCustomObject]@{ Version=$verObj; Release=$release } } else { $null }
+    if ($release -and $verObj) { [PSCustomObject]@{ Version = $verObj; Release = $release } } else { $null }
 }
 
 function Get-LatestWindowsDesktopVersion {
@@ -572,7 +580,7 @@ function Get-LatestWindowsDesktopVersion {
     if (-not $latest) { return $null }
     $release = $ReleaseData.releases | Where-Object { $_.'release-version' -eq $latest } | Select-Object -First 1
     $verObj = Convert-ToSafeVersion -VersionString $latest
-    if ($release -and $verObj) { [PSCustomObject]@{ Version=$verObj; Release=$release } } else { $null }
+    if ($release -and $verObj) { [PSCustomObject]@{ Version = $verObj; Release = $release } } else { $null }
 }
 
 # ========================= DOWNLOAD & INSTALL (Security Hardened) ========================= #
@@ -600,7 +608,8 @@ function Get-HostingBundleDownload {
         if ($Release.'aspnetcore-runtime' -and $Release.'aspnetcore-runtime'.files) { $candidates += $Release.'aspnetcore-runtime'.files }
         if ($Release.runtime -and $Release.runtime.files) { $candidates += $Release.runtime.files }
         if ($Release.files) { $candidates += $Release.files }
-    } catch { Write-Log -Level Debug -Message "Hosting bundle candidates collection failed" -Context @{ Error=$_.Exception.Message } }
+    }
+    catch { Write-Log -Level Debug -Message "Hosting bundle candidates collection failed" -Context @{ Error = $_.Exception.Message } }
     $candidates = $candidates | Where-Object { $_ -and $_.url }
     $candidates | Where-Object {
         $_.url -match '\.exe$' -and ($_.rid -eq 'win-x64' -or -not $_.rid) -and ($_.url -match 'dotnet-hosting' -or $_.url -match 'hosting')
@@ -622,11 +631,12 @@ function Test-FileHashIfAvailable {
     try {
         $hash = Get-FileHash -Path $FilePath -Algorithm SHA512
         return ($hash.Hash -ieq $Sha512)
-    } catch { return $false }
+    }
+    catch { return $false }
 }
 
 function Install-Exe {
-    param([string]$Path, [string]$Arguments="/quiet /norestart", [int]$TimeoutMinutes=10)
+    param([string]$Path, [string]$Arguments = "/quiet /norestart", [int]$TimeoutMinutes = 10)
     if (-not (Test-Path $Path)) { throw "Installer not found: $Path" }
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $Path
@@ -640,14 +650,14 @@ function Install-Exe {
     # FIX: Add timeout to prevent indefinite hangs
     $timeoutMs = $TimeoutMinutes * 60 * 1000
     if (-not $proc.WaitForExit($timeoutMs)) {
-        try { $proc.Kill() } catch { Write-Log -Level Debug -Message "Process kill failed" -Context @{ Error=$_.Exception.Message } }
+        try { $proc.Kill() } catch { Write-Log -Level Debug -Message "Process kill failed" -Context @{ Error = $_.Exception.Message } }
         throw "Installer timed out after $TimeoutMinutes minutes"
     }
 
     $exitCode = $proc.ExitCode
     $reboot = ($exitCode -eq 3010)
     if ($exitCode -ne 0 -and $exitCode -ne 3010) { throw "Installer failed: exit code $exitCode" }
-    [PSCustomObject]@{ ExitCode=$exitCode; RebootRequired=$reboot }
+    [PSCustomObject]@{ ExitCode = $exitCode; RebootRequired = $reboot }
 }
 
 # ========================= UNINSTALL TOOL (Dynamic URL) ========================= #
@@ -659,7 +669,7 @@ function Get-DotnetUninstallToolPath {
         "dotnet-core-uninstall.exe"
     )
     foreach ($p in $candidates) {
-        try { $cmd = Get-Command $p -ErrorAction Stop; if ($cmd -and $cmd.Source) { return $cmd.Source } } catch { Write-Log -Level Debug -Message "Command lookup failed" -Context @{ Path=$p; Error=$_.Exception.Message } }
+        try { $cmd = Get-Command $p -ErrorAction Stop; if ($cmd -and $cmd.Source) { return $cmd.Source } } catch { Write-Log -Level Debug -Message "Command lookup failed" -Context @{ Path = $p; Error = $_.Exception.Message } }
     }
     return $null
 }
@@ -670,11 +680,12 @@ function Get-LatestUninstallToolUrl {
         $release = Invoke-RestMethod -Uri $api -Headers @{ 'User-Agent' = $script:UserAgent } -ErrorAction Stop
         $asset = $release.assets | Where-Object { $_.name -match 'dotnet-core-uninstall.*\.msi$' } | Select-Object -First 1
         if ($asset) {
-            Write-Log -Level Info -Message "Found latest uninstall tool" -Context @{ Version=$release.tag_name }
+            Write-Log -Level Info -Message "Found latest uninstall tool" -Context @{ Version = $release.tag_name }
             return $asset.browser_download_url
         }
-    } catch {
-        Write-Log -Level Debug -Message "GitHub API check failed" -Context @{ Error=$_.Exception.Message; Function=$MyInvocation.MyCommand.Name }
+    }
+    catch {
+        Write-Log -Level Debug -Message "GitHub API check failed" -Context @{ Error = $_.Exception.Message; Function = $MyInvocation.MyCommand.Name }
     }
     return $script:DefaultUninstallMsiUrl
 }
@@ -682,7 +693,7 @@ function Get-LatestUninstallToolUrl {
 function Install-DotnetUninstallTool {
     param([string]$UrlOverride)
     $existing = Get-DotnetUninstallToolPath
-    if ($existing) { Write-Log -Level Ok -Message "Uninstall tool present" -Context @{ Path=$existing }; return $true }
+    if ($existing) { Write-Log -Level Ok -Message "Uninstall tool present" -Context @{ Path = $existing }; return $true }
 
     $msiUrl = if ($UrlOverride) { $UrlOverride } else { Get-LatestUninstallToolUrl }
     $temp = Join-Path $env:TEMP ("dotnet-uninstall-" + [Guid]::NewGuid().ToString("N") + ".msi")
@@ -697,7 +708,7 @@ function Install-DotnetUninstallTool {
         Write-Log -Level Info -Message "Verifying digital signature and publisher"
         $sig = Get-AuthenticodeSignature -FilePath $temp
         if ($sig.Status -ne 'Valid') {
-            Write-Log -Level Error -Message "MSI signature invalid - installation blocked" -Context @{ Status=$sig.Status; Signer=$sig.SignerCertificate.Subject }
+            Write-Log -Level Error -Message "MSI signature invalid - installation blocked" -Context @{ Status = $sig.Status; Signer = $sig.SignerCertificate.Subject }
             throw "MSI signature validation failed. The downloaded file may be corrupted or tampered with."
         }
 
@@ -706,17 +717,17 @@ function Install-DotnetUninstallTool {
         # Microsoft uses product-specific CNs (like "CN=.NET") with "O=Microsoft Corporation"
         $publisher = $sig.SignerCertificate.Subject
         if ($publisher -notmatch 'CN=Microsoft Corporation' -and $publisher -notmatch 'O=Microsoft Corporation') {
-            Write-Log -Level Error -Message "MSI publisher validation failed - not signed by Microsoft" -Context @{ Publisher=$publisher }
+            Write-Log -Level Error -Message "MSI publisher validation failed - not signed by Microsoft" -Context @{ Publisher = $publisher }
             throw "Publisher validation failed. MSI must be signed by Microsoft Corporation."
         }
 
         # Check certificate expiration
         if ($sig.SignerCertificate.NotAfter -lt (Get-Date)) {
-            Write-Log -Level Error -Message "Signer certificate has expired" -Context @{ Expired=$sig.SignerCertificate.NotAfter }
+            Write-Log -Level Error -Message "Signer certificate has expired" -Context @{ Expired = $sig.SignerCertificate.NotAfter }
             throw "Signer certificate has expired."
         }
 
-        Write-Log -Level Ok -Message "Signature and publisher validated" -Context @{ Publisher=$publisher }
+        Write-Log -Level Ok -Message "Signature and publisher validated" -Context @{ Publisher = $publisher }
 
         Write-Log -Level Info -Message "Installing uninstall tool"
         if ($PSCmdlet.ShouldProcess($temp, "Install MSI")) {
@@ -726,51 +737,53 @@ function Install-DotnetUninstallTool {
             $timeoutMs = 10 * 60 * 1000  # 10 minutes
             if (-not $proc.WaitForExit($timeoutMs)) {
                 Write-Log -Level Warn -Message "MSI installer timed out after 10 minutes"
-                try { $proc.Kill() } catch { Write-Log -Level Debug -Message "MSI process kill failed" -Context @{ Error=$_.Exception.Message } }
+                try { $proc.Kill() } catch { Write-Log -Level Debug -Message "MSI process kill failed" -Context @{ Error = $_.Exception.Message } }
                 return $false
             }
             if ($proc.ExitCode -eq 3010) { $script:RebootRequired = $true }
             if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
-                Write-Log -Level Warn -Message "MSI install non-zero exit" -Context @{ ExitCode=$proc.ExitCode }
+                Write-Log -Level Warn -Message "MSI install non-zero exit" -Context @{ ExitCode = $proc.ExitCode }
                 return $false
             }
         }
 
         Start-Sleep -Seconds 2
         $found = Get-DotnetUninstallToolPath
-        if ($found) { Write-Log -Level Ok -Message "Uninstall tool installed" -Context @{ Path=$found }; return $true }
+        if ($found) { Write-Log -Level Ok -Message "Uninstall tool installed" -Context @{ Path = $found }; return $true }
         Write-Log -Level Warn -Message "Tool not found after install"; return $false
-    } catch {
-        Write-Log -Level Warn -Message "Tool install failed" -Context @{ Error=$_.Exception.Message }
+    }
+    catch {
+        Write-Log -Level Warn -Message "Tool install failed" -Context @{ Error = $_.Exception.Message }
         return $false
-    } finally {
-        try { Remove-Item -Path $temp -Force -ErrorAction SilentlyContinue } catch { Write-Log -Level Debug -Message "Temp file cleanup failed" -Context @{ Path=$temp; Error=$_.Exception.Message } }
+    }
+    finally {
+        try { Remove-Item -Path $temp -Force -ErrorAction SilentlyContinue } catch { Write-Log -Level Debug -Message "Temp file cleanup failed" -Context @{ Path = $temp; Error = $_.Exception.Message } }
     }
 }
 
 # ========================= REMOVAL ========================= #
 
 function Remove-AspNetCoreChannel {
-    param([string]$MajorMinor, [ValidateSet('x64','x86')][string]$ArchLimit)
+    param([string]$MajorMinor, [ValidateSet('x64', 'x86')][string]$ArchLimit)
     $tool = Get-DotnetUninstallToolPath
     if (-not $tool) { Write-Log -Level Warn -Message "Uninstall tool not found"; return $false }
 
-    $archs = if ($ArchLimit) { @($ArchLimit) } else { @('x64','x86') }
+    $archs = if ($ArchLimit) { @($ArchLimit) } else { @('x64', 'x86') }
     foreach ($a in $archs) {
-        $args = @("remove","--aspnet-runtime","--major-minor",$MajorMinor,"--yes","--$a")
+        $args = @("remove", "--aspnet-runtime", "--major-minor", $MajorMinor, "--yes", "--$a")
         $label = "ASP.NET Core $MajorMinor $a"
-        Write-Log -Level Info -Message "Removing EOL channel" -Context @{ Target=$label }
+        Write-Log -Level Info -Message "Removing EOL channel" -Context @{ Target = $label }
         if ($PSCmdlet.ShouldProcess($label, "Remove ASP.NET Core runtime")) {
             # FIX: Added timeout handling using WaitForExit() method
             $p = Start-Process -FilePath $tool -ArgumentList $args -PassThru -NoNewWindow
             $timeoutMs = 10 * 60 * 1000  # 10 minutes
             if (-not $p.WaitForExit($timeoutMs)) {
-                Write-Log -Level Warn -Message "Uninstall tool timed out after 10 minutes" -Context @{ Target=$label }
-                try { $p.Kill() } catch { Write-Log -Level Debug -Message "Uninstall process kill failed" -Context @{ Error=$_.Exception.Message } }
+                Write-Log -Level Warn -Message "Uninstall tool timed out after 10 minutes" -Context @{ Target = $label }
+                try { $p.Kill() } catch { Write-Log -Level Debug -Message "Uninstall process kill failed" -Context @{ Error = $_.Exception.Message } }
                 return $false
             }
             Add-Action -Type 'EOL-Removed' -Product 'AspNetCore' -Channel $MajorMinor -Arch $a -Detail "Removed" -ExitCode $p.ExitCode -Method 'UninstallTool'
-            if ($p.ExitCode -gt 1) { Write-Log -Level Warn -Message "Tool error" -Context @{ ExitCode=$p.ExitCode }; return $false }
+            if ($p.ExitCode -gt 1) { Write-Log -Level Warn -Message "Tool error" -Context @{ ExitCode = $p.ExitCode }; return $false }
         }
     }
     return $true
@@ -789,15 +802,17 @@ function Get-FolderSizeBytes {
         $sum = ($files | Measure-Object -Property Length -Sum).Sum
         if ($null -eq $sum) { return 0 }
         return $sum
-    } catch {
-        Write-Log -Level Debug -Message "DirectoryInfo failed, using fallback" -Context @{ Path=$Path; Error=$_.Exception.Message }
+    }
+    catch {
+        Write-Log -Level Debug -Message "DirectoryInfo failed, using fallback" -Context @{ Path = $Path; Error = $_.Exception.Message }
         # Fallback to PowerShell cmdlets
         try {
             $sum = (Get-ChildItem -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum).Sum
             if ($null -eq $sum) { return 0 }
             return $sum
-        } catch {
-            Write-Log -Level Debug -Message "Folder size calculation failed" -Context @{ Path=$Path; Error=$_.Exception.Message }
+        }
+        catch {
+            Write-Log -Level Debug -Message "Folder size calculation failed" -Context @{ Path = $Path; Error = $_.Exception.Message }
             return 0
         }
     }
@@ -812,14 +827,15 @@ function Get-PatchObjectsFromShared {
         try {
             $v = [version]$pf.Name
             $bytes = Get-FolderSizeBytes -Path $pf.FullName
-            [PSCustomObject]@{ Root=$SharedRoot; Product=$ProductFolderName; Version=$pf.Name; MajorMinor="$($v.Major).$($v.Minor)"; Patch=[int]$v.Build; Bytes=[long]$bytes; Path=$pf.FullName }
-        } catch { Write-Log -Level Debug -Message "Patch object creation failed" -Context @{ Path=$pf.FullName; Error=$_.Exception.Message } }
+            [PSCustomObject]@{ Root = $SharedRoot; Product = $ProductFolderName; Version = $pf.Name; MajorMinor = "$($v.Major).$($v.Minor)"; Patch = [int]$v.Build; Bytes = [long]$bytes; Path = $pf.FullName }
+        }
+        catch { Write-Log -Level Debug -Message "Patch object creation failed" -Context @{ Path = $pf.FullName; Error = $_.Exception.Message } }
     }
 }
 
 function Get-DiskUsageSnapshot {
-    $roots = @("C:\Program Files\dotnet\shared","C:\Program Files (x86)\dotnet\shared") | Where-Object { Test-Path $_ }
-    $products = @("Microsoft.NETCore.App","Microsoft.AspNetCore.App","Microsoft.WindowsDesktop.App")
+    $roots = @("C:\Program Files\dotnet\shared", "C:\Program Files (x86)\dotnet\shared") | Where-Object { Test-Path $_ }
+    $products = @("Microsoft.NETCore.App", "Microsoft.AspNetCore.App", "Microsoft.WindowsDesktop.App")
     $entries = @()
     foreach ($root in $roots) {
         foreach ($prod in $products) {
@@ -867,14 +883,14 @@ function Summarize-DiskUsage {
 }
 
 function Invoke-PostPatchCleanup {
-    param([ValidateSet('x64','x86')][string]$ArchToClean)
+    param([ValidateSet('x64', 'x86')][string]$ArchToClean)
     $tool = Get-DotnetUninstallToolPath
     if (-not $tool) { Write-Log -Level Warn -Message "Uninstall tool not found"; return @() }
 
     $targets = @(
-        @{ Name="Base .NET Runtime"; Arg="--runtime"; Product="BaseRuntime" },
-        @{ Name="ASP.NET Core Runtime"; Arg="--aspnet-runtime"; Product="AspNetCore" },
-        @{ Name="Windows Desktop Runtime"; Arg="--windowsdesktop-runtime"; Product="WindowsDesktop" }
+        @{ Name = "Base .NET Runtime"; Arg = "--runtime"; Product = "BaseRuntime" },
+        @{ Name = "ASP.NET Core Runtime"; Arg = "--aspnet-runtime"; Product = "AspNetCore" },
+        @{ Name = "Windows Desktop Runtime"; Arg = "--windowsdesktop-runtime"; Product = "WindowsDesktop" }
     )
     $archArgs = @("--$ArchToClean")
     $results = @()
@@ -882,18 +898,18 @@ function Invoke-PostPatchCleanup {
     foreach ($t in $targets) {
         $args = @('remove', $t.Arg, '--all-lower-patches', '--yes') + $archArgs
         $label = "$($t.Name) $ArchToClean"
-        Write-Log -Level Info -Message "Cleaning lower patches" -Context @{ Target=$label }
+        Write-Log -Level Info -Message "Cleaning lower patches" -Context @{ Target = $label }
         if ($PSCmdlet.ShouldProcess($label, "Remove lower patches")) {
             # FIX: Added timeout handling using WaitForExit() method
             $p = Start-Process -FilePath $tool -ArgumentList $args -PassThru -NoNewWindow
             $timeoutMs = 10 * 60 * 1000  # 10 minutes
             if (-not $p.WaitForExit($timeoutMs)) {
-                Write-Log -Level Warn -Message "Cleanup operation timed out after 10 minutes" -Context @{ Target=$label }
-                try { $p.Kill() } catch { Write-Log -Level Debug -Message "Cleanup process kill failed" -Context @{ Error=$_.Exception.Message } }
-                $results += [PSCustomObject]@{ Label=$label; ExitCode=-1; Product=$t.Product; Arch=$ArchToClean }
+                Write-Log -Level Warn -Message "Cleanup operation timed out after 10 minutes" -Context @{ Target = $label }
+                try { $p.Kill() } catch { Write-Log -Level Debug -Message "Cleanup process kill failed" -Context @{ Error = $_.Exception.Message } }
+                $results += [PSCustomObject]@{ Label = $label; ExitCode = -1; Product = $t.Product; Arch = $ArchToClean }
                 continue
             }
-            $results += [PSCustomObject]@{ Label=$label; ExitCode=$p.ExitCode; Product=$t.Product; Arch=$ArchToClean }
+            $results += [PSCustomObject]@{ Label = $label; ExitCode = $p.ExitCode; Product = $t.Product; Arch = $ArchToClean }
             $status = if ($p.ExitCode -eq 0) { "completed" } elseif ($p.ExitCode -eq 1) { "no items" } else { "failed" }
             Add-Action -Type 'Cleanup' -Product $t.Product -Channel 'lower-patches' -Arch $ArchToClean -Detail "$label $status" -ExitCode $p.ExitCode -Method 'UninstallTool'
         }
@@ -911,7 +927,7 @@ function Invoke-RuntimeUpdatePlan {
         [Parameter(Mandatory)][object]$ReleaseIndex,
         [switch]$UpdateAspNet,
         [switch]$UpdateDesktop,
-        [ValidateSet('x64','x86','Both')][string]$Architecture = 'Both'
+        [ValidateSet('x64', 'x86', 'Both')][string]$Architecture = 'Both'
     )
 
     $plan = @()
@@ -935,7 +951,8 @@ function Invoke-RuntimeUpdatePlan {
                 $download = if ($IncludeHostingBundle -and (Test-IisPresent) -and $grp.Architecture -eq 'x64') {
                     $hb = Get-HostingBundleDownload -Release $latest.Release
                     if ($hb) { $hb } else { Get-AspNetCoreDownload -Release $latest.Release -ArchLabel $grp.Architecture }
-                } else {
+                }
+                else {
                     Get-AspNetCoreDownload -Release $latest.Release -ArchLabel $grp.Architecture
                 }
 
@@ -1018,7 +1035,8 @@ function Invoke-ExecutionPlan {
                                 throw "Hash verification failed for $($item.FileName)"
                             }
                             Write-Log -Level Ok -Message "Hash verified for $($item.FileName)"
-                        } else {
+                        }
+                        else {
                             Write-Log -Level Warn -Message "No hash available for $($item.FileName), checking signature"
                             $sig = Get-AuthenticodeSignature -FilePath $tempFile
                             if ($sig.Status -ne 'Valid') {
@@ -1035,7 +1053,8 @@ function Invoke-ExecutionPlan {
                         # FIX: Check if $installResult exists before accessing properties
                         if ($installResult -and $installResult.RebootRequired) { $script:RebootRequired = $true }
                         Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
-                    } else {
+                    }
+                    else {
                         Write-Log -Level Info -Message "[WhatIf] Would install $($item.TargetVersion)"
                     }
 
@@ -1050,7 +1069,7 @@ function Invoke-ExecutionPlan {
                     }
 
                     Add-Action -Type 'Update' -Product $item.Product -Channel $item.Channel -Arch $item.Architecture `
-                               -Detail "Updated to $($item.TargetVersion)" -ExitCode 0 -Method 'DirectInstall'
+                        -Detail "Updated to $($item.TargetVersion)" -ExitCode 0 -Method 'DirectInstall'
                 }
 
                 'Remove' {
@@ -1070,8 +1089,9 @@ function Invoke-ExecutionPlan {
 
             Write-Log -Level Ok -Message "$($item.Product) $($item.Channel) $($item.Architecture) completed"
 
-        } catch {
-            Write-Log -Level Error -Message "Failed: $($_.Exception.Message)" -Context @{ Product=$item.Product; Channel=$item.Channel }
+        }
+        catch {
+            Write-Log -Level Error -Message "Failed: $($_.Exception.Message)" -Context @{ Product = $item.Product; Channel = $item.Channel }
             $results += [PSCustomObject]@{
                 Product = $item.Product
                 Channel = $item.Channel
@@ -1123,7 +1143,8 @@ function Get-SystemStatus {
         $reclaimSum = ($diskSummary | Measure-Object -Property LowerBytes -Sum).Sum
         $status.TotalDiskUsage = if ($null -eq $totalSum) { 0 } else { $totalSum }
         $status.ReclaimableDisk = if ($null -eq $reclaimSum) { 0 } else { $reclaimSum }
-    } else {
+    }
+    else {
         $status.TotalDiskUsage = 0
         $status.ReclaimableDisk = 0
     }
@@ -1139,8 +1160,9 @@ function Get-SystemStatus {
             }
         }
         $status.EolChannels = $eolChannels
-    } catch {
-        Write-Log -Level Debug -Message "EOL detection failed" -Context @{ Error=$_.Exception.Message; Function=$MyInvocation.MyCommand.Name }
+    }
+    catch {
+        Write-Log -Level Debug -Message "EOL detection failed" -Context @{ Error = $_.Exception.Message; Function = $MyInvocation.MyCommand.Name }
         $status.EolChannels = @()
     }
 
@@ -1160,7 +1182,8 @@ function New-SystemSnapshot {
     $isClientOS = $false
     try {
         $isClientOS = (Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop).ProductType -eq 1
-    } catch {
+    }
+    catch {
         Write-Log -Level Debug -Message "Could not determine OS type" -Context @{ Error = $_.Exception.Message }
     }
 
@@ -1170,15 +1193,17 @@ function New-SystemSnapshot {
             Checkpoint-Computer -Description $SnapshotLabel -RestorePointType MODIFY_SETTINGS -ErrorAction Stop
             Write-Log -Level Ok -Message "System restore point created"
             return $true
-        } catch {
-            Write-Log -Level Warn -Message "Restore point creation failed" -Context @{ Error=$_.Exception.Message }
+        }
+        catch {
+            Write-Log -Level Warn -Message "Restore point creation failed" -Context @{ Error = $_.Exception.Message }
             return $false
         }
     }
 
     if ($IsWindows -and -not $isClientOS) {
         Write-Log -Level Warn -Message "System restore points are only supported on client operating systems (Win32_OperatingSystem.ProductType -ne 1); skipping rollback snapshot on this server"
-    } else {
+    }
+    else {
         Write-Log -Level Debug -Message "Restore point not available on this system"
     }
     return $false
@@ -1245,7 +1270,8 @@ function Show-MainMenu {
         if ($status.EolChannels.Count -gt 0) {
             Write-Host "  [5]  EOL Removal Wizard" -NoNewline -ForegroundColor White
             Write-Host "                       [$($status.EolChannels.Count) EOL!]" -ForegroundColor Red
-        } else {
+        }
+        else {
             Write-Host "  [5]  EOL Removal Wizard" -ForegroundColor White
         }
         Write-Host "  [6]  Cleanup Lower Patches" -ForegroundColor White
@@ -1287,7 +1313,7 @@ function Invoke-QuickMaintenance {
     $index = Get-ReleasesIndex
 
     $updatePlan = Invoke-RuntimeUpdatePlan -AspNetGroups $status.AspNetGroups -DesktopGroups $status.DesktopGroups `
-                                            -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
+        -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
 
     if ($updatePlan.Count -gt 0) {
         Write-Host "`nUpdates available:" -ForegroundColor Yellow
@@ -1299,7 +1325,8 @@ function Invoke-QuickMaintenance {
         $results = Invoke-ExecutionPlan -Plan $updatePlan
         $successCount = ($results | Where-Object { $_.Success }).Count
         Write-Host "[OK] Updates: $successCount/$($results.Count) successful" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "[OK] All runtimes up to date" -ForegroundColor Green
     }
 
@@ -1342,7 +1369,8 @@ function Show-SystemStatusDetailed {
     Write-Host "`nEOL Status:" -ForegroundColor Yellow
     if ($status.EolChannels.Count -eq 0) {
         Write-Host "  [OK] No EOL channels" -ForegroundColor Green
-    } else {
+    }
+    else {
         Write-Host "  [!]  EOL found:" -ForegroundColor Red
         foreach ($eol in $status.EolChannels) { Write-Host "     - $eol" -ForegroundColor DarkYellow }
     }
@@ -1356,7 +1384,7 @@ function Invoke-AutomatedUpdate {
     $status = Get-SystemStatus
     $index = Get-ReleasesIndex
     $plan = Invoke-RuntimeUpdatePlan -AspNetGroups $status.AspNetGroups -DesktopGroups $status.DesktopGroups `
-                                      -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
+        -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
 
     if ($plan.Count -eq 0) { Write-Host "[OK] All up to date" -ForegroundColor Green; return }
 
@@ -1373,7 +1401,7 @@ function Invoke-InteractiveUpdate {
     $status = Get-SystemStatus
     $index = Get-ReleasesIndex
     $allUpdates = Invoke-RuntimeUpdatePlan -AspNetGroups $status.AspNetGroups -DesktopGroups $status.DesktopGroups `
-                                            -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
+        -ReleaseIndex $index -UpdateAspNet -UpdateDesktop
 
     if ($allUpdates.Count -eq 0) { Write-Host "[OK] All up to date" -ForegroundColor Green; return }
 
@@ -1392,7 +1420,8 @@ function Invoke-InteractiveUpdate {
         try {
             $indices = $choice -split ',' | ForEach-Object { [int]$_.Trim() - 1 }
             $selected = $indices | ForEach-Object { if ($_ -ge 0 -and $_ -lt $allUpdates.Count) { $allUpdates[$_] } }
-        } catch { Write-Host "Invalid selection" -ForegroundColor Red; return }
+        }
+        catch { Write-Host "Invalid selection" -ForegroundColor Red; return }
     }
 
     if ($selected.Count -eq 0) { Write-Host "None selected" -ForegroundColor Yellow; return }
@@ -1420,7 +1449,7 @@ function Invoke-EolRemovalWizard {
         $parts = $eol -split ' '
         # FIX: Validate split results before accessing array elements
         if ($parts.Count -lt 2) {
-            Write-Log -Level Warn -Message "Invalid EOL format, skipping risk assessment" -Context @{ EOL=$eol }
+            Write-Log -Level Warn -Message "Invalid EOL format, skipping risk assessment" -Context @{ EOL = $eol }
             continue
         }
         $channel = $parts[0]
@@ -1451,7 +1480,7 @@ function Invoke-EolRemovalWizard {
         $parts = $eol -split ' '
         # FIX: Validate split results before accessing array elements
         if ($parts.Count -lt 2) {
-            Write-Log -Level Warn -Message "Invalid EOL format, skipping removal" -Context @{ EOL=$eol }
+            Write-Log -Level Warn -Message "Invalid EOL format, skipping removal" -Context @{ EOL = $eol }
             Write-Host "  [X] Skipped $eol (invalid format)" -ForegroundColor Red
             continue
         }
@@ -1502,14 +1531,15 @@ function Show-DiskUsageAnalyzer {
             return
         }
 
-        foreach ($s in ($summary | Sort-Object Product,Channel)) {
+        foreach ($s in ($summary | Sort-Object Product, Channel)) {
             Write-Host "`n$($s.Product) $($s.Channel):" -ForegroundColor Yellow
             Write-Host "  Total: $(Format-Bytes $s.TotalBytes)" -ForegroundColor White
             Write-Host "  Lower patches: $(Format-Bytes $s.LowerBytes)" -ForegroundColor Gray
         }
 
         Write-Host "`n[OK] Analysis complete" -ForegroundColor Green
-    } catch {
+    }
+    catch {
         Write-Log -Level Error -Message "Disk analysis failed: $($_.Exception.Message)"
         Write-Host "`n[ERROR] Disk analysis failed. See logs for details." -ForegroundColor Red
     }
@@ -1553,7 +1583,8 @@ try {
             Write-Host ""
             Read-Host "Press Enter to exit"
             exit 1
-        } else {
+        }
+        else {
             Write-Log -Level Error -Message "Administrator privileges required"
             throw "Run PowerShell as Administrator"
         }
@@ -1564,7 +1595,8 @@ try {
         Show-StartupScreen
         Show-MainMenu
         Write-Host "`n[OK] Session complete`n" -ForegroundColor Green
-    } else {
+    }
+    else {
         # AUTOMATED CLI MODE
         Write-Banner
 
@@ -1594,7 +1626,7 @@ try {
                 Write-Section "Execution Plan (Preview)"
 
                 $updatePlan = Invoke-RuntimeUpdatePlan -AspNetGroups $status.AspNetGroups -DesktopGroups $status.DesktopGroups `
-                                                        -ReleaseIndex $index -UpdateAspNet -UpdateDesktop -Architecture $archToProcess
+                    -ReleaseIndex $index -UpdateAspNet -UpdateDesktop -Architecture $archToProcess
 
                 if ($updatePlan.Count -gt 0) {
                     Write-Host "`n[PLAN] Planned Updates:" -ForegroundColor Yellow
@@ -1622,7 +1654,7 @@ try {
 
             # Execute updates
             $updatePlan = Invoke-RuntimeUpdatePlan -AspNetGroups $status.AspNetGroups -DesktopGroups $status.DesktopGroups `
-                                                    -ReleaseIndex $index -UpdateAspNet -UpdateDesktop -Architecture $archToProcess
+                -ReleaseIndex $index -UpdateAspNet -UpdateDesktop -Architecture $archToProcess
 
             if ($updatePlan.Count -gt 0) {
                 Write-Log -Level Info -Message "Executing $($updatePlan.Count) update(s)"
@@ -1654,9 +1686,10 @@ try {
                         }
                     }
                     $reportData | Export-Csv -Path $ReportPath -NoTypeInformation -Encoding UTF8
-                    Write-Log -Level Ok -Message "Report exported" -Context @{ Path=$ReportPath }
-                } catch {
-                    Write-Log -Level Warn -Message "Report export failed" -Context @{ Error=$_.Exception.Message }
+                    Write-Log -Level Ok -Message "Report exported" -Context @{ Path = $ReportPath }
+                }
+                catch {
+                    Write-Log -Level Warn -Message "Report export failed" -Context @{ Error = $_.Exception.Message }
                 }
             }
 
@@ -1672,9 +1705,10 @@ try {
                         RebootRequired = $script:RebootRequired
                     }
                     $summary | ConvertTo-Json -Depth 10 | Out-File -FilePath $JsonSummaryPath -Encoding UTF8
-                    Write-Log -Level Ok -Message "JSON exported" -Context @{ Path=$JsonSummaryPath }
-                } catch {
-                    Write-Log -Level Warn -Message "JSON export failed" -Context @{ Error=$_.Exception.Message }
+                    Write-Log -Level Ok -Message "JSON exported" -Context @{ Path = $JsonSummaryPath }
+                }
+                catch {
+                    Write-Log -Level Warn -Message "JSON export failed" -Context @{ Error = $_.Exception.Message }
                 }
             }
 
@@ -1684,12 +1718,14 @@ try {
                 Write-Host "[!]  System reboot recommended" -ForegroundColor Yellow
             }
 
-        } finally {
+        }
+        finally {
             if ($LogPath) { Stop-TypedTranscript }
         }
     }
 
-} catch {
+}
+catch {
     Write-Log -Level Error -Message "Fatal error: $($_.Exception.Message)"
     Write-Host "`nFatal error. Check logs." -ForegroundColor Red
     exit 1


### PR DESCRIPTION
Closes #116 #118 #128

PSSA enforcement campaign for #116 (comment-based help), #118 (ShouldProcess), #128 (style rules).
Fixes: formatter-normalized style, manual casing fixes, comment-based help headers, SupportsShouldProcess retrofits with `$PSCmdlet.ShouldProcess()` guards (no -ConfirmImpact; normal runs stay silent, -WhatIf/-Confirm become available).

## Summary by Sourcery

Align security and automation PowerShell scripts with PSSA style guidance and ShouldProcess semantics across utilities, compliance checks, monitoring, and CI tooling.

Bug Fixes:
- Ensure ShouldProcess checks are honored instead of ad-hoc WhatIf flags during runtime update execution to avoid unintended changes in preview scenarios.
- Harden URL validation and MSI signature/publisher checks in .NET runtime uninstall tool flows while preserving existing safety guarantees.

Enhancements:
- Normalize PowerShell parameter, hashtable, switch, and control-flow formatting to comply with PSSA style conventions across multiple scripts.
- Add or strengthen CmdletBinding SupportsShouldProcess and associated $PSCmdlet.ShouldProcess guards for operations that change system state, including .NET runtime maintenance, uninstall tool installation, runtime cleanup, app updates, and rollback snapshots.
- Improve logging consistency and context objects in maintenance and security scripts to produce clearer, structured output while retaining existing behaviors.
- Refine ordering and calculation of summary metrics (health scores, success rates, compliance percentages) for monitoring and compliance scripts without altering their core logic.