### PR TITLE
fix(ci): hashtable splatting in release-module build step

### DIFF
--- a/.github/workflows/release-module.yml
+++ b/.github/workflows/release-module.yml
@@ -55,8 +55,10 @@ jobs:
       - name: Build module (generate fresh from catalog)
         shell: pwsh
         run: |
-          $buildArgs = @()
-          if ($env:MODULE_VERSION) { $buildArgs += @('-Version', $env:MODULE_VERSION) }
+          # Hashtable splatting: array splatting binds positionally and cannot carry
+          # named parameters like -Version (v5.0.0 tag run failed on exactly this).
+          $buildArgs = @{}
+          if ($env:MODULE_VERSION) { $buildArgs.Version = $env:MODULE_VERSION }
           & ./tools/Build-Module.ps1 @buildArgs
 
       - name: Test-ModuleManifest gate


### PR DESCRIPTION
The v5.0.0 tag run of release-module.yml failed: `Build-Module.ps1 @buildArgs` used array splatting, which binds positionally and cannot carry named `-Version`. Switched to hashtable splatting. Reproduced and verified locally with a param-identical stub.

## Summary by Sourcery

Fix version argument handling in the release-module CI build to prevent tagged release failures.

Bug Fixes:
- Fix the release-module build step so module versions are passed correctly during tagged releases.

CI:
- Correct PowerShell argument handling in the release-module workflow by using named-parameter splatting for optional version input.