### PR TITLE
ci: enforce comment-based help, style and ShouldProcess rules

### DIFF
--- a/.github/workflows/validate-powershell.yml
+++ b/.github/workflows/validate-powershell.yml
@@ -101,6 +101,48 @@ jobs:
             Write-Host "No issues found by PSScriptAnalyzer!" -ForegroundColor Green
           }
 
+      - name: Enforce policy rules (comment-based help, style, ShouldProcess)
+        shell: pwsh
+        run: |
+          $settings = @{
+            Severity = @('Error', 'Warning', 'Information')
+            Rules = @{
+              PSUseConsistentIndentation = @{ Enable = $true }
+              PSUseConsistentWhitespace  = @{ Enable = $true }
+              PSPlaceOpenBrace           = @{ Enable = $true }
+              PSPlaceCloseBrace          = @{ Enable = $true }
+              PSUseCorrectCasing         = @{ Enable = $true }
+            }
+            IncludeRules = @(
+              'PSUseConsistentIndentation', 'PSUseConsistentWhitespace',
+              'PSPlaceOpenBrace', 'PSPlaceCloseBrace', 'PSUseCorrectCasing',
+              'PSShouldProcess', 'PSUseShouldProcessForStateChangingFunctions',
+              'PSUseSupportsShouldProcess'
+            )
+          }
+          $policyFindings = Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Settings $settings
+          if ($policyFindings) {
+            $policyFindings | Format-Table RuleName, ScriptName, Line, Message -AutoSize
+            Write-Host "Policy enforcement found $($policyFindings.Count) finding(s). Failing the pipeline." -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "Policy enforcement passed (help/style/ShouldProcess)." -ForegroundColor Green
+
+      - name: Enforce comment-based help (SYNOPSIS presence)
+        shell: pwsh
+        run: |
+          $missing = @()
+          Get-ChildItem -Path ./scripts -Filter *.ps1 -Recurse | ForEach-Object {
+            $content = Get-Content -LiteralPath $_.FullName -Raw
+            if ($content -and $content -notmatch '\.SYNOPSIS') { $missing += $_.FullName }
+          }
+          if ($missing.Count -gt 0) {
+            $missing | ForEach-Object { Write-Host "MISSING .SYNOPSIS: $_" -ForegroundColor Red }
+            Write-Host "$($missing.Count) script(s) missing comment-based help. Failing the pipeline." -ForegroundColor Red
+            exit 1
+          }
+          Write-Host "Comment-based help present in all scripts." -ForegroundColor Green
+
       - name: Upload Analysis Results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.vscode/PSScriptAnalyzerSettings.psd1
+++ b/.vscode/PSScriptAnalyzerSettings.psd1
@@ -9,15 +9,6 @@
     ExcludeRules = @(
         # Output and formatting
         'PSAvoidUsingWriteHost',              # Scripts need Write-Host for user output
-        'PSProvideCommentHelp',               # Not all scripts need full help blocks
-
-        # Style and formatting (too strict for existing codebase)
-        'PSUseConsistentIndentation',
-        'PSUseConsistentWhitespace',
-        'PSPlaceOpenBrace',
-        'PSPlaceCloseBrace',
-        'PSUseCorrectCasing',
-
         # Compatibility checks (may be too strict)
         'PSUseCompatibleCmdlets',
         'PSUseCompatibleSyntax',
@@ -29,11 +20,6 @@
         'PSUseBOMForUnicodeEncodedFile',
         'PSUseToExportFieldsInManifest',
         'PSMissingModuleManifestField',
-
-        # ShouldProcess rules (not needed for all scripts)
-        'PSShouldProcess',
-        'PSUseShouldProcessForStateChangingFunctions',
-        'PSUseSupportsShouldProcess',
 
         # Other overly strict rules
         'PSReviewUnusedParameter',

--- a/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
+++ b/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
@@ -90,7 +90,11 @@ function Test-AzureADBitLockerBackup {
         $systemDrive = $env:SystemDrive
 
         # Get the BitLocker Management event log events with ID 845 and Level 4 (Information) from the past nDays
-        $events = Get-WinEvent -FilterHashTable @{LogName = "Microsoft-Windows-BitLocker/BitLocker Management"; ID = 845; Level = 4; StartTime = $pastDate } -ErrorAction Stop
+<<<<<<< HEAD
+        $events = Get-WinEvent -FilterHashtable @{LogName = "Microsoft-Windows-BitLocker/BitLocker Management"; ID = 845; Level = 4; StartTime = $pastDate } -ErrorAction Stop
+=======
+        $events = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-BitLocker/BitLocker Management"; ID=845; Level=4; StartTime=$pastDate} -ErrorAction Stop
+>>>>>>> d9c7f54 (fix: correct -FilterHashtable casing in BitLocker detection (PSUseCorrectCasing))
 
         # If events exist, check if any of them are for the system drive
         if ($events) {

--- a/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
+++ b/scripts/endpoints/devices/bitlocker/Detect_BitLockerKeyBackup.ps1
@@ -90,11 +90,7 @@ function Test-AzureADBitLockerBackup {
         $systemDrive = $env:SystemDrive
 
         # Get the BitLocker Management event log events with ID 845 and Level 4 (Information) from the past nDays
-<<<<<<< HEAD
         $events = Get-WinEvent -FilterHashtable @{LogName = "Microsoft-Windows-BitLocker/BitLocker Management"; ID = 845; Level = 4; StartTime = $pastDate } -ErrorAction Stop
-=======
-        $events = Get-WinEvent -FilterHashtable @{LogName="Microsoft-Windows-BitLocker/BitLocker Management"; ID=845; Level=4; StartTime=$pastDate} -ErrorAction Stop
->>>>>>> d9c7f54 (fix: correct -FilterHashtable casing in BitLocker detection (PSUseCorrectCasing))
 
         # If events exist, check if any of them are for the system drive
         if ($events) {


### PR DESCRIPTION
Closes #116 #118 #128

Removes the 9 rule exclusions from .vscode/PSScriptAnalyzerSettings.psd1 and adds two enforcement steps to validate-powershell.yml:
1. Policy gate: PSSA with the 5 style rules (enabled) + 3 ShouldProcess rules, failing on ANY finding.
2. Comment-based help gate: every scripts/**/*.ps1 must contain .SYNOPSIS (PSSA's PSProvideCommentHelp only checks functions, not bare scripts).

Code fixes landed in #240-#244 (4411 style findings, 56 ShouldProcess findings, 48 missing help headers).

## Summary by Sourcery

Tighten PowerShell quality gates in CI by enforcing style, ShouldProcess, and comment-based help policies across scripts.

Enhancements:
- Align PowerShell cmdlet usage with analyzer expectations by correcting the Get-WinEvent FilterHashtable parameter casing.
- Remove previous rule exclusions from the PSScriptAnalyzer settings to fully apply style and ShouldProcess rules during analysis.

CI:
- Add a PSScriptAnalyzer-based policy gate that fails the pipeline on any style or ShouldProcess rule violations.
- Add a CI step that enforces presence of .SYNOPSIS comment-based help in all PowerShell scripts under scripts/.