### PR TITLE
docs: fix mermaid rendering in ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Bug-Free Umbrella uses **weather-themed codenames** to make releases memorable:
 - GitHub wiki retired; all 31 wiki pages migrated into `docs/` as regular markdown files — documentation is now versioned with the code and PR-reviewable
 - New `docs/README.md` hub and `docs/ARCHITECTURE.md` with mermaid diagrams; root README badge wall updated
 - `wiki/` staging directory and `sync-wiki.yml` workflow removed; all wiki links across READMEs, SUPPORT, WARP, PR templates and category docs repointed to `docs/`
+- Fixed mermaid node-label rendering in `docs/ARCHITECTURE.md` (quoted `[+]`/`[-]` labels)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,8 +117,8 @@ Every script follows a strict contract (enforced by PSScriptAnalyzer settings + 
 flowchart LR
     HELP[Comment-based help] --> PARAM[[CmdletBinding + validation]]
     PARAM --> FLOW{try / catch}
-    FLOW -->|success| OK[Write-Host [+] · exit 0]
-    FLOW -->|error| ERR[Write-Host [-] · exit 1]
+    FLOW -->|success| OK["Write-Host [+] · exit 0"]
+    FLOW -->|error| ERR["Write-Host [-] · exit 1"]
 ```
 
 ## 6. Testing


### PR DESCRIPTION
GitHub's mermaid parser rejects unquoted `[+]`/`[-]` inside `ID[...]` node labels (Parse error: 'Expecting SQE... got SQS'). Quoted the two labels: `OK["Write-Host [+] · exit 0"]`, `ERR["Write-Host [-] · exit 1"]`. Scanned all 6 mermaid blocks in docs/ — no other hazards.

## Summary by Sourcery

Fix mermaid diagram node label rendering issues in ARCHITECTURE documentation and record the change in the changelog.

Enhancements:
- Update CHANGELOG.md to document the mermaid rendering fix in ARCHITECTURE.md.

Documentation:
- Quote special-character node labels in the mermaid flowchart in docs/ARCHITECTURE.md to ensure proper rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CI/CD architecture diagram so success and error labels render correctly in Mermaid.
  * Clarified the displayed `Write-Host` messages by quoting labels containing `[+]` and `[-]`.

* **Changelog**
  * Added an Unreleased entry documenting the diagram rendering fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->