### PR TITLE
fix: enforce PSSA style/help/ShouldProcess in endpoints/intune

### DIFF
--- a/scripts/endpoints/intune/IntuneGraphHelper.psm1
+++ b/scripts/endpoints/intune/IntuneGraphHelper.psm1
@@ -21,7 +21,7 @@ function Connect-IntuneGraph {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string[]]$Scopes = @(
             "DeviceManagementManagedDevices.Read.All",
             "DeviceManagementConfiguration.Read.All",
@@ -110,13 +110,13 @@ function Export-IntuneReportToHTML {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [object[]]$Data,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Title,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$FilePath
     )
 
@@ -227,13 +227,13 @@ function Export-IntuneReportToCSV {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [object[]]$Data,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Title,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$FilePath
     )
 

--- a/scripts/endpoints/intune/deployment/Export-WingetPackageList.ps1
+++ b/scripts/endpoints/intune/deployment/Export-WingetPackageList.ps1
@@ -42,17 +42,17 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('JSON','CSV','Console')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('JSON', 'CSV', 'Console')]
     [string]$ExportFormat = 'Console',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SourceFilter,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeSystemApps
 )
 
@@ -71,7 +71,7 @@ function Get-WingetPath {
 
 function Get-WingetPackages {
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) { return @() }
+    if (-not $wingetPath) { return @() }
 
     Write-Host "Enumerating winget packages..." -ForegroundColor Cyan
 
@@ -84,21 +84,21 @@ function Get-WingetPackages {
         # Skip header lines
         $dataLines = $lines | Select-Object -Skip 2
 
-        foreach($line in $dataLines) {
+        foreach ($line in $dataLines) {
             # Parse winget list output format
-            if($line -match '^\s*(.+?)\s+(.+?)\s+([\d\.]+)\s*(<\s*([\d\.]+))?\s*(.*)$') {
+            if ($line -match '^\s*(.+?)\s+(.+?)\s+([\d\.]+)\s*(<\s*([\d\.]+))?\s*(.*)$') {
                 $name = $matches[1].Trim()
                 $id = $matches[2].Trim()
                 $version = $matches[3].Trim()
-                $availableVersion = if($matches[5]) { $matches[5].Trim() } else { $version }
+                $availableVersion = if ($matches[5]) { $matches[5].Trim() } else { $version }
                 $source = $matches[6].Trim()
 
                 # Apply filters
-                if($SourceFilter -and $source -notlike "*$SourceFilter*") {
+                if ($SourceFilter -and $source -notlike "*$SourceFilter*") {
                     continue
                 }
 
-                if(-not $IncludeSystemApps -and $source -like "*msstore*") {
+                if (-not $IncludeSystemApps -and $source -like "*msstore*") {
                     continue
                 }
 
@@ -124,25 +124,26 @@ function Get-WingetPackages {
 }
 
 function Export-Data {
-    if($script:packages.Count -eq 0) {
+    if ($script:packages.Count -eq 0) {
         Write-Warning "No packages to export"
         return
     }
 
-    switch($ExportFormat) {
+    switch ($ExportFormat) {
         'JSON' {
             $jsonData = $script:packages | ConvertTo-Json -Depth 10
 
-            if($OutputPath) {
+            if ($OutputPath) {
                 $jsonData | Out-File -FilePath $OutputPath -Encoding UTF8
                 Write-Host "Exported to: $OutputPath" -ForegroundColor Green
-            } else {
+            }
+            else {
                 Write-Output $jsonData
             }
         }
 
         'CSV' {
-            if(-not $OutputPath) {
+            if (-not $OutputPath) {
                 $OutputPath = "$env:TEMP\winget-packages_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
             }
 

--- a/scripts/endpoints/intune/deployment/New-BulkWingetUpdater.ps1
+++ b/scripts/endpoints/intune/deployment/New-BulkWingetUpdater.ps1
@@ -53,33 +53,33 @@
     Designed for Intune Proactive Remediations
 #>
 
-[CmdletBinding(DefaultParameterSetName='Single')]
+[CmdletBinding(DefaultParameterSetName = 'Single')]
 param(
-    [Parameter(Mandatory=$true, ParameterSetName='Single')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Single')]
     [string]$AppName,
 
-    [Parameter(Mandatory=$true, ParameterSetName='Single')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Single')]
     [string]$WingetID,
 
-    [Parameter(Mandatory=$true, ParameterSetName='Single')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Single')]
     [string]$ProcessName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath = ".",
 
-    [Parameter(Mandatory=$false, ParameterSetName='Single')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Single')]
     [switch]$ForceUpdate,
 
-    [Parameter(Mandatory=$true, ParameterSetName='Batch')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Batch')]
     [switch]$GenerateBatch,
 
-    [Parameter(Mandatory=$true, ParameterSetName='Batch')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Batch')]
     [string]$CSVPath
 )
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Success' { 'Green' }
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
@@ -89,6 +89,7 @@ function Write-ColorOutput {
 }
 
 function New-DetectScript {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$Name,
         [string]$ID,
@@ -96,8 +97,12 @@ function New-DetectScript {
         [bool]$Force = $false
     )
 
-    $processCheck = if(-not $Force) {
-@"
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Generate detect script')) {
+        return
+    }
+
+    $processCheck = if (-not $Force) {
+        @"
 try {
 `$process = Get-Process -Name "$Process" -ErrorAction SilentlyContinue
 # Check if there's an available update
@@ -124,8 +129,9 @@ if ((`$lines -match '\bVersion\s+Available\b' -and `$process -eq `$null)) {
     exit 1
 }
 "@
-    } else {
-@"
+    }
+    else {
+        @"
 if (`$lines -match '\bVersion\s+Available\b') {
     `$verInstalled, `$verAvailable = (-split `$lines[-1])[-3,-2]
     Write-Host "Application update available for $Name. Current version is `$verInstalled, version available is `$verAvailable"
@@ -140,7 +146,7 @@ if (`$lines -match '\bVersion\s+Available\b') {
 "@
     }
 
-@"
+    @"
 <#
 .SYNOPSIS
     Detects if $Name has an available update via winget.
@@ -214,6 +220,7 @@ catch {
 }
 
 function New-RemediateScript {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$Name,
         [string]$ID,
@@ -221,8 +228,12 @@ function New-RemediateScript {
         [bool]$Force = $false
     )
 
-    $processCheck = if(-not $Force) {
-@"
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Generate remediate script')) {
+        return
+    }
+
+    $processCheck = if (-not $Force) {
+        @"
 # Check if app is running
 `$process = Get-Process -Name "`$AppProcess" -ErrorAction SilentlyContinue
 if (`$process -ne `$null) {
@@ -230,14 +241,15 @@ if (`$process -ne `$null) {
     exit 1
 }
 "@
-    } else {
-@"
+    }
+    else {
+        @"
 # Force update enabled - will update even if running
 Write-Verbose -Verbose "Force update enabled"
 "@
     }
 
-@"
+    @"
 <#
 .SYNOPSIS
     Remediates $Name by installing available updates via winget.
@@ -317,6 +329,7 @@ catch {
 }
 
 function New-WingetScripts {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [string]$Name,
         [string]$ID,
@@ -327,19 +340,23 @@ function New-WingetScripts {
 
     # Create output directory
     $appFolder = Join-Path $Path $Name
-    if(-not (Test-Path $appFolder)) {
+    if (-not (Test-Path $appFolder)) {
         New-Item -ItemType Directory -Path $appFolder -Force | Out-Null
     }
 
     # Generate detect script
     $detectScript = New-DetectScript -Name $Name -ID $ID -Process $Process -Force $Force
     $detectPath = Join-Path $appFolder "detect.ps1"
-    $detectScript | Out-File -FilePath $detectPath -Encoding UTF8 -Force
+    if ($PSCmdlet.ShouldProcess($detectPath, 'Write detect script')) {
+        $detectScript | Out-File -FilePath $detectPath -Encoding UTF8 -Force
+    }
 
     # Generate remediate script
     $remediateScript = New-RemediateScript -Name $Name -ID $ID -Process $Process -Force $Force
     $remediatePath = Join-Path $appFolder "remediate.ps1"
-    $remediateScript | Out-File -FilePath $remediatePath -Encoding UTF8 -Force
+    if ($PSCmdlet.ShouldProcess($remediatePath, 'Write remediate script')) {
+        $remediateScript | Out-File -FilePath $remediatePath -Encoding UTF8 -Force
+    }
 
     Write-ColorOutput "  Created: $appFolder" -Level Success
     Write-ColorOutput "    - detect.ps1" -Level Info
@@ -351,8 +368,8 @@ Write-Host "`n========================================" -ForegroundColor Cyan
 Write-Host "  Winget Remediation Script Generator" -ForegroundColor Cyan
 Write-Host "========================================`n" -ForegroundColor Cyan
 
-if($GenerateBatch) {
-    if(-not (Test-Path $CSVPath)) {
+if ($GenerateBatch) {
+    if (-not (Test-Path $CSVPath)) {
         Write-ColorOutput "ERROR: CSV file not found: $CSVPath" -Level Error
         exit 1
     }
@@ -360,7 +377,7 @@ if($GenerateBatch) {
     $apps = Import-Csv -Path $CSVPath
     Write-ColorOutput "Generating scripts for $($apps.Count) applications...`n" -Level Info
 
-    foreach($app in $apps) {
+    foreach ($app in $apps) {
         Write-Host "Processing: $($app.AppName)" -ForegroundColor Cyan
         New-WingetScripts -Name $app.AppName -ID $app.WingetID -Process $app.ProcessName -Path $OutputPath -Force:$ForceUpdate
     }

--- a/scripts/endpoints/intune/deployment/New-IntuneWinPackage.ps1
+++ b/scripts/endpoints/intune/deployment/New-IntuneWinPackage.ps1
@@ -41,16 +41,16 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SourceFolder,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputFolder,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$SetupFile,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ContentPrepToolPath
 )
 
@@ -252,7 +252,7 @@ $failed = ($packagesCreated | Where-Object { $_.Status -ne "Success" }).Count
 
 Write-Host "Total Processed:  $($packagesCreated.Count)" -ForegroundColor White
 Write-Host "Successful:       $successful" -ForegroundColor Green
-Write-Host "Failed:           $failed" -ForegroundColor $(if($failed -gt 0){'Red'}else{'Green'})
+Write-Host "Failed:           $failed" -ForegroundColor $(if ($failed -gt 0) { 'Red' }else { 'Green' })
 
 if ($successful -gt 0) {
     Write-Host "`nPackages Created:" -ForegroundColor Cyan

--- a/scripts/endpoints/intune/deployment/New-Win32AppTemplate.ps1
+++ b/scripts/endpoints/intune/deployment/New-Win32AppTemplate.ps1
@@ -44,20 +44,20 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$AppName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$InstallCommand,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$UninstallCommand,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('Registry', 'File', 'MSI', 'Script')]
     [string]$DetectionType = 'Registry',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputFolder
 )
 

--- a/scripts/endpoints/intune/deployment/New-WingetRemediationScript.ps1
+++ b/scripts/endpoints/intune/deployment/New-WingetRemediationScript.ps1
@@ -54,16 +54,16 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$PackageId,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputFolder,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$AppDisplayName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeReadme
 )
 

--- a/scripts/endpoints/intune/deployment/New-WingetSourceConfig.ps1
+++ b/scripts/endpoints/intune/deployment/New-WingetSourceConfig.ps1
@@ -61,34 +61,34 @@
     Custom sources require appropriate certificates/authentication
 #>
 
-[CmdletBinding(DefaultParameterSetName='Add')]
+[CmdletBinding(DefaultParameterSetName = 'Add')]
 param(
-    [Parameter(Mandatory=$true, ParameterSetName='Add')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Add')]
     [string]$SourceName,
 
-    [Parameter(Mandatory=$true, ParameterSetName='Add')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Add')]
     [string]$SourceURL,
 
-    [Parameter(Mandatory=$false, ParameterSetName='Add')]
-    [ValidateSet('Microsoft.Rest','Microsoft.PreIndexed.Package')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Add')]
+    [ValidateSet('Microsoft.Rest', 'Microsoft.PreIndexed.Package')]
     [string]$SourceType = 'Microsoft.Rest',
 
-    [Parameter(Mandatory=$false, ParameterSetName='Add')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Add')]
     [switch]$RemoveDefaultSources,
 
-    [Parameter(Mandatory=$false, ParameterSetName='Reset')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Reset')]
     [switch]$ResetSources,
 
-    [Parameter(Mandatory=$false, ParameterSetName='Export')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Export')]
     [switch]$ExportConfig,
 
-    [Parameter(Mandatory=$false, ParameterSetName='Import')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Import')]
     [string]$ImportConfig,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath = ".",
 
-    [Parameter(Mandatory=$false, ParameterSetName='Add')]
+    [Parameter(Mandatory = $false, ParameterSetName = 'Add')]
     [switch]$GenerateIntuneScript
 )
 
@@ -96,7 +96,7 @@ param(
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Success' { 'Green' }
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
@@ -112,7 +112,7 @@ function Get-WingetPath {
     }
     catch {
         $wingetExe = Resolve-Path "C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue
-        if($wingetExe) {
+        if ($wingetExe) {
             return $wingetExe[-1].Path
         }
         return $null
@@ -121,7 +121,7 @@ function Get-WingetPath {
 
 function Get-CurrentSources {
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) {
+    if (-not $wingetPath) {
         Write-ColorOutput "Winget not found" -Level Error
         return @()
     }
@@ -140,7 +140,7 @@ function Get-CurrentSources {
 
 function Add-CustomSource {
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) { return }
+    if (-not $wingetPath) { return }
 
     Write-Host "`nAdding custom source: $SourceName" -ForegroundColor Cyan
     Write-Host "  URL: $SourceURL" -ForegroundColor Gray
@@ -156,17 +156,21 @@ function Add-CustomSource {
 }
 
 function Remove-DefaultSources {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) { return }
+    if (-not $wingetPath) { return }
 
     Write-Host "`nRemoving default sources..." -ForegroundColor Yellow
 
     $defaultSources = @('winget', 'msstore')
 
-    foreach($source in $defaultSources) {
+    foreach ($source in $defaultSources) {
         try {
-            & $wingetPath source remove --name $source 2>&1 | Out-Null
-            Write-ColorOutput "  Removed: $source" -Level Success
+            if ($PSCmdlet.ShouldProcess($source, 'Remove winget source')) {
+                & $wingetPath source remove --name $source 2>&1 | Out-Null
+                Write-ColorOutput "  Removed: $source" -Level Success
+            }
         }
         catch {
             Write-ColorOutput "  Could not remove $source (may not exist)" -Level Warning
@@ -175,14 +179,18 @@ function Remove-DefaultSources {
 }
 
 function Reset-WingetSources {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) { return }
+    if (-not $wingetPath) { return }
 
     Write-Host "`nResetting winget sources to defaults..." -ForegroundColor Cyan
 
     try {
-        & $wingetPath source reset --force
-        Write-ColorOutput "Successfully reset winget sources" -Level Success
+        if ($PSCmdlet.ShouldProcess('winget', 'Reset sources to defaults')) {
+            & $wingetPath source reset --force
+            Write-ColorOutput "Successfully reset winget sources" -Level Success
+        }
     }
     catch {
         Write-ColorOutput "Failed to reset sources: $($_.Exception.Message)" -Level Error
@@ -206,12 +214,12 @@ function Import-SourceConfig {
     param([string]$ConfigPath)
 
     $wingetPath = Get-WingetPath
-    if(-not $wingetPath) {
+    if (-not $wingetPath) {
         Write-ColorOutput "Winget not found - cannot import configuration" -Level Error
         return
     }
 
-    if(-not (Test-Path $ConfigPath)) {
+    if (-not (Test-Path $ConfigPath)) {
         Write-ColorOutput "Configuration file not found: $ConfigPath" -Level Error
         return
     }
@@ -222,20 +230,20 @@ function Import-SourceConfig {
         $config = Get-Content -Path $ConfigPath -Raw | ConvertFrom-Json
 
         $sources = @()
-        if($config.Sources) {
+        if ($config.Sources) {
             $sources = @($config.Sources)
         }
-        elseif($config -is [System.Array]) {
+        elseif ($config -is [System.Array]) {
             $sources = @($config)
         }
 
         $removeSources = @()
-        if($config.RemoveSources) {
+        if ($config.RemoveSources) {
             $removeSources = @($config.RemoveSources)
         }
 
         # Remove sources first
-        foreach($source in $removeSources) {
+        foreach ($source in $removeSources) {
             try {
                 & $wingetPath source remove --name $source.Name 2>&1 | Out-Null
                 Write-ColorOutput "  Removed: $($source.Name)" -Level Success
@@ -246,12 +254,12 @@ function Import-SourceConfig {
         }
 
         # Add/update sources
-        foreach($source in $sources) {
+        foreach ($source in $sources) {
             $sourceName = $source.Name
             $sourceArg = $source.Arg
-            $sourceType = if($source.Type) { $source.Type } else { 'Microsoft.Rest' }
+            $sourceType = if ($source.Type) { $source.Type } else { 'Microsoft.Rest' }
 
-            if(-not $sourceName -or -not $sourceArg) {
+            if (-not $sourceName -or -not $sourceArg) {
                 Write-ColorOutput "  Skipping invalid source entry (Name and Arg are required)" -Level Warning
                 continue
             }
@@ -270,6 +278,8 @@ function Import-SourceConfig {
 }
 
 function New-IntuneDeploymentScript {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
     $scriptContent = @"
 <#
 .SYNOPSIS
@@ -317,7 +327,7 @@ catch {
 }
 "@
 
-    if($RemoveDefaultSources) {
+    if ($RemoveDefaultSources) {
         $scriptContent += @"
 
 # Remove default sources
@@ -328,9 +338,10 @@ Write-Host "Removing default sources..."
     }
 
     $scriptPath = Join-Path $OutputPath "Deploy-WingetSource_$SourceName.ps1"
-    $scriptContent | Out-File -FilePath $scriptPath -Encoding UTF8
-
-    Write-ColorOutput "`nIntune deployment script generated: $scriptPath" -Level Success
+    if ($PSCmdlet.ShouldProcess($scriptPath, 'Write Intune deployment script')) {
+        $scriptContent | Out-File -FilePath $scriptPath -Encoding UTF8
+        Write-ColorOutput "`nIntune deployment script generated: $scriptPath" -Level Success
+    }
     Write-Host "`nTo deploy:" -ForegroundColor Cyan
     Write-Host "  1. Upload to Intune as Win32 app or PowerShell script" -ForegroundColor Gray
     Write-Host "  2. Deploy to device groups" -ForegroundColor Gray
@@ -345,23 +356,23 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 Write-Host "Current Configuration:" -ForegroundColor Cyan
 Get-CurrentSources
 
-if($ResetSources) {
+if ($ResetSources) {
     Reset-WingetSources
 }
-elseif($ExportConfig) {
+elseif ($ExportConfig) {
     Export-SourceConfig
 }
-elseif($ImportConfig) {
+elseif ($ImportConfig) {
     Import-SourceConfig -ConfigPath $ImportConfig
 }
 else {
-    if($RemoveDefaultSources) {
+    if ($RemoveDefaultSources) {
         Remove-DefaultSources
     }
 
     Add-CustomSource
 
-    if($GenerateIntuneScript) {
+    if ($GenerateIntuneScript) {
         New-IntuneDeploymentScript
     }
 }

--- a/scripts/endpoints/intune/maintenance/Add-LenovoFriendlyModelNames.ps1
+++ b/scripts/endpoints/intune/maintenance/Add-LenovoFriendlyModelNames.ps1
@@ -136,9 +136,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet(
-        "extensionAttribute1","extensionAttribute2","extensionAttribute3","extensionAttribute4","extensionAttribute5",
-        "extensionAttribute6","extensionAttribute7","extensionAttribute8","extensionAttribute9","extensionAttribute10",
-        "extensionAttribute11","extensionAttribute12","extensionAttribute13","extensionAttribute14","extensionAttribute15"
+        "extensionAttribute1", "extensionAttribute2", "extensionAttribute3", "extensionAttribute4", "extensionAttribute5",
+        "extensionAttribute6", "extensionAttribute7", "extensionAttribute8", "extensionAttribute9", "extensionAttribute10",
+        "extensionAttribute11", "extensionAttribute12", "extensionAttribute13", "extensionAttribute14", "extensionAttribute15"
     )]
     [string]$ExtensionAttributeName = "extensionAttribute1",
 
@@ -166,14 +166,14 @@ function Write-Log {
         [Parameter(Mandatory)]
         [string]$Message,
 
-        [ValidateSet("Info","Warn","Error","Verbose")]
+        [ValidateSet("Info", "Warn", "Error", "Verbose")]
         [string]$Level = "Info"
     )
 
     switch ($Level) {
-        "Info"    { Write-Host $Message -ForegroundColor Cyan }
-        "Warn"    { Write-Host $Message -ForegroundColor Yellow }
-        "Error"   { Write-Host $Message -ForegroundColor Red }
+        "Info" { Write-Host $Message -ForegroundColor Cyan }
+        "Warn" { Write-Host $Message -ForegroundColor Yellow }
+        "Error" { Write-Host $Message -ForegroundColor Red }
         "Verbose" { if ($VerboseOutput) { Write-Host $Message -ForegroundColor DarkGray } }
     }
 }
@@ -359,8 +359,8 @@ function Get-LenovoModelLookup {
     }
 
     [PSCustomObject]@{
-        Lookup    = $mtmToFamily
-        Missing   = $missingMtms.ToArray()
+        Lookup = $mtmToFamily
+        Missing = $missingMtms.ToArray()
         SourceUrl = $allModelsUrl
         TotalProcessed = $allModels.Count
     }
@@ -429,6 +429,7 @@ function Set-EntraDeviceExtensionAttribute {
         with method 2. This handles cases where the identifier is actually a deviceId
         rather than an object ID.
     #>
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
         [string]$AzureDeviceIdentifier,
@@ -450,8 +451,11 @@ function Set-EntraDeviceExtensionAttribute {
 
     # Attempt 1: Treat identifier as Entra device object ID
     try {
-        Invoke-MgGraphRequest -Method PATCH -Uri "/v1.0/devices/$AzureDeviceIdentifier" -Body $payloadJson -ErrorAction Stop | Out-Null
-        return "PatchedByObjectId"
+        if ($PSCmdlet.ShouldProcess($AzureDeviceIdentifier, "Set extension attribute $AttributeName")) {
+            Invoke-MgGraphRequest -Method PATCH -Uri "/v1.0/devices/$AzureDeviceIdentifier" -Body $payloadJson -ErrorAction Stop | Out-Null
+            return "PatchedByObjectId"
+        }
+        return
     }
     catch {
         # Only retry on NotFound - other errors are real failures (permissions, payload issues, etc.)
@@ -464,8 +468,11 @@ function Set-EntraDeviceExtensionAttribute {
 
     # Attempt 2: Treat identifier as Entra deviceId
     try {
-        Invoke-MgGraphRequest -Method PATCH -Uri "/v1.0/devices(deviceId='$AzureDeviceIdentifier')" -Body $payloadJson -ErrorAction Stop | Out-Null
-        return "PatchedByDeviceId"
+        if ($PSCmdlet.ShouldProcess($AzureDeviceIdentifier, "Set extension attribute $AttributeName")) {
+            Invoke-MgGraphRequest -Method PATCH -Uri "/v1.0/devices(deviceId='$AzureDeviceIdentifier')" -Body $payloadJson -ErrorAction Stop | Out-Null
+            return "PatchedByDeviceId"
+        }
+        return
     }
     catch {
         Write-Log "Failed to update device with identifier $AzureDeviceIdentifier using both addressing methods" "Error"
@@ -595,12 +602,12 @@ try {
 
     # Initialize counters and error tracking
     $stats = @{
-        NotesUpdated    = 0
-        NotesSkipped    = 0
-        ExtUpdated      = 0
-        ExtSkipped      = 0
-        Unknown         = 0
-        Errors          = 0
+        NotesUpdated = 0
+        NotesSkipped = 0
+        ExtUpdated = 0
+        ExtSkipped = 0
+        Unknown = 0
+        Errors = 0
     }
 
     $errorLog = New-Object System.Collections.Generic.List[object]
@@ -705,13 +712,13 @@ try {
             $stats.Errors++
 
             $errorDetails = [PSCustomObject]@{
-                DeviceName      = $device.deviceName
-                Model           = $device.model
-                MTM             = $mtm
-                IntuneId        = $device.id
+                DeviceName = $device.deviceName
+                Model = $device.model
+                MTM = $mtm
+                IntuneId = $device.id
                 AzureADDeviceId = $azureDeviceIdentifier
-                Error           = $_.Exception.Message
-                Timestamp       = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+                Error = $_.Exception.Message
+                Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
             }
 
             $errorLog.Add($errorDetails)

--- a/scripts/endpoints/intune/maintenance/Compare-ConfigurationDrift.ps1
+++ b/scripts/endpoints/intune/maintenance/Compare-ConfigurationDrift.ps1
@@ -183,7 +183,8 @@ try {
         Write-Host "  Configuration Policies: $($currentSnapshot.ConfigurationPolicies.Count)"
         Write-Host "  Applications: $($currentSnapshot.Applications.Count)"
 
-    } else {
+    }
+    else {
         # Compare against baseline
         if (-not $BaselinePath) {
             Write-Error "Please specify -BaselinePath or use -CreateBaseline to create a new baseline"
@@ -300,7 +301,8 @@ try {
         }
     }
 
-} catch {
+}
+catch {
     Write-Error "Error during configuration drift analysis: $_"
     exit 1
 }

--- a/scripts/endpoints/intune/maintenance/Export-IntuneConfiguration.ps1
+++ b/scripts/endpoints/intune/maintenance/Export-IntuneConfiguration.ps1
@@ -40,16 +40,16 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string[]]$ConfigTypes = @('All'),
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeAssignments,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CompressOutput
 )
 
@@ -57,7 +57,7 @@ param(
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
+    $color = switch ($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
     Write-Host $Message -ForegroundColor $color
 }
 
@@ -68,8 +68,8 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 Write-ColorOutput "Connecting to Microsoft Graph..." -Level Info
 try {
     $context = Get-MgContext
-    if(-not $context) {
-        Connect-MgGraph -Scopes "DeviceManagementConfiguration.Read.All","DeviceManagementApps.Read.All","DeviceManagementServiceConfig.Read.All"
+    if (-not $context) {
+        Connect-MgGraph -Scopes "DeviceManagementConfiguration.Read.All", "DeviceManagementApps.Read.All", "DeviceManagementServiceConfig.Read.All"
     }
     Write-ColorOutput "  Connected" -Level Success
 }
@@ -95,7 +95,7 @@ if (-not $OutputPath) {
     $OutputPath = Join-Path $ReportDir "IntuneBackup_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
 }
 
-if(-not (Test-Path $OutputPath)) {
+if (-not (Test-Path $OutputPath)) {
     New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
 }
 
@@ -105,14 +105,14 @@ $exportSummary = @{
     ItemsExported = 0
 }
 
-if('All' -in $ConfigTypes -or 'DeviceConfig' -in $ConfigTypes) {
+if ('All' -in $ConfigTypes -or 'DeviceConfig' -in $ConfigTypes) {
     Write-Host "`nExporting device configuration policies..." -ForegroundColor Cyan
     try {
         $policies = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations" -Method GET
         $policyPath = Join-Path $OutputPath "DeviceConfigurations"
         New-Item -ItemType Directory -Path $policyPath -Force | Out-Null
 
-        foreach($policy in $policies.value) {
+        foreach ($policy in $policies.value) {
             $safeName = ($policy.displayName -replace '[\\/:*?"<>|]', '_').Trim()
             if ([string]::IsNullOrWhiteSpace($safeName)) {
                 $safeName = "DeviceConfiguration"
@@ -128,14 +128,14 @@ if('All' -in $ConfigTypes -or 'DeviceConfig' -in $ConfigTypes) {
     }
 }
 
-if('All' -in $ConfigTypes -or 'Compliance' -in $ConfigTypes) {
+if ('All' -in $ConfigTypes -or 'Compliance' -in $ConfigTypes) {
     Write-Host "`nExporting compliance policies..." -ForegroundColor Cyan
     try {
         $policies = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies" -Method GET
         $policyPath = Join-Path $OutputPath "CompliancePolicies"
         New-Item -ItemType Directory -Path $policyPath -Force | Out-Null
 
-        foreach($policy in $policies.value) {
+        foreach ($policy in $policies.value) {
             $safeName = ($policy.displayName -replace '[\\/:*?"<>|]', '_').Trim()
             if ([string]::IsNullOrWhiteSpace($safeName)) {
                 $safeName = "CompliancePolicy"
@@ -160,7 +160,7 @@ Write-Host "`n========================================`n" -ForegroundColor Cyan
 
 $exportSummary | ConvertTo-Json | Out-File (Join-Path $OutputPath "export-summary.json") -Encoding UTF8
 
-if($CompressOutput) {
+if ($CompressOutput) {
     $zipPath = "$OutputPath.zip"
     Compress-Archive -Path $OutputPath -DestinationPath $zipPath -Force
     Write-ColorOutput "Created archive: $zipPath" -Level Success

--- a/scripts/endpoints/intune/maintenance/Find-PolicyConflicts.ps1
+++ b/scripts/endpoints/intune/maintenance/Find-PolicyConflicts.ps1
@@ -44,17 +44,17 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'HTML',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckSettingsCatalog,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckConfigurationProfiles = $true,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$CheckCompliancePolicies
 )
 
@@ -280,7 +280,7 @@ try {
     Write-Host "========================================" -ForegroundColor Cyan
 
     Write-Host "Total Policies Analyzed:  $($allPolicies.Count)" -ForegroundColor White
-    Write-Host "Potential Conflicts:      $($conflicts.Count)" -ForegroundColor $(if($conflicts.Count -gt 0){'Yellow'}else{'Green'})
+    Write-Host "Potential Conflicts:      $($conflicts.Count)" -ForegroundColor $(if ($conflicts.Count -gt 0) { 'Yellow' }else { 'Green' })
 
     if ($conflicts.Count -gt 0) {
         $high = ($conflicts | Where-Object { $_.Severity -eq "High" }).Count

--- a/scripts/endpoints/intune/maintenance/Find-StaleDevices.ps1
+++ b/scripts/endpoints/intune/maintenance/Find-StaleDevices.ps1
@@ -50,18 +50,18 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$DaysInactive,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('Report', 'Delete', 'Retire')]
     [string]$Action = 'Report',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'Both',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$AutoConfirm
 )
 
@@ -106,7 +106,7 @@ if (-not $DaysInactive) {
 }
 
 Write-Host "`nSearching for devices inactive for $DaysInactive+ days..." -ForegroundColor Cyan
-Write-Host "Action mode: $Action" -ForegroundColor $(if($Action -eq 'Report'){'Green'}else{'Yellow'})
+Write-Host "Action mode: $Action" -ForegroundColor $(if ($Action -eq 'Report') { 'Green' }else { 'Yellow' })
 
 # Connect to Microsoft Graph
 $scopes = @("DeviceManagementManagedDevices.Read.All")
@@ -181,7 +181,7 @@ try {
     Write-Host "========================================" -ForegroundColor Cyan
     Write-Host "Total Devices:           $($devices.Count)" -ForegroundColor White
     Write-Host "Inactive Threshold:      $DaysInactive days" -ForegroundColor Yellow
-    Write-Host "Stale Devices Found:     $($staleDevices.Count)" -ForegroundColor $(if($staleDevices.Count -gt 0){'Red'}else{'Green'})
+    Write-Host "Stale Devices Found:     $($staleDevices.Count)" -ForegroundColor $(if ($staleDevices.Count -gt 0) { 'Red' }else { 'Green' })
 
     if ($staleDevices.Count -eq 0) {
         Write-Host "`n✓ No stale devices found! Your tenant is clean." -ForegroundColor Green
@@ -290,7 +290,7 @@ try {
         Write-Host "========================================" -ForegroundColor Cyan
         Write-Host "Total Processed:  $($staleDevices.Count)" -ForegroundColor White
         Write-Host "Successful:       $successCount" -ForegroundColor Green
-        Write-Host "Failed:           $failCount" -ForegroundColor $(if($failCount -gt 0){'Red'}else{'Green'})
+        Write-Host "Failed:           $failCount" -ForegroundColor $(if ($failCount -gt 0) { 'Red' }else { 'Green' })
     }
 
     Write-Host "`n✓ Stale device processing completed!" -ForegroundColor Green

--- a/scripts/endpoints/intune/maintenance/Invoke-DeviceBulkActions.ps1
+++ b/scripts/endpoints/intune/maintenance/Invoke-DeviceBulkActions.ps1
@@ -50,22 +50,22 @@
     Requires permissions: DeviceManagementManagedDevices.ReadWrite.All
 #>
 
-[CmdletBinding(SupportsShouldProcess=$true)]
+[CmdletBinding(SupportsShouldProcess = $true)]
 param(
-    [Parameter(Mandatory=$true)]
-    [ValidateSet('Sync','Restart','Retire','Wipe','CollectDiagnostics')]
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Sync', 'Restart', 'Retire', 'Wipe', 'CollectDiagnostics')]
     [string]$Action,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string[]]$DeviceNames,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$DeviceFilter,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$GroupName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$NonCompliantOnly
 )
 
@@ -81,7 +81,7 @@ $script:results = @{
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
+    $color = switch ($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
     Write-Host $Message -ForegroundColor $color
 }
 
@@ -89,8 +89,8 @@ function Connect-ToGraph {
     Write-Host "Connecting to Microsoft Graph..." -ForegroundColor Cyan
     try {
         $context = Get-MgContext
-        if(-not $context) {
-            Connect-MgGraph -Scopes "DeviceManagementManagedDevices.ReadWrite.All","Group.Read.All"
+        if (-not $context) {
+            Connect-MgGraph -Scopes "DeviceManagementManagedDevices.ReadWrite.All", "Group.Read.All"
         }
         Write-ColorOutput "  Connected successfully" -Level Success
     }
@@ -106,30 +106,30 @@ function Get-TargetDevices {
     $devices = @()
     
     try {
-        if($DeviceNames) {
-            foreach($name in $DeviceNames) {
+        if ($DeviceNames) {
+            foreach ($name in $DeviceNames) {
                 $device = Get-MgDeviceManagementManagedDevice -Filter "deviceName eq '$name'" -All
-                if($device) { $devices += $device }
+                if ($device) { $devices += $device }
             }
         }
-        elseif($GroupName) {
+        elseif ($GroupName) {
             $group = Get-MgGroup -Filter "displayName eq '$GroupName'"
-            if($group) {
+            if ($group) {
                 $members = Get-MgGroupMember -GroupId $group.Id -All
-                foreach($member in $members) {
+                foreach ($member in $members) {
                     $device = Get-MgDeviceManagementManagedDevice -ManagedDeviceId $member.Id -ErrorAction SilentlyContinue
-                    if($device) { $devices += $device }
+                    if ($device) { $devices += $device }
                 }
             }
         }
-        elseif($DeviceFilter) {
+        elseif ($DeviceFilter) {
             $devices = Get-MgDeviceManagementManagedDevice -Filter $DeviceFilter -All
         }
         else {
             $devices = Get-MgDeviceManagementManagedDevice -All
         }
 
-        if($NonCompliantOnly) {
+        if ($NonCompliantOnly) {
             $devices = $devices | Where-Object { $_.ComplianceState -ne 'compliant' }
         }
 
@@ -144,14 +144,15 @@ function Get-TargetDevices {
 }
 
 function Invoke-DeviceAction {
+    [CmdletBinding(SupportsShouldProcess)]
     param($Device)
     
     $deviceName = $Device.DeviceName
     $deviceId = $Device.Id
 
-    if($PSCmdlet.ShouldProcess($deviceName, $Action)) {
+    if ($PSCmdlet.ShouldProcess($deviceName, $Action)) {
         try {
-            switch($Action) {
+            switch ($Action) {
                 'Sync' {
                     Invoke-MgSyncDeviceManagementManagedDevice -ManagedDeviceId $deviceId
                     Write-ColorOutput "  [OK] Synced: $deviceName" -Level Success
@@ -204,7 +205,7 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 Connect-ToGraph
 $devices = Get-TargetDevices
 
-if($devices.Count -eq 0) {
+if ($devices.Count -eq 0) {
     Write-ColorOutput "No devices found matching criteria" -Level Warning
     exit 0
 }
@@ -212,7 +213,7 @@ if($devices.Count -eq 0) {
 Write-Host "`nExecuting action: $Action" -ForegroundColor Cyan
 Write-Host "Targeted devices: $($devices.Count)`n" -ForegroundColor Gray
 
-foreach($device in $devices) {
+foreach ($device in $devices) {
     Invoke-DeviceAction -Device $device
 }
 
@@ -222,7 +223,7 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "Action: $Action"
 Write-Host "Targeted: $($script:results.TargetedDevices)"
 Write-ColorOutput "Successful: $($script:results.SuccessfulActions)" -Level Success
-if($script:results.FailedActions -gt 0) {
+if ($script:results.FailedActions -gt 0) {
     Write-ColorOutput "Failed: $($script:results.FailedActions)" -Level Error
 }
 Write-Host "`n========================================`n" -ForegroundColor Cyan

--- a/scripts/endpoints/intune/maintenance/Test-IntuneConnectivity.Tests.ps1
+++ b/scripts/endpoints/intune/maintenance/Test-IntuneConnectivity.Tests.ps1
@@ -1,3 +1,30 @@
+<#
+.SYNOPSIS
+    Pester tests for Test-IntuneConnectivity.ps1.
+
+.DESCRIPTION
+    Validates the behavior of the Intune connectivity script:
+    - Parameter validation (Detailed, ExportResults, no parameters)
+    - Endpoint connectivity tests (Intune enrollment, Azure AD, Windows Update, Microsoft Graph)
+    - Failure detection (connection failures, HTTP errors, DNS resolution, timeouts)
+    - Success reporting and summary statistics
+    - Detailed output mode
+    - CSV export functionality
+    - Performance within reasonable time
+    - Error handling (missing endpoints, continued testing after failures)
+
+.EXAMPLE
+    PS C:\> Invoke-Pester -Path .\Test-IntuneConnectivity.Tests.ps1
+    Runs all tests against the Test-IntuneConnectivity.ps1 script.
+
+.NOTES
+    File Name  : Test-IntuneConnectivity.Tests.ps1
+    Author     : IT Administration
+    Prerequisite: PowerShell 7.0, Pester 5
+    Version    : 1.0.0
+    Date       : 2025-01-01
+#>
+
 BeforeAll {
     # Import the script to test
     $scriptPath = "$PSScriptRoot/Test-IntuneConnectivity.ps1"

--- a/scripts/endpoints/intune/maintenance/Test-IntuneConnectivity.ps1
+++ b/scripts/endpoints/intune/maintenance/Test-IntuneConnectivity.ps1
@@ -92,7 +92,8 @@ foreach ($category in $intuneEndpoints.Keys) {
                 Write-Host "  ✅ $endpoint - Status: $statusCode" -ForegroundColor Green
             }
 
-        } catch {
+        }
+        catch {
             $status = "❌ Failed"
             $statusCode = if ($_.Exception.Response) { $_.Exception.Response.StatusCode.value__ } else { "N/A" }
             $errorMsg = $_.Exception.Message
@@ -131,7 +132,8 @@ try {
     $dnsTest = Resolve-DnsName -Name "login.microsoftonline.com" -ErrorAction Stop
     Write-Host "    ✅ DNS resolution working" -ForegroundColor Green
     $dnsWorking = $true
-} catch {
+}
+catch {
     Write-Host "    ❌ DNS resolution failed" -ForegroundColor Red
     $dnsWorking = $false
 }
@@ -142,7 +144,8 @@ $proxySettings = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\Curren
 if ($proxySettings.ProxyEnable -eq 1) {
     Write-Host "    ⚠️  Proxy enabled: $($proxySettings.ProxyServer)" -ForegroundColor Yellow
     $proxyConfigured = $true
-} else {
+}
+else {
     Write-Host "    ✅ No proxy configured" -ForegroundColor Green
     $proxyConfigured = $false
 }
@@ -154,11 +157,13 @@ try {
     if ($dsregStatus -match "AzureAdJoined\s*:\s*YES") {
         Write-Host "    ✅ Device is Azure AD joined" -ForegroundColor Green
         $azureAdJoined = $true
-    } else {
+    }
+    else {
         Write-Host "    ⚠️  Device is not Azure AD joined" -ForegroundColor Yellow
         $azureAdJoined = $false
     }
-} catch {
+}
+catch {
     Write-Host "    ❌ Could not determine Azure AD join status" -ForegroundColor Red
     $azureAdJoined = $false
 }

--- a/scripts/endpoints/intune/reporting/Get-AppInstallErrorReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AppInstallErrorReport.ps1
@@ -37,19 +37,19 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$AppName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Days = 7,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Top,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -80,7 +80,7 @@ $script:report = @{
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
+    $color = switch ($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
     Write-Host $Message -ForegroundColor $color
 }
 
@@ -88,7 +88,7 @@ Write-Host "`n========================================" -ForegroundColor Cyan
 Write-Host "  App Installation Error Report" -ForegroundColor Cyan
 Write-Host "========================================`n" -ForegroundColor Cyan
 
-Connect-MgGraph -Scopes "DeviceManagementApps.Read.All","DeviceManagementManagedDevices.Read.All" -NoWelcome
+Connect-MgGraph -Scopes "DeviceManagementApps.Read.All", "DeviceManagementManagedDevices.Read.All" -NoWelcome
 
 Write-Host "Querying app installation status..." -ForegroundColor Cyan
 $cutoffDate = (Get-Date).AddDays(-$Days)
@@ -96,13 +96,13 @@ $cutoffDate = (Get-Date).AddDays(-$Days)
 try {
     $apps = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps" -Method GET
     
-    foreach($app in $apps.value) {
-        if($AppName -and $app.displayName -notlike "*$AppName*") { continue }
+    foreach ($app in $apps.value) {
+        if ($AppName -and $app.displayName -notlike "*$AppName*") { continue }
         
         $status = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/deviceStatuses" -Method GET
         
-        foreach($deviceStatus in $status.value) {
-            if($deviceStatus.installState -eq 'failed' -and $deviceStatus.lastSyncDateTime -gt $cutoffDate) {
+        foreach ($deviceStatus in $status.value) {
+            if ($deviceStatus.installState -eq 'failed' -and $deviceStatus.lastSyncDateTime -gt $cutoffDate) {
                 $failure = [PSCustomObject]@{
                     AppName = $app.displayName
                     DeviceName = $deviceStatus.deviceName
@@ -134,13 +134,13 @@ Write-ColorOutput "Total Failures: $($script:report.Summary.TotalFailures)" -Lev
 Write-Host "Unique Apps: $($script:report.Summary.UniqueApps)"
 Write-Host "Unique Devices: $($script:report.Summary.UniqueDevices)"
 
-if($script:report.Failures.Count -gt 0) {
+if ($script:report.Failures.Count -gt 0) {
     Write-Host "`nTop Failures:" -ForegroundColor Cyan
-    $displayCount = if($Top) { $Top } else { 20 }
+    $displayCount = if ($Top) { $Top } else { 20 }
     $script:report.Failures | Select-Object -First $displayCount | Format-Table AppName, DeviceName, ErrorCode, LastSync -AutoSize
 }
 
-if($ExportHTML) {
+if ($ExportHTML) {
     $html = @"
 <!DOCTYPE html><html><head><title>App Installation Failures</title>
 <style>body{font-family:'Segoe UI',sans-serif;margin:20px}table{width:100%;border-collapse:collapse}
@@ -155,7 +155,7 @@ $(foreach($f in $script:report.Failures){"<tr><td>$($f.AppName)</td><td>$($f.Dev
     Write-ColorOutput "`nHTML report: $reportPath" -Level Success
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     $csvPath = "$ReportDir\AppInstallErrors_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
     $script:report.Failures | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report: $csvPath" -Level Success

--- a/scripts/endpoints/intune/reporting/Get-AppInstallationStatus.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AppInstallationStatus.ps1
@@ -50,20 +50,20 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$AppName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$AppId,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'Both',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowSuccessOnly,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowFailuresOnly
 )
 

--- a/scripts/endpoints/intune/reporting/Get-AutopilotDeploymentReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-AutopilotDeploymentReport.ps1
@@ -41,20 +41,20 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Days = 30,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet('All','Compliant','NonCompliant','Unknown')]
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('All', 'Compliant', 'NonCompliant', 'Unknown')]
     [string]$Status = 'All',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ProfileName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV
 )
 
@@ -86,7 +86,7 @@ $script:report = @{
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
+    $color = switch ($Level) { 'Success' { 'Green' } 'Warning' { 'Yellow' } 'Error' { 'Red' } default { 'Cyan' } }
     Write-Host $Message -ForegroundColor $color
 }
 
@@ -97,8 +97,8 @@ Write-Host "========================================`n" -ForegroundColor Cyan
 Write-ColorOutput "Connecting to Microsoft Graph..." -Level Info
 try {
     $context = Get-MgContext
-    if(-not $context) {
-        Connect-MgGraph -Scopes "DeviceManagementManagedDevices.Read.All","DeviceManagementServiceConfig.Read.All"
+    if (-not $context) {
+        Connect-MgGraph -Scopes "DeviceManagementManagedDevices.Read.All", "DeviceManagementServiceConfig.Read.All"
     }
     Write-ColorOutput "  Connected successfully" -Level Success
 }
@@ -113,17 +113,17 @@ $cutoffDate = (Get-Date).AddDays(-$Days)
 try {
     $devices = Get-MgDeviceManagementManagedDevice -Filter "deviceEnrollmentType eq 'windowsAutoEnrollment' or deviceEnrollmentType eq 'windowsAutopilotEnrollment' or deviceEnrollmentType eq 'windowsBulkAzureDomainJoin'" -All
     
-    foreach($device in $devices) {
-        if($device.EnrolledDateTime -lt $cutoffDate) { continue }
+    foreach ($device in $devices) {
+        if ($device.EnrolledDateTime -lt $cutoffDate) { continue }
         
         # Report the actual device compliance state - do NOT present it as deployment success/failure
         $complianceStatus = switch ($device.ComplianceState) {
             'compliant' { 'Compliant' }
-            'unknown'   { 'Unknown' }
-            default     { 'NonCompliant' }
+            'unknown' { 'Unknown' }
+            default { 'NonCompliant' }
         }
         
-        if($Status -ne 'All' -and $complianceStatus -ne $Status) { continue }
+        if ($Status -ne 'All' -and $complianceStatus -ne $Status) { continue }
         
         $deployment = [PSCustomObject]@{
             DeviceName = $device.DeviceName
@@ -155,12 +155,12 @@ Write-ColorOutput "Compliant: $($script:report.Summary.Compliant)" -Level Succes
 Write-ColorOutput "NonCompliant: $($script:report.Summary.NonCompliant)" -Level Error
 Write-ColorOutput "Unknown: $($script:report.Summary.Unknown)" -Level Warning
 
-if($script:report.Deployments.Count -gt 0) {
+if ($script:report.Deployments.Count -gt 0) {
     Write-Host "`nRecent Deployments:" -ForegroundColor Cyan
     $script:report.Deployments | Select-Object -First 20 | Format-Table DeviceName, EnrollmentDate, Compliance, UserPrincipalName -AutoSize
 }
 
-if($ExportHTML) {
+if ($ExportHTML) {
     $reportPath = "$ReportDir\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').html"
     $html = @"
 <!DOCTYPE html>
@@ -179,7 +179,7 @@ $(foreach($d in $script:report.Deployments){$c=$d.Compliance.ToLower();"<tr><td>
     Write-ColorOutput "`nHTML report: $reportPath" -Level Success
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     $csvPath = "$ReportDir\AutopilotReport_$(Get-Date -Format 'yyyyMMdd_HHmmss').csv"
     $script:report.Deployments | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
     Write-ColorOutput "CSV report: $csvPath" -Level Success

--- a/scripts/endpoints/intune/reporting/Get-BitLockerStatus.ps1
+++ b/scripts/endpoints/intune/reporting/Get-BitLockerStatus.ps1
@@ -49,17 +49,17 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'Both',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowUnencryptedOnly,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowMissingKeys,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeNonWindows
 )
 
@@ -238,7 +238,7 @@ try {
     Write-Host "Unknown Status:          $unknown" -ForegroundColor Yellow
     Write-Host ""
     Write-Host "Recovery Keys Backed Up: $keysBackedUp" -ForegroundColor Green
-    Write-Host "No Key Backup:           $noBackup" -ForegroundColor $(if($noBackup -gt 0){'Red'}else{'Green'})
+    Write-Host "No Key Backup:           $noBackup" -ForegroundColor $(if ($noBackup -gt 0) { 'Red' }else { 'Green' })
 
     if ($report.Count -eq 0) {
         Write-Host "`nNo devices match the current filter criteria." -ForegroundColor Yellow
@@ -250,7 +250,7 @@ try {
     Write-Host "`nBreakdown by Encryption Status:" -ForegroundColor Cyan
     $grouped = $report | Group-Object -Property EncryptionStatus
     foreach ($group in $grouped | Sort-Object Count -Descending) {
-        $color = switch($group.Name) {
+        $color = switch ($group.Name) {
             "Encrypted" { "Green" }
             "Not Encrypted" { "Red" }
             default { "Yellow" }

--- a/scripts/endpoints/intune/reporting/Get-DeviceComplianceReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-DeviceComplianceReport.ps1
@@ -37,14 +37,14 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'HTML',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeCompliant,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$OutputPath
 )
 

--- a/scripts/endpoints/intune/reporting/Get-DeviceGroupMembership.ps1
+++ b/scripts/endpoints/intune/reporting/Get-DeviceGroupMembership.ps1
@@ -50,20 +50,20 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$DeviceName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$GroupName,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowDynamicGroupsOnly,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'Both',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowAllMappings
 )
 

--- a/scripts/endpoints/intune/reporting/Get-DeviceHealthScore.ps1
+++ b/scripts/endpoints/intune/reporting/Get-DeviceHealthScore.ps1
@@ -79,14 +79,16 @@ function Calculate-DeviceHealthScore {
     # Compliance Status (25 points)
     if ($device.complianceState -eq "compliant") {
         $score += 25
-    } else {
+    }
+    else {
         $issues += "Non-compliant ($($device.complianceState))"
     }
 
     # BitLocker Encryption (20 points)
     if ($device.isEncrypted -eq $true) {
         $score += 20
-    } else {
+    }
+    else {
         $issues += "Not encrypted"
     }
 
@@ -104,10 +106,12 @@ function Calculate-DeviceHealthScore {
 
         if ($daysSinceSync -le 7) {
             $score += 15
-        } elseif ($daysSinceSync -le 14) {
+        }
+        elseif ($daysSinceSync -le 14) {
             $score += 10
             $issues += "Check-in over 7 days ago"
-        } else {
+        }
+        else {
             $issues += "Check-in over 14 days ago"
         }
     }
@@ -129,7 +133,8 @@ function Calculate-DeviceHealthScore {
     # Management State (5 points)
     if ($device.managementState -eq "managed") {
         $score += 5
-    } else {
+    }
+    else {
         $issues += "Not managed properly"
     }
 
@@ -139,10 +144,10 @@ function Calculate-DeviceHealthScore {
         Percentage = [math]::Round(($score / $maxScore) * 100, 1)
         Issues = $issues -join ", "
         HealthRating = if ($score -ge 90) { "Excellent" }
-                      elseif ($score -ge 75) { "Good" }
-                      elseif ($score -ge 60) { "Fair" }
-                      elseif ($score -ge 40) { "Poor" }
-                      else { "Critical" }
+        elseif ($score -ge 75) { "Good" }
+        elseif ($score -ge 60) { "Fair" }
+        elseif ($score -ge 40) { "Poor" }
+        else { "Critical" }
     }
 }
 
@@ -173,7 +178,8 @@ try {
                 LastSyncDate = $device.lastSyncDateTime
                 DaysSinceSync = if ($device.lastSyncDateTime) {
                     [math]::Round(((Get-Date) - [DateTime]::Parse($device.lastSyncDateTime)).TotalDays, 1)
-                } else { "Never" }
+                }
+                else { "Never" }
                 SerialNumber = $device.serialNumber
                 Model = $device.model
                 Issues = $health.Issues
@@ -198,7 +204,8 @@ try {
 
     if ($Format -eq "CSV") {
         $healthReport | Export-Csv -Path $reportPath -NoTypeInformation
-    } else {
+    }
+    else {
         $htmlReport = ConvertTo-IntuneHtmlReport -Data $healthReport -Title "Device Health Score Report" -Description "Generated on $(Get-Date) | Minimum Score: $MinHealthScore"
         $htmlReport | Out-File -FilePath $reportPath -Encoding UTF8
     }
@@ -206,7 +213,8 @@ try {
     Write-Host "`n✅ Report generated successfully:" -ForegroundColor Green
     Write-Host "   $reportPath" -ForegroundColor Cyan
 
-} catch {
+}
+catch {
     Write-Error "Error generating device health score report: $_"
     exit 1
 }

--- a/scripts/endpoints/intune/reporting/Get-IntuneDevicePrimaryUsers.ps1
+++ b/scripts/endpoints/intune/reporting/Get-IntuneDevicePrimaryUsers.ps1
@@ -66,9 +66,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet(
-        "extensionAttribute1","extensionAttribute2","extensionAttribute3","extensionAttribute4","extensionAttribute5",
-        "extensionAttribute6","extensionAttribute7","extensionAttribute8","extensionAttribute9","extensionAttribute10",
-        "extensionAttribute11","extensionAttribute12","extensionAttribute13","extensionAttribute14","extensionAttribute15"
+        "extensionAttribute1", "extensionAttribute2", "extensionAttribute3", "extensionAttribute4", "extensionAttribute5",
+        "extensionAttribute6", "extensionAttribute7", "extensionAttribute8", "extensionAttribute9", "extensionAttribute10",
+        "extensionAttribute11", "extensionAttribute12", "extensionAttribute13", "extensionAttribute14", "extensionAttribute15"
     )]
     [string]$FriendlyModelAttribute = "extensionAttribute1",
 
@@ -91,18 +91,18 @@ function Write-Log {
     #>
     param(
         [Parameter(Mandatory)][string]$Message,
-        [ValidateSet("INFO","WARN","ERROR","SUCCESS","DEBUG")]
+        [ValidateSet("INFO", "WARN", "ERROR", "SUCCESS", "DEBUG")]
         [string]$Level = "INFO"
     )
 
-    if ($Quiet -and $Level -in @("INFO","DEBUG")) { return }
+    if ($Quiet -and $Level -in @("INFO", "DEBUG")) { return }
 
     switch ($Level) {
-        "INFO"    { Write-Host $Message -ForegroundColor Cyan }
-        "WARN"    { Write-Warning $Message }
-        "ERROR"   { Write-Host $Message -ForegroundColor Red }
+        "INFO" { Write-Host $Message -ForegroundColor Cyan }
+        "WARN" { Write-Warning $Message }
+        "ERROR" { Write-Host $Message -ForegroundColor Red }
         "SUCCESS" { Write-Host $Message -ForegroundColor Green }
-        "DEBUG"   { Write-Host $Message -ForegroundColor DarkGray }
+        "DEBUG" { Write-Host $Message -ForegroundColor DarkGray }
     }
 }
 
@@ -183,7 +183,7 @@ function Resolve-InputTokens {
                 $props = $first.PSObject.Properties.Name
 
                 # Try to find a likely device name column
-                $col = @("DeviceName","deviceName","Name","ComputerName","Computer","Hostname","Host") |
+                $col = @("DeviceName", "deviceName", "Name", "ComputerName", "Computer", "Hostname", "Host") |
                     Where-Object { $props -contains $_ } |
                     Select-Object -First 1
 
@@ -315,11 +315,11 @@ function Get-ManagedDeviceDetails {
     param([Parameter(Mandatory)][string]$ManagedDeviceId)
 
     $select = @(
-        "id","deviceName","azureAdDeviceId","userPrincipalName","lastSyncDateTime",
-        "manufacturer","model","serialNumber",
-        "operatingSystem","osVersion",
-        "totalStorageSpaceInBytes","freeStorageSpaceInBytes","physicalMemoryInBytes",
-        "processorArchitecture","hardwareInformation"
+        "id", "deviceName", "azureAdDeviceId", "userPrincipalName", "lastSyncDateTime",
+        "manufacturer", "model", "serialNumber",
+        "operatingSystem", "osVersion",
+        "totalStorageSpaceInBytes", "freeStorageSpaceInBytes", "physicalMemoryInBytes",
+        "processorArchitecture", "hardwareInformation"
     ) -join ","
 
     $uri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/{0}?`$select={1}" -f $ManagedDeviceId, $select
@@ -346,7 +346,7 @@ function Get-RegisteredOwnerUser {
 
     $safeName = Escape-ODataString -Value $DeviceName
 
-    $aadMatches = Get-MgDevice -Filter "displayName eq '$safeName'" -Property Id,DisplayName -ErrorAction SilentlyContinue
+    $aadMatches = Get-MgDevice -Filter "displayName eq '$safeName'" -Property Id, DisplayName -ErrorAction SilentlyContinue
     foreach ($dev in ($aadMatches | ForEach-Object { $_ })) {
 
         $owners = Get-MgDeviceRegisteredOwner -DeviceId $dev.Id -All -ErrorAction SilentlyContinue
@@ -549,54 +549,54 @@ try {
 
             # Add result to collection
             $results.Add([pscustomobject]@{
-                DeviceName             = $deviceName
-                LastSeen               = $lastSeen
+                    DeviceName = $deviceName
+                    LastSeen = $lastSeen
 
-                PrimaryUserDisplayName = $primaryUserDisplayName
-                PrimaryUserUPN         = $primaryUserUPN
-                Source                 = $source
+                    PrimaryUserDisplayName = $primaryUserDisplayName
+                    PrimaryUserUPN = $primaryUserUPN
+                    Source = $source
 
-                FriendlyModel          = $friendlyModel
-                Manufacturer           = $manufacturer
-                Model                  = $model
-                SerialNumber           = $serialNumber
-                OperatingSystem        = $os
-                OSVersion              = $osVersion
+                    FriendlyModel = $friendlyModel
+                    Manufacturer = $manufacturer
+                    Model = $model
+                    SerialNumber = $serialNumber
+                    OperatingSystem = $os
+                    OSVersion = $osVersion
 
-                CPU                    = $cpuFriendly
-                CPUArchitecture        = $cpuArch
+                    CPU = $cpuFriendly
+                    CPUArchitecture = $cpuArch
 
-                RAM_GB                 = $ramGB
-                StorageTotal_GB        = $storageTotalGB
-                StorageFree_GB         = $storageFreeGB
-                StorageFree_Percent    = $storageFreePct
-            })
+                    RAM_GB = $ramGB
+                    StorageTotal_GB = $storageTotalGB
+                    StorageFree_GB = $storageFreeGB
+                    StorageFree_Percent = $storageFreePct
+                })
         }
         catch {
             # Add error result
             $results.Add([pscustomobject]@{
-                DeviceName             = $token
-                LastSeen               = $null
+                    DeviceName = $token
+                    LastSeen = $null
 
-                PrimaryUserDisplayName = $null
-                PrimaryUserUPN         = $null
-                Source                 = "Error: $($_.Exception.Message)"
+                    PrimaryUserDisplayName = $null
+                    PrimaryUserUPN = $null
+                    Source = "Error: $($_.Exception.Message)"
 
-                FriendlyModel          = $null
-                Manufacturer           = $null
-                Model                  = $null
-                SerialNumber           = $null
-                OperatingSystem        = $null
-                OSVersion              = $null
+                    FriendlyModel = $null
+                    Manufacturer = $null
+                    Model = $null
+                    SerialNumber = $null
+                    OperatingSystem = $null
+                    OSVersion = $null
 
-                CPU                    = $null
-                CPUArchitecture        = $null
+                    CPU = $null
+                    CPUArchitecture = $null
 
-                RAM_GB                 = $null
-                StorageTotal_GB        = $null
-                StorageFree_GB         = $null
-                StorageFree_Percent    = $null
-            })
+                    RAM_GB = $null
+                    StorageTotal_GB = $null
+                    StorageFree_GB = $null
+                    StorageFree_Percent = $null
+                })
         }
     }
 

--- a/scripts/endpoints/intune/reporting/Get-PolicyAssignmentReport.ps1
+++ b/scripts/endpoints/intune/reporting/Get-PolicyAssignmentReport.ps1
@@ -77,10 +77,10 @@ try {
 
         foreach ($assignment in $assignments.value) {
             $targetType = if ($assignment.target.'@odata.type' -match "allLicensedUsersAssignmentTarget") { "All Users" }
-                         elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
-                         elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
-                         elseif ($assignment.target.'@odata.type' -match "exclusionGroupAssignmentTarget") { "Excluded Group: $($assignment.target.groupId)" }
-                         else { "Unknown" }
+            elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
+            elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
+            elseif ($assignment.target.'@odata.type' -match "exclusionGroupAssignmentTarget") { "Excluded Group: $($assignment.target.groupId)" }
+            else { "Unknown" }
 
             $assignmentReport += [PSCustomObject]@{
                 PolicyName = $policy.displayName
@@ -100,9 +100,9 @@ try {
 
         foreach ($assignment in $assignments.value) {
             $targetType = if ($assignment.target.'@odata.type' -match "allLicensedUsersAssignmentTarget") { "All Users" }
-                         elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
-                         elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
-                         else { "Unknown" }
+            elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
+            elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
+            else { "Unknown" }
 
             $assignmentReport += [PSCustomObject]@{
                 PolicyName = $policy.displayName
@@ -122,9 +122,9 @@ try {
 
         foreach ($assignment in $assignments.value) {
             $targetType = if ($assignment.target.'@odata.type' -match "allLicensedUsersAssignmentTarget") { "All Users" }
-                         elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
-                         elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
-                         else { "Unknown" }
+            elseif ($assignment.target.'@odata.type' -match "allDevicesAssignmentTarget") { "All Devices" }
+            elseif ($assignment.target.'@odata.type' -match "groupAssignmentTarget") { "Group: $($assignment.target.groupId)" }
+            else { "Unknown" }
 
             $assignmentReport += [PSCustomObject]@{
                 PolicyName = $policy.name
@@ -156,7 +156,8 @@ try {
 
     if ($Format -eq "CSV") {
         $assignmentReport | Export-Csv -Path $reportPath -NoTypeInformation
-    } else {
+    }
+    else {
         # Generate HTML report
         $htmlReport = ConvertTo-IntuneHtmlReport -Data $assignmentReport -Title "Intune Policy Assignment Report" -Description "Generated on $(Get-Date)"
         $htmlReport | Out-File -FilePath $reportPath -Encoding UTF8
@@ -171,7 +172,8 @@ try {
     Write-Host "  Compliance Policies: $(($assignmentReport | Where-Object { $_.PolicyType -eq 'Compliance Policy' }).Count)"
     Write-Host "  Settings Catalog: $(($assignmentReport | Where-Object { $_.PolicyType -eq 'Settings Catalog' }).Count)"
 
-} catch {
+}
+catch {
     Write-Error "Error generating policy assignment report: $_"
     exit 1
 }

--- a/scripts/endpoints/intune/reporting/Get-UserDeviceAffinity.ps1
+++ b/scripts/endpoints/intune/reporting/Get-UserDeviceAffinity.ps1
@@ -155,7 +155,8 @@ try {
     $usersWithMultipleDevices = ($affinityReport | Where-Object { $_.DeviceCount -gt 1 }).Count
     $avgDevicesPerUser = if ($usersWithDevices -gt 0) {
         [math]::Round(($affinityReport | Where-Object { $_.DeviceCount -gt 0 } | Measure-Object -Property DeviceCount -Average).Average, 2)
-    } else { 0 }
+    }
+    else { 0 }
 
     Write-Host "`nUser-Device Affinity Summary:" -ForegroundColor Yellow
     Write-Host "  Total Users: $totalUsers"
@@ -175,7 +176,8 @@ try {
         # Flatten device details for CSV
         $csvReport = $affinityReport | Select-Object DisplayName, UserPrincipalName, AccountEnabled, Department, JobTitle, DeviceCount, DeviceList
         $csvReport | Export-Csv -Path $reportPath -NoTypeInformation
-    } else {
+    }
+    else {
         # Create enhanced HTML report with device details
         $htmlContent = @"
 <!DOCTYPE html>
@@ -257,7 +259,8 @@ try {
     Write-Host "`n✅ Report generated successfully:" -ForegroundColor Green
     Write-Host "   $reportPath" -ForegroundColor Cyan
 
-} catch {
+}
+catch {
     Write-Error "Error generating user-device affinity report: $_"
     exit 1
 }

--- a/scripts/endpoints/intune/reporting/Get-WindowsUpdateCompliance.ps1
+++ b/scripts/endpoints/intune/reporting/Get-WindowsUpdateCompliance.ps1
@@ -48,17 +48,17 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet('HTML', 'CSV', 'Both')]
     [string]$ExportFormat = 'Both',
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ShowNonCompliantOnly,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeAutoPatchInfo,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$DaysOutdated = 30
 )
 
@@ -239,7 +239,7 @@ try {
     Write-Host "Protected:               $protected ($(if($totalDevices -gt 0){'{0:P0}' -f ($protected/$totalDevices)}else{'N/A'}))" -ForegroundColor Green
     Write-Host "Not Protected:           $notProtected ($(if($totalDevices -gt 0){'{0:P0}' -f ($notProtected/$totalDevices)}else{'N/A'}))" -ForegroundColor Red
     Write-Host "Unknown Status:          $unknown" -ForegroundColor Yellow
-    Write-Host "No AV Report (${DaysOutdated}+ days):  $stale" -ForegroundColor $(if($stale -gt 0){'Yellow'}else{'Green'})
+    Write-Host "No AV Report (${DaysOutdated}+ days):  $stale" -ForegroundColor $(if ($stale -gt 0) { 'Yellow' }else { 'Green' })
 
     if ($IncludeAutoPatchInfo) {
         Write-Host "`nAutoPatch Ring Distribution:" -ForegroundColor Cyan

--- a/scripts/endpoints/intune/reporting/Get-WingetUpdateCompliance.ps1
+++ b/scripts/endpoints/intune/reporting/Get-WingetUpdateCompliance.ps1
@@ -53,22 +53,22 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$TenantId,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string]$ApplicationFilter,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$IncludeUpToDate,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportHTML,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch]$ExportCSV,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [int]$Top
 )
 
@@ -98,7 +98,7 @@ $script:report = @{
 
 function Write-ColorOutput {
     param([string]$Message, [string]$Level = 'Info')
-    $color = switch($Level) {
+    $color = switch ($Level) {
         'Success' { 'Green' }
         'Warning' { 'Yellow' }
         'Error' { 'Red' }
@@ -112,18 +112,19 @@ function Connect-GraphAPI {
 
     try {
         $context = Get-MgContext
-        if(-not $context) {
+        if (-not $context) {
             $params = @{
                 Scopes = @(
                     "DeviceManagementManagedDevices.Read.All",
                     "DeviceManagementConfiguration.Read.All"
                 )
             }
-            if($TenantId) { $params.TenantId = $TenantId }
+            if ($TenantId) { $params.TenantId = $TenantId }
 
             Connect-MgGraph @params
             Write-ColorOutput "  Connected successfully" -Level Success
-        } else {
+        }
+        else {
             Write-ColorOutput "  Already connected to tenant: $($context.TenantId)" -Level Success
         }
     }
@@ -143,7 +144,7 @@ function Get-DeviceWingetData {
             All = $true
         }
 
-        if($Top) {
+        if ($Top) {
             $params.Remove('All')
             $params.Top = $Top
         }
@@ -180,35 +181,36 @@ function Get-SampleComplianceData {
     Write-Host "  (In production, this would query actual device inventory)" -ForegroundColor Gray
 
     $sampleApps = @(
-        @{App="Google Chrome"; Current="120.0.6099"; Available="121.0.6167"; Status="Outdated"}
-        @{App="Microsoft Teams"; Current="1.6.00.36361"; Available="1.7.00.1234"; Status="Outdated"}
-        @{App="7-Zip"; Current="23.01"; Available="24.01"; Status="Outdated"}
-        @{App="Visual Studio Code"; Current="1.85.0"; Available="1.85.0"; Status="UpToDate"}
-        @{App="Adobe Reader"; Current="23.008.20421"; Available="24.001.20604"; Status="Outdated"}
+        @{App = "Google Chrome"; Current = "120.0.6099"; Available = "121.0.6167"; Status = "Outdated" }
+        @{App = "Microsoft Teams"; Current = "1.6.00.36361"; Available = "1.7.00.1234"; Status = "Outdated" }
+        @{App = "7-Zip"; Current = "23.01"; Available = "24.01"; Status = "Outdated" }
+        @{App = "Visual Studio Code"; Current = "1.85.0"; Available = "1.85.0"; Status = "UpToDate" }
+        @{App = "Adobe Reader"; Current = "23.008.20421"; Available = "24.001.20604"; Status = "Outdated" }
     )
 
-    foreach($app in $sampleApps) {
+    foreach ($app in $sampleApps) {
         $appData = [PSCustomObject]@{
             ApplicationName = $app.App
             InstalledVersion = $app.Current
             AvailableVersion = $app.Available
             Status = $app.Status
             DeviceCount = Get-Random -Minimum 50 -Maximum 500
-            OutdatedCount = if($app.Status -eq "Outdated") { Get-Random -Minimum 20 -Maximum 200 } else { 0 }
+            OutdatedCount = if ($app.Status -eq "Outdated") { Get-Random -Minimum 20 -Maximum 200 } else { 0 }
         }
 
-        if($ApplicationFilter) {
-            if($appData.ApplicationName -like $ApplicationFilter) {
+        if ($ApplicationFilter) {
+            if ($appData.ApplicationName -like $ApplicationFilter) {
                 $script:report.Applications += $appData
             }
         }
-        elseif($app.Status -eq "Outdated" -or $IncludeUpToDate) {
+        elseif ($app.Status -eq "Outdated" -or $IncludeUpToDate) {
             $script:report.Applications += $appData
         }
 
-        if($app.Status -eq "Outdated") {
+        if ($app.Status -eq "Outdated") {
             $script:report.OutdatedApps++
-        } else {
+        }
+        else {
             $script:report.UpToDateApps++
         }
     }
@@ -227,7 +229,7 @@ function Show-Summary {
     Write-ColorOutput "Outdated Applications: $($script:report.OutdatedApps)" -Level Warning
     Write-ColorOutput "Up-to-Date Applications: $($script:report.UpToDateApps)" -Level Success
 
-    if($script:report.Applications.Count -gt 0) {
+    if ($script:report.Applications.Count -gt 0) {
         Write-Host "`nApplication Update Status:" -ForegroundColor Cyan
         $script:report.Applications | Format-Table ApplicationName, InstalledVersion, AvailableVersion, Status, DeviceCount, OutdatedCount -AutoSize
     }
@@ -345,12 +347,12 @@ Get-SampleComplianceData
 
 Show-Summary
 
-if($ExportHTML) {
+if ($ExportHTML) {
     Write-Host "Generating HTML report..." -ForegroundColor Cyan
     Export-HTMLReport
 }
 
-if($ExportCSV) {
+if ($ExportCSV) {
     Write-Host "Generating CSV report..." -ForegroundColor Cyan
     Export-CSVReport
 }


### PR DESCRIPTION
Closes #116 #118 #128

PSSA enforcement campaign for #116 (comment-based help), #118 (ShouldProcess), #128 (style rules).
Fixes: formatter-normalized style, manual casing fixes, comment-based help headers, SupportsShouldProcess retrofits with `$PSCmdlet.ShouldProcess()` guards (no -ConfirmImpact; normal runs stay silent, -WhatIf/-Confirm become available).

## Summary by Sourcery

Align Intune endpoint scripts with PSSA style and safety conventions while adding coverage for Intune connectivity testing.

Enhancements:
- Normalize parameter, switch, and hashtable formatting across Intune deployment, maintenance, and reporting scripts to comply with PSSA style rules.
- Add SupportsShouldProcess semantics and guarded operations to Intune maintenance and deployment functions that perform changes against devices, Graph, or local files.
- Improve script logging and output consistency for Intune utilities by standardizing Write-ColorOutput/Write-Log usage and summaries.
- Update IntuneGraphHelper and various reporting/maintenance scripts with minor structural and formatting tweaks for more consistent module behavior.

Tests:
- Introduce Pester test suite for Test-IntuneConnectivity.ps1, covering parameter validation, endpoint connectivity checks, failure handling, and report generation behavior.